### PR TITLE
feat: add diagnostics for notification schedule errors

### DIFF
--- a/app/src/screens/settings/ScheduledNotificationsScreen.tsx
+++ b/app/src/screens/settings/ScheduledNotificationsScreen.tsx
@@ -118,6 +118,22 @@ export default function ScheduledNotificationsScreen({ navigation }: Props) {
       });
     }
 
+    // Sort by trigger time (soonest first)
+    filtered.sort((a, b) => {
+      const getTriggerTimestamp = (trigger: Notifications.NotificationTrigger | null): number => {
+        if (!trigger) return Infinity;
+        if ('type' in trigger && trigger.type === 'date' && 'date' in trigger && trigger.date) {
+          return new Date(trigger.date).getTime();
+        }
+        // For calendar/daily triggers, they repeat so put them at the end
+        return Infinity;
+      };
+
+      const timeA = getTriggerTimestamp(a.osNotification.trigger);
+      const timeB = getTriggerTimestamp(b.osNotification.trigger);
+      return timeA - timeB;
+    });
+
     setFilteredNotifications(filtered);
   }, [enrichedNotifications, selectedFilter, searchText]);
 

--- a/app/src/services/notifications/medicationNotifications.ts
+++ b/app/src/services/notifications/medicationNotifications.ts
@@ -60,6 +60,8 @@ export async function handleTakeNow(medicationId: string, scheduleId: string): P
         scheduleId,
         medicationName: medication.name,
         availableScheduleIds: medication.schedule?.map(s => s.id) || [],
+        scheduleCount: medication.schedule?.length || 0,
+        medicationActive: medication.active,
         operation: 'handleTakeNow',
         component: 'NotificationConsistency',
       });
@@ -347,6 +349,8 @@ export async function handleTakeAllNow(
             scheduleId,
             medicationName: medication.name,
             availableScheduleIds: medication.schedule?.map(s => s.id) || [],
+            scheduleCount: medication.schedule?.length || 0,
+            medicationActive: medication.active,
             operation: 'handleTakeAllNow',
             index: i,
             component: 'NotificationConsistency',
@@ -1813,6 +1817,7 @@ export async function scheduleNotificationsForDays(
         data: {
           medicationId: medication.id,
           scheduleId: schedule.id,
+          scheduledAt: Date.now(), // DIAGNOSTIC: Track when notification was scheduled for age calculation
         },
         categoryIdentifier: MEDICATION_REMINDER_CATEGORY,
         sound: true,
@@ -1843,6 +1848,7 @@ export async function scheduleNotificationsForDays(
               medicationId: medication.id,
               scheduleId: schedule.id,
               isFollowUp: true,
+              scheduledAt: Date.now(), // DIAGNOSTIC: Track when notification was scheduled for age calculation
             },
             categoryIdentifier: MEDICATION_REMINDER_CATEGORY,
             sound: true,
@@ -1968,6 +1974,7 @@ export async function topUpNotifications(threshold: number = 3): Promise<void> {
                 data: {
                   medicationId: medication.id,
                   scheduleId: schedule.id,
+                  scheduledAt: Date.now(), // DIAGNOSTIC: Track when notification was scheduled for age calculation
                 },
                 categoryIdentifier: MEDICATION_REMINDER_CATEGORY,
                 sound: true,

--- a/app/src/store/medicationStore.ts
+++ b/app/src/store/medicationStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import * as Sentry from '@sentry/react-native';
 import { logger } from '../utils/logger';
 import { Medication, MedicationDose, MedicationSchedule } from '../models/types';
 import { medicationRepository, medicationDoseRepository, medicationScheduleRepository } from '../database/medicationRepository';
@@ -670,6 +671,16 @@ export const useMedicationStore = create<MedicationState>((set, get) => ({
       set({ schedules, loading: false });
 
       logger.log('[Store] Schedule added:', newSchedule.id);
+
+      // DIAGNOSTIC: Add Sentry breadcrumb for schedule creation
+      // This helps trace schedule lifecycle when debugging "Schedule not found" errors
+      Sentry.addBreadcrumb({
+        category: 'schedule',
+        message: 'Schedule created',
+        data: { scheduleId: newSchedule.id, medicationId: schedule.medicationId, time: schedule.time },
+        level: 'info',
+      });
+
       return newSchedule;
     } catch (error) {
       await errorLogger.log('database', 'Failed to add schedule', error as Error, {
@@ -703,6 +714,15 @@ export const useMedicationStore = create<MedicationState>((set, get) => ({
       set({ schedules, loading: false });
 
       logger.log('[Store] Schedule updated:', id);
+
+      // DIAGNOSTIC: Add Sentry breadcrumb for schedule update
+      // This helps trace schedule lifecycle when debugging "Schedule not found" errors
+      Sentry.addBreadcrumb({
+        category: 'schedule',
+        message: 'Schedule updated',
+        data: { scheduleId: id, updates: Object.keys(updates) },
+        level: 'info',
+      });
     } catch (error) {
       await errorLogger.log('database', 'Failed to update schedule', error as Error, {
         operation: 'updateSchedule',
@@ -732,6 +752,15 @@ export const useMedicationStore = create<MedicationState>((set, get) => ({
       set({ schedules, loading: false });
 
       logger.log('[Store] Schedule deleted:', id);
+
+      // DIAGNOSTIC: Add Sentry breadcrumb for schedule deletion
+      // This helps trace schedule lifecycle when debugging "Schedule not found" errors
+      Sentry.addBreadcrumb({
+        category: 'schedule',
+        message: 'Schedule deleted',
+        data: { scheduleId: id },
+        level: 'info',
+      });
     } catch (error) {
       await errorLogger.log('database', 'Failed to delete schedule', error as Error, {
         operation: 'deleteSchedule',


### PR DESCRIPTION
## Summary

Adds diagnostic instrumentation to help debug "Schedule not found" errors in notification handlers.

**Changes:**
- Add Sentry breadcrumbs for schedule create/update/delete operations in `medicationStore.ts`
- Add `scheduledAt` timestamp to notification data payload for notification age calculation
- Enhance error context in `handleTakeNow` and `handleTakeAllNow` with `scheduleCount` and `medicationActive`
- Sort scheduled notifications list by trigger time (soonest first) in developer tools

## Context

These diagnostics will help determine whether "Schedule not found" errors are caused by:
1. Stale notifications referencing deleted schedule IDs after schedule regeneration
2. Other bugs in schedule lookup

When the error occurs next time, Sentry will show:
- `availableScheduleIds` - what schedule IDs currently exist
- `scheduleCount` - how many schedules the medication has
- `medicationActive` - whether the medication is still active
- Breadcrumbs showing recent schedule create/update/delete operations
- `scheduledAt` in notification data (for newly scheduled notifications)

## Test plan
- [x] TypeScript type check passes
- [x] All notification-related tests pass (137 tests)
- [ ] Manual verification of sorted notification list in developer tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)