### PR TITLE
Fix: Critical alerts missing from follow-up notifications

### DIFF
--- a/app/src/services/notifications/medicationNotifications.ts
+++ b/app/src/services/notifications/medicationNotifications.ts
@@ -1824,6 +1824,7 @@ export async function scheduleNotificationsForDays(
             categoryIdentifier: MEDICATION_REMINDER_CATEGORY,
             sound: true,
             ...(effectiveSettings.criticalAlertsEnabled && { critical: true } as unknown as Record<string, unknown>),
+            ...(effectiveSettings.criticalAlertsEnabled && { interruptionLevel: 'critical' } as unknown as Record<string, unknown>),
           },
           followUpDate,
           followUpMapping
@@ -1947,7 +1948,9 @@ export async function topUpNotifications(threshold: number = 3): Promise<void> {
                 },
                 categoryIdentifier: MEDICATION_REMINDER_CATEGORY,
                 sound: true,
-                ...(effectiveSettings.timeSensitiveEnabled && { interruptionLevel: 'timeSensitive' } as unknown as Record<string, unknown>),
+                ...(effectiveSettings.criticalAlertsEnabled && { critical: true } as unknown as Record<string, unknown>),
+                ...(effectiveSettings.criticalAlertsEnabled && { interruptionLevel: 'critical' } as unknown as Record<string, unknown>),
+                ...(!effectiveSettings.criticalAlertsEnabled && effectiveSettings.timeSensitiveEnabled && { interruptionLevel: 'timeSensitive' } as unknown as Record<string, unknown>),
               },
               triggerDate,
               {


### PR DESCRIPTION
## Summary
- Fixed follow-up notifications to properly use critical alerts when enabled
- Added `interruptionLevel: 'critical'` alongside existing `critical: true` flag in two locations
- Enhanced topUpNotifications() to support critical alerts with proper priority handling (critical > timeSensitive)

## Problem
iOS requires both `critical: true` AND `interruptionLevel: 'critical'` for proper critical alert behavior. The follow-up notification system was only setting the `critical` flag, causing follow-ups to be delivered as normal time-sensitive messages instead of critical alerts that can break through Do Not Disturb and Focus modes.

## Changes
1. **scheduleNotificationsForDays()** (line 1827): Added `interruptionLevel: 'critical'` to follow-up notifications when critical alerts are enabled
2. **topUpNotifications()** (lines 1951-1953): 
   - Added critical alert support with both `critical: true` and `interruptionLevel: 'critical'`
   - Implemented proper priority: critical alerts take precedence over timeSensitive
   - Only uses timeSensitive when critical alerts are not enabled

## Implementation Details
The fix aligns with the existing pattern used in `scheduleFollowUpForScheduledNotification()` and `scheduleFollowUpForScheduledMultipleNotification()`, which already implement the correct dual-property approach for critical alerts.

## Test plan
- [ ] Verify critical alerts are enabled in notification settings
- [ ] Schedule a medication with follow-up notifications enabled
- [ ] Confirm follow-up notification is delivered as critical alert (breaks through DND/Focus)
- [ ] Test top-up notifications work correctly with critical alerts
- [ ] Confirm time-sensitive still works when critical alerts are disabled

## Validation
- All precommit checks passed (npm audit, linting, type checking, tests)
- Test coverage remains above 80%
- No new ESLint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)