### PR TITLE
Fix branding consistency: ensure all visible text uses 'MigraLog'

### DIFF
--- a/app/e2e/onboardingWorkflow.test.js
+++ b/app/e2e/onboardingWorkflow.test.js
@@ -22,7 +22,7 @@ describe('Onboarding Workflow', () => {
 
     // Step 1: Welcome Screen
     console.log('📱 Step 1: Looking for Welcome screen...');
-    await expect(element(by.text('Welcome to Migralog'))).toBeVisible();
+    await expect(element(by.text('Welcome to MigraLog'))).toBeVisible();
     await element(by.text('Continue')).tap();
     console.log('✅ Step 1: Welcome screen completed');
 

--- a/app/src/screens/welcome/steps/WelcomeStep.tsx
+++ b/app/src/screens/welcome/steps/WelcomeStep.tsx
@@ -16,12 +16,12 @@ export function WelcomeStep({ colors }: StepProps) {
           style={styles.logoImage}
           resizeMode="contain"
           accessible={true}
-          accessibilityLabel="Migralog app icon"
+          accessibilityLabel="MigraLog app icon"
         />
       </View>
 
       <Text style={[styles.title, { color: colors.text }]}>
-        Welcome to Migralog
+        Welcome to MigraLog
       </Text>
 
       <Text style={[styles.subtitle, { color: colors.textSecondary }]}>


### PR DESCRIPTION
## Summary
- Fix inconsistent branding in welcome screen from 'Migralog' to 'MigraLog'
- Update accessibility label and E2E test to match corrected branding  
- Ensures consistent 'MigraLog' branding across all user-facing text