### PR TITLE
Fix #192: Track localization for date/time formatting

### DIFF
--- a/app/src/utils/dateFormatting.ts
+++ b/app/src/utils/dateFormatting.ts
@@ -3,6 +3,18 @@
  *
  * These functions provide episode-specific date/time formatting operations
  * that handle edge cases like multi-day episodes and ongoing episodes.
+ *
+ * TODO: [Localization] This module needs i18n support. See docs/features/localization-tracking.md
+ * Key areas requiring localization:
+ * - Time format strings ('h:mm a') should respect 12h/24h locale preferences
+ * - Date format strings ('MMM d') should use locale-aware ordering
+ * - Hardcoded English text ("Today", "Yesterday", "Started at", etc.) needs i18n
+ * - Duration text ("hour", "day", etc.) needs i18n with proper pluralization
+ *
+ * Recommended approach:
+ * - Use date-fns locale support: format(date, pattern, { locale: userLocale })
+ * - Add i18n library (react-i18next) for static text
+ * - Create centralized locale-aware formatting service
  */
 
 import { format, isSameDay, isToday, isYesterday } from 'date-fns';
@@ -34,6 +46,8 @@ export function formatEpisodeTimeRange(
     const startIsOnTargetDate = isSameDay(startDate, targetDateObj);
 
     // Helper to format start time for ongoing episodes
+    // TODO: [Localization] "Started at" and "Started" need i18n translation
+    // TODO: [Localization] 'h:mm a' format should respect user's 12h/24h preference
     const formatOngoingStart = () =>
       startIsOnTargetDate
         ? `Started at ${format(startDate, 'h:mm a')}`
@@ -94,6 +108,7 @@ export function formatEpisodeDuration(
     const hours = Math.floor(durationMs / (1000 * 60 * 60));
     const minutes = Math.floor((durationMs % (1000 * 60 * 60)) / (1000 * 60));
 
+    // TODO: [Localization] Duration abbreviations "h" and "m" need i18n
     if (hours > 0) {
       return `${hours}h ${minutes}m`;
     }
@@ -121,6 +136,8 @@ export function formatDurationLong(hours: number): string {
 
   const roundedHours = Math.round(hours);
 
+  // TODO: [Localization] "day/days" and "hour/hours" need i18n with proper pluralization rules
+  // Note: English has simple singular/plural, but other languages have complex plural forms
   if (roundedHours >= 24) {
     const days = Math.floor(roundedHours / 24);
     const remainingHours = roundedHours % 24;
@@ -157,6 +174,7 @@ export function formatRelativeDate(
 
     const timeStr = format(date, timeFormat);
 
+    // TODO: [Localization] "Today" and "Yesterday" need i18n translation
     if (isToday(date)) {
       return `Today, ${timeStr}`;
     } else if (isYesterday(date)) {

--- a/docs/features/localization-tracking.md
+++ b/docs/features/localization-tracking.md
@@ -1,0 +1,171 @@
+# Localization Tracking for Date/Time Formatting
+
+**Status:** Tracking / Planning
+**Created:** Issue #192 (PR #188 code review follow-up)
+**Last Updated:** 2025-01-21
+
+## Overview
+
+This document tracks all date/time formatting that will need localization when MigraLog implements internationalization (i18n) support. The current implementation uses hardcoded English format strings and text.
+
+## Scope
+
+This tracking covers:
+1. **Time format preferences** (12-hour vs 24-hour)
+2. **Date format patterns** (locale-specific ordering)
+3. **Hardcoded English text** (relative dates, labels)
+4. **Duration formatting** (hours, minutes, days)
+
+## Affected Files
+
+### Core Utilities (High Priority)
+
+| File | Issue | Current State |
+|------|-------|---------------|
+| `src/utils/dateFormatting.ts` | All functions | Hardcoded format strings (`'h:mm a'`, `'MMM d'`), English text ("Today", "Yesterday", "Started at", "hour", "day") |
+| `src/utils/timelineGrouping.ts` | `format(dayStart, 'EEEE, MMM d')` | English weekday/month names |
+| `src/utils/medicationTimeline.ts` | Date formatting | Imports from date-fns |
+
+### Screen Components (Medium Priority)
+
+| File | Issue | Current State |
+|------|-------|---------------|
+| `src/screens/DashboardScreen.tsx` | `format(item.doseTime, 'h:mm a')` | 12-hour time format hardcoded |
+| `src/screens/MedicationsScreen.tsx` | Multiple `format()` calls | `'h:mm a'`, `'MMM d, yyyy'` |
+| `src/screens/MedicationDetailScreen.tsx` | Multiple `format()` calls | `'EEE'`, `'d'`, `'MMM d, yyyy h:mm a'` |
+| `src/screens/NewEpisodeScreen.tsx` | `format(startTime, 'MMM d, yyyy h:mm a')` | Full date-time format |
+| `src/screens/EpisodeDetailScreen.tsx` | `format(dayGroup.date, 'MMM d')` | Short date format |
+| `src/screens/LogMedicationScreen.tsx` | `format(timestamp, 'MMM d, yyyy h:mm a')` | Full date-time format |
+| `src/screens/EditMedicationDoseScreen.tsx` | `format(timestamp, 'MMM d, yyyy h:mm a')` | Full date-time format |
+| `src/screens/EditIntensityReadingScreen.tsx` | `format(timestamp, 'MMM d, yyyy h:mm a')` | Full date-time format |
+| `src/screens/DailyStatusPromptScreen.tsx` | `format(date, 'EEEE, MMMM d, yyyy')` + "Yesterday" fallback | Full date with weekday |
+| `src/screens/PerformanceScreen.tsx` | `format(new Date(metric.timestamp), 'HH:mm:ss')` | 24-hour debug format |
+| `src/screens/ErrorLogsScreen.tsx` | `format(log.timestamp, 'MMM d, h:mm:ss a')` | Debug timestamp format |
+
+### UI Components (Medium Priority)
+
+| File | Issue | Current State |
+|------|-------|---------------|
+| `src/components/EpisodeCard.tsx` | `format(episode.startTime, ...)` | `'EEEE, MMM d, yyyy'` (accessibility), `'EEE, MMM d · h:mm a'` (display) |
+| `src/components/MonthlyCalendarView.tsx` | Multiple `format()` calls | `'yyyy-MM-dd'` (data), `'MMMM d, yyyy'` (a11y), `'d'`, `'MMMM yyyy'` (display) |
+
+### Database Layer (Low Priority - Data Storage)
+
+| File | Issue | Current State |
+|------|-------|---------------|
+| `src/database/dailyStatusRepository.ts` | `format(date, 'yyyy-MM-dd')` | ISO format for data storage (OK to keep as-is) |
+| `src/store/dailyStatusStore.ts` | `format(currentDate, 'yyyy-MM-dd')` | ISO format for data storage (OK to keep as-is) |
+
+## Hardcoded English Text
+
+### In `dateFormatting.ts`:
+- `"Started at"` - prefix for ongoing episodes
+- `"Started"` - prefix for ongoing episodes (different context)
+- `"Today"` - relative date label
+- `"Yesterday"` - relative date label
+- `"day"` / `"days"` - duration units
+- `"hour"` / `"hours"` - duration units
+- `"Unknown time"` - error fallback
+- `"Unknown duration"` - error fallback
+
+### In Screen Components:
+- `"Yesterday"` fallback in `DailyStatusPromptScreen.tsx`
+- Various accessibility labels containing date/time descriptions
+
+## Recommended Approach
+
+### 1. Use date-fns Locales
+
+date-fns has excellent locale support. Import the user's locale and pass it to format:
+
+```typescript
+import { format } from 'date-fns';
+import { enUS, es, fr, de } from 'date-fns/locale';
+
+// Get locale from user preferences or device settings
+const userLocale = getUserLocale(); // e.g., enUS, es, fr
+
+format(date, 'h:mm a', { locale: userLocale });
+```
+
+### 2. Handle 12h vs 24h Time Preference
+
+Some locales use 24-hour time by default. Consider:
+- Using device locale settings
+- Adding user preference in Settings screen
+- Using locale-appropriate format strings ('h:mm a' vs 'HH:mm')
+
+```typescript
+// Example: locale-aware time format
+const timeFormat = is24HourLocale(userLocale) ? 'HH:mm' : 'h:mm a';
+```
+
+### 3. Implement i18n Library for Static Text
+
+For hardcoded strings like "Today", "Yesterday", "Started at", use an i18n library:
+
+**Options:**
+- `react-i18next` - Most popular, full-featured
+- `react-native-i18n` - Simple, lightweight
+- `expo-localization` - Expo-native device locale detection
+
+```typescript
+import { t } from 'i18next';
+
+// Instead of: `Started at ${format(startDate, 'h:mm a')}`
+// Use: t('episode.startedAt', { time: formatTime(startDate) })
+```
+
+### 4. Centralize Format Patterns
+
+Create a locale-aware formatting service:
+
+```typescript
+// src/services/localizationService.ts
+export const DateFormats = {
+  time: (locale: Locale) => is24Hour(locale) ? 'HH:mm' : 'h:mm a',
+  shortDate: 'MMM d',
+  fullDate: 'MMM d, yyyy',
+  fullDateTime: (locale: Locale) => `MMM d, yyyy ${DateFormats.time(locale)}`,
+  dayOfWeek: 'EEEE',
+  // etc.
+};
+```
+
+## Implementation Priority
+
+1. **Phase 1 - Foundation:**
+   - Add locale detection (expo-localization)
+   - Create centralized formatting service
+   - Add user preference for 12h/24h time
+
+2. **Phase 2 - Core Utilities:**
+   - Update `dateFormatting.ts` to use locales
+   - Update `timelineGrouping.ts`
+
+3. **Phase 3 - Screens:**
+   - Update all screen components to use centralized formatting
+   - Add i18n library for static text
+
+4. **Phase 4 - Components:**
+   - Update EpisodeCard, MonthlyCalendarView
+   - Update accessibility labels
+
+## Testing Considerations
+
+- Test with RTL locales (Arabic, Hebrew)
+- Test with different date orderings (MM/DD vs DD/MM)
+- Test 12h and 24h time formats
+- Test long month/day names in different languages
+- Ensure accessibility labels are properly localized
+
+## Related Issues
+
+- Issue #192: Track localization for date/time formatting (this document)
+- Future: Full i18n implementation
+
+## Notes
+
+- The `'yyyy-MM-dd'` format used for data storage in repositories should NOT be localized (ISO 8601 standard)
+- Performance screen and error logs use debug-oriented formats that may not need localization
+- Accessibility labels should be localized along with visual text


### PR DESCRIPTION
## Summary
- Adds comprehensive tracking documentation for future localization (i18n) work
- Adds TODO comments to `dateFormatting.ts` identifying specific localization needs
- Creates `docs/features/localization-tracking.md` with full audit of affected files

## What This PR Does
This is a **tracking/documentation issue** - no functional changes. It prepares for future localization work by:

1. **Auditing the codebase** - Identified 20+ files using date-fns `format()` with hardcoded format strings
2. **Adding TODO comments** - Marked specific locations in `dateFormatting.ts` needing localization
3. **Creating tracking document** - Comprehensive guide documenting:
   - All affected files categorized by priority
   - Hardcoded English text needing translation ("Today", "Yesterday", "Started at", etc.)
   - Recommended approach using date-fns locales and i18n library
   - Priority-ordered implementation plan

## Files Changed
- `src/utils/dateFormatting.ts` - Added TODO comments for localization
- `docs/features/localization-tracking.md` - New tracking document

## Test plan
- [x] Precommit passes (lint, TypeScript, tests)
- [x] No functional changes - documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)