### PR TITLE
Update splash screen background color to logo blue

### DIFF
--- a/app/app.config.js
+++ b/app/app.config.js
@@ -13,7 +13,7 @@ module.exports = {
     splash: {
       image: "./assets/splash-icon.png",
       resizeMode: "contain",
-      backgroundColor: "#ffffff"
+      backgroundColor: "#4c1d95"
     },
     ios: {
       supportsTablet: true,
@@ -43,7 +43,7 @@ module.exports = {
     android: {
       adaptiveIcon: {
         foregroundImage: "./assets/adaptive-icon.png",
-        backgroundColor: "#ffffff"
+        backgroundColor: "#4c1d95"
       },
       edgeToEdgeEnabled: true,
       predictiveBackGestureEnabled: false,


### PR DESCRIPTION
## Summary
- Changed splash screen background color from white (#ffffff) to logo blue (#4c1d95)
- Updated Android adaptive icon background color to match
- Creates a more cohesive brand experience during app launch and in the app drawer

## Changes Made
- `app.config.js`: Updated `splash.backgroundColor` to #4c1d95
- `app.config.js`: Updated `android.adaptiveIcon.backgroundColor` to #4c1d95
- Color value extracted from the MigraLog logo SVG file (migralog.svg)

## Platform Impact
- ✅ iOS: Splash screen background color updated
- ✅ Android: Splash screen and adaptive icon background updated

## Testing
- ✅ All precommit checks passed (lint, typecheck, unit tests - 57/57 suites, 1193/1194 tests)
- ✅ UI tests: 11/20 passed (9 failures due to simulator connection timeouts, unrelated to splash screen changes)

## Visual Impact
The splash screen will now display with a purple-blue background (#4c1d95) matching the app logo instead of white, providing better visual continuity with the app's brand identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)