### PR TITLE
Fix recreate notification schedules to include daily checkin

### DIFF
--- a/app/src/screens/settings/DeveloperToolsScreen.tsx
+++ b/app/src/screens/settings/DeveloperToolsScreen.tsx
@@ -15,6 +15,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTheme, ThemeColors } from '../../theme';
 import { errorLogger, ErrorLog } from '../../services/errorLogger';
 import { notificationService } from '../../services/notifications/notificationService';
+import { dailyCheckinService } from '../../services/notifications/dailyCheckinService';
 import * as SQLite from 'expo-sqlite';
 import * as Sentry from '@sentry/react-native';
 import * as Notifications from 'expo-notifications';
@@ -404,6 +405,7 @@ export default function DeveloperToolsScreen({ navigation }: Props) {
           onPress: async () => {
             try {
               await notificationService.rescheduleAllMedicationNotifications();
+              await dailyCheckinService.rescheduleNotification();
               Alert.alert(
                 'Success',
                 'All notification schedules have been recreated with current settings.'


### PR DESCRIPTION
- Add import for dailyCheckinService to DeveloperToolsScreen
- Call dailyCheckinService.rescheduleNotification() in handleRecreateAllSchedules
- Ensures both medication reminders AND daily checkin notifications are recreated

Fixes the issue where the 'Recreate All Notification Schedules' button only recreated medication reminders but not daily checkin notifications.