### PR TITLE
Fix require cycle: NotificationDismissalService ↔ medicationNotifications

### DIFF
--- a/app/src/services/notifications/NotificationDismissalService.ts
+++ b/app/src/services/notifications/NotificationDismissalService.ts
@@ -2,7 +2,7 @@ import * as Notifications from 'expo-notifications';
 import { logger } from '../../utils/logger';
 import { medicationRepository, medicationDoseRepository } from '../../database/medicationRepository';
 import { scheduledNotificationRepository } from '../../database/scheduledNotificationRepository';
-import { MEDICATION_REMINDER_CATEGORY, MULTIPLE_MEDICATION_REMINDER_CATEGORY } from './medicationNotifications';
+import { MEDICATION_REMINDER_CATEGORY, MULTIPLE_MEDICATION_REMINDER_CATEGORY } from './notificationCategories';
 
 /**
  * Result of a notification dismissal check

--- a/app/src/services/notifications/medicationNotifications.ts
+++ b/app/src/services/notifications/medicationNotifications.ts
@@ -19,10 +19,10 @@ import { notifyUserOfError } from './errorNotificationHelper';
 import { scheduledNotificationRepository } from '../../database/scheduledNotificationRepository';
 import { NotificationType, ScheduledNotificationMappingInput } from '../../types/notifications';
 import { notificationDismissalService } from './NotificationDismissalService';
+import { MEDICATION_REMINDER_CATEGORY, MULTIPLE_MEDICATION_REMINDER_CATEGORY } from './notificationCategories';
 
-// Notification categories for action buttons
-export const MEDICATION_REMINDER_CATEGORY = 'MEDICATION_REMINDER';
-export const MULTIPLE_MEDICATION_REMINDER_CATEGORY = 'MULTIPLE_MEDICATION_REMINDER';
+// Re-export notification categories for backward compatibility
+export { MEDICATION_REMINDER_CATEGORY, MULTIPLE_MEDICATION_REMINDER_CATEGORY };
 
 /**
  * Handle "Take Now" action - log medication immediately

--- a/app/src/services/notifications/notificationCategories.ts
+++ b/app/src/services/notifications/notificationCategories.ts
@@ -1,0 +1,10 @@
+/**
+ * Notification category identifiers
+ *
+ * These constants are used by both notification scheduling and dismissal logic.
+ * Extracted to a separate file to avoid circular dependencies.
+ */
+
+// Notification categories for action buttons
+export const MEDICATION_REMINDER_CATEGORY = 'MEDICATION_REMINDER';
+export const MULTIPLE_MEDICATION_REMINDER_CATEGORY = 'MULTIPLE_MEDICATION_REMINDER';

--- a/app/src/services/notifications/notificationService.ts
+++ b/app/src/services/notifications/notificationService.ts
@@ -22,6 +22,9 @@ import {
   cancelNotification,
 } from './notificationScheduler';
 
+// Import notification categories from shared file
+import { MEDICATION_REMINDER_CATEGORY, MULTIPLE_MEDICATION_REMINDER_CATEGORY } from './notificationCategories';
+
 // Lazy import to avoid circular dependency with medicationStore
 // medicationNotifications imports medicationStore, which imports notificationService
 let medicationNotificationsModule: typeof import('./medicationNotifications') | null = null;
@@ -35,9 +38,8 @@ const getMedicationNotifications = async () => {
 // Re-export types and functions for backwards compatibility
 export type { NotificationPermissions };
 
-// Re-export constants that are needed at module load time
-export const MEDICATION_REMINDER_CATEGORY = 'MEDICATION_REMINDER';
-export const MULTIPLE_MEDICATION_REMINDER_CATEGORY = 'MULTIPLE_MEDICATION_REMINDER';
+// Re-export constants for backwards compatibility
+export { MEDICATION_REMINDER_CATEGORY, MULTIPLE_MEDICATION_REMINDER_CATEGORY };
 
 /**
  * Handle incoming notifications and decide whether to show them


### PR DESCRIPTION
## Summary

Fixes #299 by eliminating the circular dependency between `NotificationDismissalService.ts` and `medicationNotifications.ts`.

## Changes

- **Created** `notificationCategories.ts` - New file containing shared notification category constants:
  - `MEDICATION_REMINDER_CATEGORY`
  - `MULTIPLE_MEDICATION_REMINDER_CATEGORY`

- **Updated** `NotificationDismissalService.ts` - Import constants from `notificationCategories.ts` instead of `medicationNotifications.ts`

- **Updated** `medicationNotifications.ts` - Import and re-export constants for backward compatibility

- **Updated** `notificationService.ts` - Import constants from `notificationCategories.ts` instead of hardcoding them

## Problem Solved

Before this fix, Metro bundler showed this warning on every build:
```
WARN  Require cycle: src/services/notifications/NotificationDismissalService.ts -> src/services/notifications/medicationNotifications.ts -> src/services/notifications/NotificationDismissalService.ts
```

The circular dependency was:
1. `NotificationDismissalService.ts` imported category constants from `medicationNotifications.ts`
2. `medicationNotifications.ts` imported `notificationDismissalService` from `NotificationDismissalService.ts`

## Solution Approach

**Extracted shared code to a separate module** - This is the cleanest approach for breaking circular dependencies when two modules need to share constants or types. The new `notificationCategories.ts` file:
- Contains only constant definitions (no imports)
- Can be imported by any module without creating cycles
- Maintains backward compatibility by re-exporting from `medicationNotifications.ts`

## Testing

- ✅ All tests pass: `npm run test:ci`
- ✅ Linting passes: `npm run test:lint:ci`
- ✅ TypeScript compilation passes: `npx tsc --noEmit`
- ✅ Pre-commit checks pass: `npm run precommit`
- ✅ No functionality changes - purely a refactoring

## Impact

- **Risk**: Low - No functionality changes, only import reorganization
- **Breaking changes**: None - Backward compatibility maintained via re-exports
- **Performance**: Neutral - No runtime impact

Generated with [Claude Code](https://claude.com/claude-code)