### PR TITLE
Fix notification rescheduling defects causing reminders to be lost after app updates

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -73,8 +73,12 @@ function App() {
 
       // Initialize daily check-in service
       await dailyCheckinService.initialize();
-      await dailyCheckinService.scheduleNotification();
       logger.log('Daily check-in service initialized');
+
+      // Reschedule all notifications on startup to ensure they persist after app updates
+      // This handles both medication reminders and daily check-in
+      await notificationService.rescheduleAllNotifications();
+      logger.log('All notifications rescheduled on startup');
 
       // Initialize test deep links (dev only)
       if (__DEV__) {

--- a/app/src/services/notifications/index.ts
+++ b/app/src/services/notifications/index.ts
@@ -35,6 +35,7 @@ export {
   cancelScheduledMedicationReminder,
   dismissMedicationNotification,
   rescheduleAllMedicationNotifications,
+  rescheduleAllNotifications,
 } from './medicationNotifications';
 
 export {

--- a/app/src/services/notifications/notificationService.ts
+++ b/app/src/services/notifications/notificationService.ts
@@ -31,6 +31,7 @@ import {
   cancelScheduledMedicationReminder,
   dismissMedicationNotification,
   rescheduleAllMedicationNotifications,
+  rescheduleAllNotifications,
 } from './medicationNotifications';
 
 // Re-export types and functions for backwards compatibility
@@ -613,8 +614,8 @@ class NotificationService {
         await cancelAllNotifications();
         logger.log('[Notification] All notifications cancelled (global toggle disabled)');
       } else {
-        // Enable: Reschedule all medication reminders
-        await rescheduleAllMedicationNotifications();
+        // Enable: Reschedule all notifications (medications and daily check-in)
+        await rescheduleAllNotifications();
         logger.log('[Notification] All notifications rescheduled (global toggle enabled)');
       }
     } catch (error) {
@@ -633,6 +634,10 @@ class NotificationService {
 
   async rescheduleAllMedicationNotifications(): Promise<void> {
     return rescheduleAllMedicationNotifications();
+  }
+
+  async rescheduleAllNotifications(): Promise<void> {
+    return rescheduleAllNotifications();
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix medication reminders being lost after app updates by adding notification rescheduling to app startup
- Fix daily check-in notifications being silently lost when managing medications by implementing selective notification cancellation

## Details

This PR addresses two critical notification scheduling defects:

**Issue #1: Reminders lost after app updates**
- iOS can clear scheduled notifications during app updates
- The app had no recovery mechanism on startup
- Fixed by adding `rescheduleAllNotifications()` to app initialization

**Issue #2: Daily check-in notifications silently lost**
- `rescheduleAllMedicationNotifications()` cancelled ALL notifications but only rescheduled medications
- Daily check-in notifications were lost when adding/editing medications or toggling notification settings
- Fixed by implementing selective cancellation that only targets medication notifications

## Changes

- Added `rescheduleAllNotifications()` function that properly reschedules both medication and daily check-in notifications
- Updated `rescheduleAllMedicationNotifications()` to only cancel medication-specific notifications with null safety
- Added notification rescheduling to App.tsx initialization flow
- Fixed race condition by removing redundant daily check-in scheduling
- Updated tests to reflect new behavior

## Testing

✅ All 2067 tests pass
✅ No ESLint warnings
✅ No TypeScript errors
✅ Code review completed