### PR TITLE
fix: correct text matcher in medication dose E2E test

### DIFF
--- a/app/e2e/medicationDoseEditDelete.test.js
+++ b/app/e2e/medicationDoseEditDelete.test.js
@@ -81,7 +81,7 @@ describe('Medication Dose Edit/Delete', () => {
     await element(by.id('medication-detail-scrollview')).scrollTo('bottom');
     await waitForAnimation(500);
 
-    await waitFor(element(by.text('Recent Activity (30 days)')))
+    await waitFor(element(by.text('Recent Activity')))
       .toBeVisible()
       .withTimeout(5000);
 


### PR DESCRIPTION
## Summary
- Fixes failing E2E test that was looking for incorrect UI text "Recent Activity (30 days)"
- Updates text matcher to "Recent Activity" to match the actual section header in MedicationDetailScreen.tsx

## Changes
- Updated text assertion in medicationDoseEditDelete.test.js line 84 to match actual UI implementation

## Testing
- Test was timing out at line 86 waiting for non-existent text
- With fix, test should find the correct "Recent Activity" header and pass