### PR TITLE
Remove Critical Alerts entitlement pending Apple approval

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -18,11 +18,7 @@
       "bundleIdentifier": "com.eff3.app.headache-tracker",
       "buildNumber": "1",
       "infoPlist": {
-        "ITSAppUsesNonExemptEncryption": false,
-        "com.apple.developer.usernotifications.critical-alerts": 1
-      },
-      "entitlements": {
-        "com.apple.developer.usernotifications.critical-alerts": true
+        "ITSAppUsesNonExemptEncryption": false
       }
     },
     "android": {


### PR DESCRIPTION
Temporarily removed the com.apple.developer.usernotifications.critical-alerts entitlement from app.json to allow builds to succeed while waiting for Apple's approval of the Critical Alerts capability. Regular push notifications still work; this only affects notifications that bypass Do Not Disturb mode.

Will re-enable after receiving approval from Apple Developer Program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)