### PR TITLE
Add CC BY-NC 4.0 non-commercial license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,38 @@
+Creative Commons Attribution-NonCommercial 4.0 International License (CC BY-NC 4.0)
+
+Copyright (c) 2024-2025 MigraLog Contributors
+
+This work is licensed under the Creative Commons Attribution-NonCommercial 4.0
+International License.
+
+You are free to:
+
+  Share - copy and redistribute the material in any medium or format
+
+  Adapt - remix, transform, and build upon the material
+
+Under the following terms:
+
+  Attribution - You must give appropriate credit, provide a link to the license,
+  and indicate if changes were made. You may do so in any reasonable manner, but
+  not in any way that suggests the licensor endorses you or your use.
+
+  NonCommercial - You may not use the material for commercial purposes.
+
+  No additional restrictions - You may not apply legal terms or technological
+  measures that legally restrict others from doing anything the license permits.
+
+Notices:
+
+  You do not have to comply with the license for elements of the material in the
+  public domain or where your use is permitted by an applicable exception or
+  limitation.
+
+  No warranties are given. The license may not give you all of the permissions
+  necessary for your intended use. For example, other rights such as publicity,
+  privacy, or moral rights may limit how you use the material.
+
+For the full license text, see:
+https://creativecommons.org/licenses/by-nc/4.0/legalcode
+
+SPDX-License-Identifier: CC-BY-NC-4.0


### PR DESCRIPTION
## Summary
- Add Creative Commons Attribution-NonCommercial 4.0 International license (CC BY-NC 4.0) to establish clear terms of use for the MigraLog project
- This license prevents commercial use while allowing sharing and adaptation with attribution

## Why CC BY-NC 4.0?
- **Well-established**: One of the most widely recognized non-commercial licenses
- **Clear terms**: Easy to understand for users and contributors
- **Flexibility**: Allows forking, modification, and sharing for non-commercial purposes
- **Attribution**: Requires credit to original authors

## Test plan
- [x] All precommit checks pass (lint, TypeScript, unit tests)
- [x] All E2E tests pass (16 test files, all passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)