### PR TITLE
feat: Add locale support for date/time formatting (#192)

### DIFF
--- a/app/src/utils/__tests__/dateFormatting.test.ts
+++ b/app/src/utils/__tests__/dateFormatting.test.ts
@@ -5,7 +5,24 @@ import {
   formatRelativeDate,
   formatTime,
   formatDateTime,
+  uses12HourClock,
 } from '../dateFormatting';
+
+// Mock the localeUtils module to ensure consistent test behavior
+// Tests expect 12-hour format (US locale)
+jest.mock('../localeUtils', () => {
+  const { enUS } = require('date-fns/locale');
+  return {
+    getDeviceLocale: jest.fn(() => enUS),
+    getDeviceLocaleCode: jest.fn(() => 'en-US'),
+    uses12HourClock: jest.fn(() => true),
+    getTimeFormatString: jest.fn(() => 'h:mm a'),
+    getDateTimeFormatString: jest.fn(() => 'MMM d, yyyy h:mm a'),
+    getShortDateTimeFormatString: jest.fn(() => 'MMM d, h:mm a'),
+    clearLocaleCache: jest.fn(),
+    getFormatLocaleOptions: jest.fn(() => ({ locale: enUS })),
+  };
+});
 
 describe('formatEpisodeTimeRange', () => {
   const targetDate = '2024-01-15';
@@ -126,7 +143,7 @@ describe('formatEpisodeDuration', () => {
   describe('ongoing episodes', () => {
     it('uses current time when end is null', () => {
       const now = Date.now();
-      const start = now - (2 * 60 * 60 * 1000); // 2 hours ago
+      const start = now - 2 * 60 * 60 * 1000; // 2 hours ago
 
       const result = formatEpisodeDuration(start, null);
 
@@ -136,7 +153,7 @@ describe('formatEpisodeDuration', () => {
 
     it('uses current time when end is undefined', () => {
       const now = Date.now();
-      const start = now - (30 * 60 * 1000); // 30 minutes ago
+      const start = now - 30 * 60 * 1000; // 30 minutes ago
 
       const result = formatEpisodeDuration(start);
 
@@ -295,7 +312,9 @@ describe('formatDateTime', () => {
 
     it('accepts custom format string', () => {
       const timestamp = new Date('2024-01-15T14:30:00').getTime();
-      expect(formatDateTime(timestamp, 'yyyy-MM-dd HH:mm')).toBe('2024-01-15 14:30');
+      expect(formatDateTime(timestamp, 'yyyy-MM-dd HH:mm')).toBe(
+        '2024-01-15 14:30'
+      );
     });
   });
 
@@ -314,5 +333,16 @@ describe('formatDateTime', () => {
     it('returns "Unknown time" for invalid Date object', () => {
       expect(formatDateTime(new Date('invalid'))).toBe('Unknown time');
     });
+  });
+});
+
+describe('uses12HourClock export', () => {
+  it('is exported from dateFormatting module', () => {
+    expect(typeof uses12HourClock).toBe('function');
+  });
+
+  it('returns a boolean', () => {
+    const result = uses12HourClock();
+    expect(typeof result).toBe('boolean');
   });
 });

--- a/app/src/utils/__tests__/localeUtils.test.ts
+++ b/app/src/utils/__tests__/localeUtils.test.ts
@@ -1,0 +1,196 @@
+import {
+  getDeviceLocaleCode,
+  getDeviceLocale,
+  uses12HourClock,
+  getTimeFormatString,
+  getDateTimeFormatString,
+  getShortDateTimeFormatString,
+  clearLocaleCache,
+  getFormatLocaleOptions,
+} from '../localeUtils';
+
+describe('localeUtils', () => {
+  // Clear cache before each test to ensure clean state
+  beforeEach(() => {
+    clearLocaleCache();
+  });
+
+  describe('getDeviceLocaleCode', () => {
+    it('returns a valid locale code string', () => {
+      const localeCode = getDeviceLocaleCode();
+
+      expect(typeof localeCode).toBe('string');
+      expect(localeCode.length).toBeGreaterThan(0);
+    });
+
+    it('caches the locale code on subsequent calls', () => {
+      const first = getDeviceLocaleCode();
+      const second = getDeviceLocaleCode();
+
+      expect(first).toBe(second);
+    });
+  });
+
+  describe('getDeviceLocale', () => {
+    it('returns a date-fns Locale object', () => {
+      const locale = getDeviceLocale();
+
+      expect(locale).toBeDefined();
+      expect(typeof locale.code).toBe('string');
+    });
+
+    it('caches the locale on subsequent calls', () => {
+      const first = getDeviceLocale();
+      const second = getDeviceLocale();
+
+      expect(first).toBe(second);
+    });
+
+    it('returns a valid locale that can be used with date-fns', () => {
+      const locale = getDeviceLocale();
+
+      // Locale should have the required date-fns locale structure
+      expect(locale).toHaveProperty('code');
+      expect(locale).toHaveProperty('localize');
+      expect(locale).toHaveProperty('formatLong');
+    });
+  });
+
+  describe('uses12HourClock', () => {
+    it('returns a boolean', () => {
+      const result = uses12HourClock();
+
+      expect(typeof result).toBe('boolean');
+    });
+
+    it('caches the result on subsequent calls', () => {
+      const first = uses12HourClock();
+      const second = uses12HourClock();
+
+      expect(first).toBe(second);
+    });
+  });
+
+  describe('getTimeFormatString', () => {
+    it('returns 12-hour format when uses12HourClock is true', () => {
+      // In test environment, this will use the mocked/default Intl behavior
+      const format = getTimeFormatString();
+
+      // Should be one of the two valid formats
+      expect(['h:mm a', 'HH:mm']).toContain(format);
+    });
+
+    it('returns a valid date-fns format string', () => {
+      const format = getTimeFormatString();
+
+      // Should contain hour and minute tokens
+      expect(format).toMatch(/[hH]+/);
+      expect(format).toMatch(/mm/);
+    });
+  });
+
+  describe('getDateTimeFormatString', () => {
+    it('returns a format string with date and time components', () => {
+      const format = getDateTimeFormatString();
+
+      // Should contain month, day, year, and time components
+      expect(format).toContain('MMM');
+      expect(format).toContain('d');
+      expect(format).toContain('yyyy');
+      expect(format).toMatch(/[hH]+/);
+      expect(format).toMatch(/mm/);
+    });
+
+    it('uses consistent time format with getTimeFormatString', () => {
+      const timeFormat = getTimeFormatString();
+      const dateTimeFormat = getDateTimeFormatString();
+
+      // The time portion should match
+      if (timeFormat === 'h:mm a') {
+        expect(dateTimeFormat).toContain('h:mm a');
+      } else {
+        expect(dateTimeFormat).toContain('HH:mm');
+      }
+    });
+  });
+
+  describe('getShortDateTimeFormatString', () => {
+    it('returns a format string with short date and time', () => {
+      const format = getShortDateTimeFormatString();
+
+      // Should contain month, day, and time but NOT year
+      expect(format).toContain('MMM');
+      expect(format).toContain('d');
+      expect(format).not.toContain('yyyy');
+      expect(format).toMatch(/[hH]+/);
+      expect(format).toMatch(/mm/);
+    });
+  });
+
+  describe('clearLocaleCache', () => {
+    it('clears the cached locale values', () => {
+      // Get initial values (which caches them)
+      const initialLocale = getDeviceLocale();
+      const initialCode = getDeviceLocaleCode();
+      const initialHour12 = uses12HourClock();
+
+      // Clear the cache
+      clearLocaleCache();
+
+      // Get values again - they should still be the same (same device settings)
+      // but this verifies the cache was cleared and re-computed
+      const newLocale = getDeviceLocale();
+      const newCode = getDeviceLocaleCode();
+      const newHour12 = uses12HourClock();
+
+      // Values should be equal but this confirms no errors were thrown
+      expect(newLocale.code).toBe(initialLocale.code);
+      expect(newCode).toBe(initialCode);
+      expect(newHour12).toBe(initialHour12);
+    });
+  });
+
+  describe('getFormatLocaleOptions', () => {
+    it('returns an object with locale property', () => {
+      const options = getFormatLocaleOptions();
+
+      expect(options).toHaveProperty('locale');
+      expect(options.locale).toBeDefined();
+    });
+
+    it('returns the same locale as getDeviceLocale', () => {
+      const options = getFormatLocaleOptions();
+      const locale = getDeviceLocale();
+
+      expect(options.locale).toBe(locale);
+    });
+
+    it('returns an object that can be spread into date-fns format options', () => {
+      const options = getFormatLocaleOptions();
+
+      // Should have only the locale property (for spreading)
+      expect(Object.keys(options)).toEqual(['locale']);
+    });
+  });
+
+  describe('locale fallback behavior', () => {
+    it('returns a valid locale even in test environment', () => {
+      // In Jest/Node environment, Intl might return different values
+      // but we should always get a valid locale
+      const locale = getDeviceLocale();
+
+      expect(locale).toBeDefined();
+      expect(locale.code).toBeDefined();
+    });
+
+    it('defaults to enUS-compatible locale structure', () => {
+      const locale = getDeviceLocale();
+
+      // Should have the same structure as enUS
+      expect(typeof locale.localize?.month).toBe('function');
+      expect(typeof locale.localize?.day).toBe('function');
+      expect(typeof locale.formatLong?.date).toBe('function');
+      expect(typeof locale.formatLong?.time).toBe('function');
+    });
+  });
+});

--- a/app/src/utils/localeUtils.ts
+++ b/app/src/utils/localeUtils.ts
@@ -1,0 +1,183 @@
+/**
+ * Locale utilities for date/time formatting
+ *
+ * Provides device locale detection and date-fns locale mapping for
+ * locale-aware date/time formatting throughout the app.
+ */
+
+import { enUS, enGB, enAU, enCA, de, fr, es, it, ja, ko, zhCN, pt, nl } from 'date-fns/locale';
+import type { Locale } from 'date-fns';
+
+/**
+ * Map of supported locale codes to date-fns Locale objects
+ *
+ * Add new locales here as needed. The key should match the
+ * language code or language-region code returned by the device.
+ */
+const LOCALE_MAP: Record<string, Locale> = {
+  // English variants
+  'en': enUS,
+  'en-US': enUS,
+  'en-GB': enGB,
+  'en-AU': enAU,
+  'en-CA': enCA,
+  // European languages
+  'de': de,
+  'de-DE': de,
+  'fr': fr,
+  'fr-FR': fr,
+  'es': es,
+  'es-ES': es,
+  'it': it,
+  'it-IT': it,
+  'nl': nl,
+  'nl-NL': nl,
+  'pt': pt,
+  'pt-PT': pt,
+  'pt-BR': pt,
+  // Asian languages
+  'ja': ja,
+  'ja-JP': ja,
+  'ko': ko,
+  'ko-KR': ko,
+  'zh': zhCN,
+  'zh-CN': zhCN,
+  'zh-Hans': zhCN,
+};
+
+/**
+ * Default locale to use when device locale is not supported
+ */
+const DEFAULT_LOCALE = enUS;
+
+/**
+ * Cached locale settings to avoid repeated Intl API calls
+ */
+let cachedLocale: Locale | null = null;
+let cachedHour12: boolean | null = null;
+let cachedLocaleCode: string | null = null;
+
+/**
+ * Get the device's locale code using the Intl API
+ *
+ * @returns The device locale code (e.g., 'en-US', 'de-DE')
+ */
+export function getDeviceLocaleCode(): string {
+  if (cachedLocaleCode !== null) {
+    return cachedLocaleCode;
+  }
+
+  try {
+    const resolved = Intl.DateTimeFormat().resolvedOptions();
+    cachedLocaleCode = resolved.locale || 'en-US';
+    return cachedLocaleCode;
+  } catch {
+    cachedLocaleCode = 'en-US';
+    return cachedLocaleCode;
+  }
+}
+
+/**
+ * Get the date-fns Locale object for the device's locale
+ *
+ * Falls back to en-US if the device locale is not supported.
+ *
+ * @returns The date-fns Locale object
+ */
+export function getDeviceLocale(): Locale {
+  if (cachedLocale !== null) {
+    return cachedLocale;
+  }
+
+  const localeCode = getDeviceLocaleCode();
+
+  // Try exact match first
+  if (LOCALE_MAP[localeCode]) {
+    cachedLocale = LOCALE_MAP[localeCode];
+    return cachedLocale;
+  }
+
+  // Try language code only (e.g., 'en' from 'en-US')
+  const languageCode = localeCode.split('-')[0];
+  if (LOCALE_MAP[languageCode]) {
+    cachedLocale = LOCALE_MAP[languageCode];
+    return cachedLocale;
+  }
+
+  // Fall back to default
+  cachedLocale = DEFAULT_LOCALE;
+  return cachedLocale;
+}
+
+/**
+ * Check if the device prefers 12-hour time format
+ *
+ * Uses the Intl API to detect the user's time format preference.
+ * Returns true for 12-hour format (e.g., US), false for 24-hour format (e.g., most of Europe).
+ *
+ * @returns true if 12-hour format is preferred, false for 24-hour
+ */
+export function uses12HourClock(): boolean {
+  if (cachedHour12 !== null) {
+    return cachedHour12;
+  }
+
+  try {
+    const resolved = Intl.DateTimeFormat(undefined, { hour: 'numeric' }).resolvedOptions();
+    // hour12 can be undefined in some implementations, default to true (US-style)
+    cachedHour12 = resolved.hour12 !== false;
+    return cachedHour12;
+  } catch {
+    cachedHour12 = true;
+    return cachedHour12;
+  }
+}
+
+/**
+ * Get the appropriate time format string based on device locale preferences
+ *
+ * @returns 'h:mm a' for 12-hour format, 'HH:mm' for 24-hour format
+ */
+export function getTimeFormatString(): string {
+  return uses12HourClock() ? 'h:mm a' : 'HH:mm';
+}
+
+/**
+ * Get the appropriate date-time format string based on device locale preferences
+ *
+ * @returns Format string like 'MMM d, yyyy h:mm a' or 'MMM d, yyyy HH:mm'
+ */
+export function getDateTimeFormatString(): string {
+  return uses12HourClock() ? 'MMM d, yyyy h:mm a' : 'MMM d, yyyy HH:mm';
+}
+
+/**
+ * Get the appropriate short date-time format string
+ *
+ * @returns Format string like 'MMM d, h:mm a' or 'MMM d, HH:mm'
+ */
+export function getShortDateTimeFormatString(): string {
+  return uses12HourClock() ? 'MMM d, h:mm a' : 'MMM d, HH:mm';
+}
+
+/**
+ * Clear the cached locale settings
+ *
+ * Useful for testing or when locale settings might have changed.
+ */
+export function clearLocaleCache(): void {
+  cachedLocale = null;
+  cachedHour12 = null;
+  cachedLocaleCode = null;
+}
+
+/**
+ * Get locale options for date-fns format function
+ *
+ * Returns an object that can be spread into date-fns format options.
+ *
+ * @returns Object with locale property set to device locale
+ */
+export function getFormatLocaleOptions(): { locale: Locale } {
+  return { locale: getDeviceLocale() };
+}


### PR DESCRIPTION
## Summary
- Created `localeUtils.ts` with device locale detection using the Intl API
- Added support for both 12-hour and 24-hour time formats based on device locale preferences
- Updated `dateFormatting.ts` to use locale-aware formatting with date-fns locale support
- Supports multiple locales: en-US, en-GB, en-AU, en-CA, de, fr, es, it, ja, ko, zh-CN, pt, nl
- Automatic fallback to en-US for unsupported locales
- Maintains full backward compatibility - existing callers can still pass custom format strings

## Implementation Details
- `getDeviceLocale()` - Returns the date-fns Locale object for device locale
- `uses12HourClock()` - Detects if device prefers 12-hour or 24-hour time format
- `getTimeFormatString()` - Returns appropriate format string ('h:mm a' or 'HH:mm')
- `getDateTimeFormatString()` / `getShortDateTimeFormatString()` - Returns full/short date-time formats
- All formatting functions now pass locale to date-fns `format()` function
- Results are cached to avoid repeated Intl API calls

Closes #192

## Test Plan
- [x] `npm run precommit` passes (lint, TypeScript, unit tests)
- [x] `npm run test:ui` E2E tests pass
- [x] Added comprehensive unit tests for localeUtils.ts
- [x] Updated dateFormatting.test.ts to mock locale utilities for consistent test behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)