### PR TITLE
fix: trigger deploy workflow on release creation

### DIFF
--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -6,6 +6,8 @@ on:
       - 'alpha-v*'
       - 'beta-v*'
       - 'v*'
+  release:
+    types: [created]
   workflow_dispatch:
     inputs:
       build_profile:
@@ -34,7 +36,12 @@ jobs:
 
       - name: Determine build profile from tag
         run: |
-          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          # Handle both push (tags) and release events
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            TAG_NAME="${{ github.event.release.tag_name }}"
+          else
+            TAG_NAME="${GITHUB_REF#refs/tags/}"
+          fi
           echo "Tag: $TAG_NAME"
 
           if [[ "$TAG_NAME" == alpha-v* ]]; then
@@ -98,7 +105,8 @@ jobs:
           echo "Check build status at: https://expo.dev/accounts/akin-gulp/projects/migraine-tracker/builds"
 
       - name: Extract changelog for release notes
-        if: success() && startsWith(github.ref, 'refs/tags/')
+        # Only extract changelog for tag push events (release events already have notes)
+        if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         id: changelog
         run: |
           TAG_NAME="${GITHUB_REF#refs/tags/}"
@@ -123,7 +131,8 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        if: success() && startsWith(github.ref, 'refs/tags/')
+        # Only create release for tag push events (release events already have a release)
+        if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           name: Release ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Add `release: [created]` trigger to deploy-testflight workflow
- Update tag extraction to handle both push and release events
- Skip release creation step when triggered by release event (already exists)

## Problem
`gh release create` creates tags via GitHub API, which doesn't fire `push` events. The workflow only triggered on `push: tags:`, so releases created via the script weren't building.

## Test plan
- [ ] Merge this PR
- [ ] Run `npm run release:alpha` or manually trigger workflow
- [ ] Verify Deploy to TestFlight workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)