### PR TITLE
fix: upgrade react-native-svg to fix E2E test errors

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -34,7 +34,7 @@
         "react-native-maps": "1.20.1",
         "react-native-safe-area-context": "^5.6.1",
         "react-native-screens": "^4.16.0",
-        "react-native-svg": "15.12.1",
+        "react-native-svg": "^15.14.0",
         "react-native-toast-message": "^2.3.3",
         "react-native-web": "^0.21.1",
         "sqlite3": "^5.1.7",
@@ -25025,9 +25025,9 @@
       }
     },
     "node_modules/react-native-svg": {
-      "version": "15.12.1",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
-      "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.14.0.tgz",
+      "integrity": "sha512-B3gYc7WztcOT4N54AtUutbe0Nuqqh/nkresY0fAXzUHYLsWuIu/yGiCCD3DKfAs6GLv5LFtWTu7N333Q+e3bkg==",
       "license": "MIT",
       "dependencies": {
         "css-select": "^5.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -48,7 +48,7 @@
     "react-native-maps": "1.20.1",
     "react-native-safe-area-context": "^5.6.1",
     "react-native-screens": "^4.16.0",
-    "react-native-svg": "15.12.1",
+    "react-native-svg": "^15.14.0",
     "react-native-toast-message": "^2.3.3",
     "react-native-web": "^0.21.1",
     "sqlite3": "^5.1.7",
@@ -82,6 +82,13 @@
     "react-test-renderer": "^19.1.0",
     "tslib": "^2.8.1",
     "typescript": "~5.9.2"
+  },
+  "expo": {
+    "install": {
+      "exclude": [
+        "react-native-svg"
+      ]
+    }
   },
   "private": true
 }


### PR DESCRIPTION
## Summary

Fixes E2E test failures caused by `react-native-svg` 15.12.1 dispatching unsupported `topSvgLayout` events.

## Problem

After downgrading `react-native-svg` from 15.14.0 to 15.12.1 (to match Expo SDK 54 requirements), E2E tests started failing with errors:
```
ERROR  [Error: Unsupported top level event type "topSvgLayout" dispatched]
```

These errors broke E2E test execution and caused tests to fail.

## Solution

- ✅ Upgrade `react-native-svg` from 15.12.1 to 15.14.0
- ✅ Add `react-native-svg` to `expo.install.exclude` in package.json
- ✅ Prevents expo-doctor from warning about the minor version mismatch

The newer version (15.14.0) properly handles SVG layout events and is compatible with Expo SDK 54, despite the minor version difference.

## Testing

- ✅ E2E tests run without `topSvgLayout` errors
- ✅ All SVG rendering works correctly
- ✅ expo-doctor passes (only harmless xdl duplicate React warning)
- ✅ No breaking changes to app functionality

## Impact

- E2E tests can now run reliably
- No more noisy error logs during development
- Maintains Expo SDK 54 compatibility

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>