### PR TITLE
feat: Improve symptom timeline UI and move episode metadata

### DIFF
--- a/app/src/screens/NewEpisodeScreen.tsx
+++ b/app/src/screens/NewEpisodeScreen.tsx
@@ -427,10 +427,21 @@ export default function NewEpisodeScreen({ navigation, route }: Props) {
         });
         console.log('[NewEpisode] Episode created:', episode.id);
 
-        // Add initial intensity reading
+        // Add initial intensity reading with the same timestamp as episode start
         if (intensity > 0) {
           console.log('[NewEpisode] Adding intensity reading...');
-          await addIntensityReading(episode.id, intensity);
+          const { intensityRepository } = await import('../database/episodeRepository');
+          await intensityRepository.create({
+            episodeId: episode.id,
+            timestamp: episode.startTime, // Use episode start time for initial reading
+            intensity,
+          });
+
+          // Update peak and average intensity (should be same as initial for new episode)
+          await updateEpisode(episode.id, {
+            peakIntensity: intensity,
+            averageIntensity: intensity
+          });
           console.log('[NewEpisode] Intensity reading added');
         }
 


### PR DESCRIPTION
## Summary
Resolves #2

This PR improves the symptom display in the episode timeline by showing symptom changes (deltas) with clear +/- indicators, and reorganizes the episode detail screen for better information hierarchy.

## Changes

### Symptom Timeline Improvements
- ✅ Add initial symptoms to timeline at episode start (no +/- indicators)
- ✅ Calculate and display symptom deltas (added/removed) for updates
- ✅ Show `+ Symptom Name` in green for added symptoms
- ✅ Show `− Symptom Name` in red for removed symptoms
- ✅ Remove standalone "Symptoms" card (symptoms now only appear in timeline)

### Timeline Reorganization
- ✅ Move Pain Locations section above Timeline
- ✅ Move Pain Qualities section above Timeline
- ✅ Move Triggers section above Timeline
- ✅ Add episode summary note to timeline at episode start (no label)
- ✅ Remove "Intensity Update" label from initial intensity reading
- ✅ Remove "Episode Summary" standalone card

### Bug Fixes
- ✅ Fix initial intensity timestamp to match episode start time
  - Initial symptoms, notes, and intensity now grouped together at episode start
  - Previously had slightly different timestamps causing timeline separation

## Screenshots
Before: Symptoms shown as standalone card below timeline, all symptoms displayed on every update
After: Symptoms in timeline with initial state at start, changes shown with +/- indicators

## Testing
- ✅ All 278 unit tests pass
- ✅ Episode lifecycle E2E test passes
- ✅ Manually tested UI changes with user feedback

## Test Plan
- [ ] Create episode with symptoms
- [ ] Verify initial symptoms appear in timeline without + indicators
- [ ] Edit episode to add/remove symptoms
- [ ] Verify symptom changes show with + (green) and − (red) indicators
- [ ] Verify Pain Locations, Qualities, and Triggers appear above timeline
- [ ] Verify episode summary appears in timeline at start time
- [ ] Verify no standalone Symptoms or Episode Summary cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)