### PR TITLE
fix: reschedule notifications when archiving medications

### DIFF
--- a/app/src/store/__tests__/medicationStore.test.ts
+++ b/app/src/store/__tests__/medicationStore.test.ts
@@ -4,6 +4,7 @@ import {
   medicationDoseRepository,
 } from '../../database/medicationRepository';
 import { episodeRepository } from '../../database/episodeRepository';
+import { notificationService } from '../../services/notificationService';
 import { Medication } from '../../models/types';
 import { cacheManager } from '../../utils/cacheManager';
 
@@ -11,6 +12,7 @@ import { cacheManager } from '../../utils/cacheManager';
 jest.mock('../../database/medicationRepository');
 jest.mock('../../database/episodeRepository');
 jest.mock('../../services/errorLogger');
+jest.mock('../../services/notificationService');
 
 describe('medicationStore', () => {
   beforeEach(() => {
@@ -335,6 +337,7 @@ describe('medicationStore', () => {
       });
 
       (medicationRepository.update as jest.Mock).mockResolvedValue(undefined);
+      (notificationService.rescheduleAllMedicationNotifications as jest.Mock).mockResolvedValue(undefined);
 
       await useMedicationStore.getState().archiveMedication('med-1');
 
@@ -342,6 +345,7 @@ describe('medicationStore', () => {
       expect(state.medications[0].active).toBe(false);
       expect(state.preventativeMedications).toHaveLength(0);
       expect(medicationRepository.update).toHaveBeenCalledWith('med-1', { active: false });
+      expect(notificationService.rescheduleAllMedicationNotifications).toHaveBeenCalled();
     });
 
     it('should handle errors when archiving', async () => {

--- a/app/src/store/medicationStore.ts
+++ b/app/src/store/medicationStore.ts
@@ -307,11 +307,12 @@ export const useMedicationStore = create<MedicationState>((set, get) => ({
 
   archiveMedication: async (id) => {
     try {
-      // Cancel notifications before archiving
-      await notificationService.cancelMedicationNotifications(id);
-      logger.log('[Store] Cancelled notifications for archived medication:', id);
-
       await medicationRepository.update(id, { active: false });
+
+      // Reschedule all notifications to update grouped notifications
+      // This ensures that grouped notifications no longer include the archived medication
+      await notificationService.rescheduleAllMedicationNotifications();
+      logger.log('[Store] Rescheduled all notifications after archiving medication:', id);
 
       const medications = get().medications.map(m =>
         m.id === id ? { ...m, active: false } : m


### PR DESCRIPTION
## Summary
Fixes #123 - Grouped notifications now correctly update when a medication is archived. When archiving a medication that was part of a grouped notification, all notifications are rescheduled to ensure the grouped notification no longer includes the archived medication.

## Problem
When multiple medications are scheduled for the same time (e.g., 9:20 PM), they are grouped into a single notification. If one of those medications is archived:
- The UI correctly shows only active medications
- **BUT** the scheduled notification still contains all medications in its data
- User sees incorrect notification listing archived medications

## Root Cause
The `archiveMedication()` function was calling `cancelMedicationNotifications(id)` for the specific medication, but grouped notifications are shared across multiple medications. Canceling one medication's notification ID doesn't update the grouped notification's content.

## Solution
Updated `archiveMedication()` to call `rescheduleAllMedicationNotifications()` instead of just canceling individual notifications. This ensures:
1. All existing notifications are cancelled
2. New grouped notifications are created using only active medications
3. Archived medications no longer appear in any notifications

This matches the pattern already used in `unarchiveMedication()` and is the most reliable approach.

## Changes
**src/store/medicationStore.ts**
- Updated `archiveMedication()` to call `rescheduleAllMedicationNotifications()`
- Removed redundant `cancelMedicationNotifications()` call
- Added clear comment explaining why rescheduling is necessary

**src/store/__tests__/medicationStore.test.ts**
- Added `notificationService` mock
- Updated test to verify `rescheduleAllMedicationNotifications()` is called on archive
- Ensures fix won't regress

## Testing
✅ All unit tests passing (1173 tests)
✅ ESLint passed (0 warnings)
✅ TypeScript compilation successful
✅ Added test coverage for notification rescheduling

## Example Scenario
**Before:**
1. User has 3 medications scheduled at 9:20 PM
2. Grouped notification created for all 3
3. User archives one medication
4. UI shows 2 medications ✅
5. Notification still shows all 3 ❌

**After:**
1. User has 3 medications scheduled at 9:20 PM
2. Grouped notification created for all 3
3. User archives one medication
4. All notifications rescheduled
5. UI shows 2 medications ✅
6. Notification shows 2 medications ✅

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)