### PR TITLE
Update splash screen background color to match logo blue

### DIFF
--- a/app/app.config.js
+++ b/app/app.config.js
@@ -13,7 +13,7 @@ module.exports = {
     splash: {
       image: "./assets/splash-icon.png",
       resizeMode: "contain",
-      backgroundColor: "#ffffff"
+      backgroundColor: "#4c1d95"
     },
     ios: {
       supportsTablet: true,
@@ -43,7 +43,7 @@ module.exports = {
     android: {
       adaptiveIcon: {
         foregroundImage: "./assets/adaptive-icon.png",
-        backgroundColor: "#ffffff"
+        backgroundColor: "#4c1d95"
       },
       edgeToEdgeEnabled: true,
       predictiveBackGestureEnabled: false,


### PR DESCRIPTION
## Summary
- Changed splash screen background color from white (#ffffff) to logo blue (#4c1d95)
- Updated Android adaptive icon background color to match
- Provides better visual continuity during app launch by using the logo's primary color

## Changes Made
- `app.config.js`: Updated `splash.backgroundColor` from `#ffffff` to `#4c1d95`
- `app.config.js`: Updated `android.adaptiveIcon.backgroundColor` from `#ffffff` to `#4c1d95`

## Testing
- ✅ All precommit checks passed (linting, TypeScript compilation, unit tests with 60% coverage)
- ✅ Configuration changes only - no code logic modified
- Note: E2E UI tests have pre-existing initialization timeout issues unrelated to this change

## Visual Impact
The splash screen will now display with the purple-blue color from the MigraLog logo instead of white, providing a more cohesive branding experience during app startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)