### PR TITLE
fix: remove fallback dismissal strategies - use database lookup only

### DIFF
--- a/app/src/services/notifications/NotificationDismissalService.ts
+++ b/app/src/services/notifications/NotificationDismissalService.ts
@@ -2,7 +2,6 @@ import * as Notifications from 'expo-notifications';
 import { logger } from '../../utils/logger';
 import { medicationRepository, medicationDoseRepository } from '../../database/medicationRepository';
 import { scheduledNotificationRepository } from '../../database/scheduledNotificationRepository';
-import { MEDICATION_REMINDER_CATEGORY, MULTIPLE_MEDICATION_REMINDER_CATEGORY } from './notificationCategories';
 
 /**
  * Result of a notification dismissal check
@@ -11,53 +10,35 @@ export interface DismissalResult {
   /** Whether the notification should be dismissed */
   shouldDismiss: boolean;
   /** Strategy that determined the dismissal decision */
-  strategy: 'database_id_lookup' | 'time_based' | 'content_based' | 'category_based' | 'none';
+  strategy: 'database_id_lookup' | 'none';
   /** Confidence score for the dismissal decision (0-100) */
   confidence: number;
   /** Additional context about the decision */
   context?: string;
 }
 
-
-
 /**
- * Configuration for fallback strategies
- */
-interface FallbackConfig {
-  /** Time window in minutes for time-based matching */
-  timeWindowMinutes: number;
-  /** Minimum confidence threshold for dismissal */
-  minConfidenceThreshold: number;
-}
-
-/**
- * NotificationDismissalService - Cross-Reference Dismissal Logic
+ * NotificationDismissalService - Database ID Lookup Dismissal Logic
  *
- * This service implements comprehensive notification dismissal logic using database
- * cross-reference as the primary strategy with multiple fallback approaches.
+ * This service implements notification dismissal logic using database
+ * cross-reference as the ONLY strategy for determining whether to dismiss a notification.
  *
  * Key Features:
- * - Primary: Database ID lookup for exact matching
- * - Fallback: Time-based matching within 30-minute window
- * - Fallback: Content-based matching using medication names
- * - Fallback: Category-based matching with time correlation
+ * - Database ID lookup for exact matching (ONLY strategy)
  * - Support for all notification types: single, grouped, daily check-in, follow-up
  * - Safety mechanisms for grouped notifications
- * - Comprehensive logging and confidence scoring
+ * - Fail-safe behavior: if database lookup fails, notification is NOT dismissed
+ * - Comprehensive logging for diagnostics
  */
 export class NotificationDismissalService {
-  private readonly config: FallbackConfig = {
-    timeWindowMinutes: 30,
-    minConfidenceThreshold: 80,
-  };
 
   /**
-   * Determine whether a notification should be dismissed based on cross-reference logic
+   * Determine whether a notification should be dismissed based on database ID lookup
    *
    * @param notificationId - OS notification identifier
    * @param targetMedicationId - Medication ID that was logged/acted upon
    * @param targetScheduleId - Schedule ID that was logged/acted upon
-   * @param loggedTime - Time when the dose was logged
+   * @param loggedTime - Time when the dose was logged (unused, kept for API compatibility)
    * @returns Promise<DismissalResult> - Decision and reasoning
    */
   async shouldDismissNotification(
@@ -75,97 +56,43 @@ export class NotificationDismissalService {
         component: 'NotificationDismissalService',
       });
 
-      // Strategy 1: Database ID Lookup (Primary)
-      const primaryResult = await this.checkDatabaseIdLookup(
+      // Database ID Lookup (ONLY strategy)
+      const result = await this.checkDatabaseIdLookup(
         notificationId,
         targetMedicationId,
         targetScheduleId
       );
 
-      if (primaryResult.shouldDismiss) {
-        logger.info('[NotificationDismissal] Primary strategy succeeded', {
+      if (result.shouldDismiss) {
+        logger.info('[NotificationDismissal] Database lookup succeeded - dismissing notification', {
           notificationId,
-          strategy: primaryResult.strategy,
-          confidence: primaryResult.confidence,
+          strategy: result.strategy,
+          confidence: result.confidence,
           component: 'NotificationDismissalService',
         });
-        return primaryResult;
+        return result;
       }
 
-      // If primary strategy found a match but decided not to dismiss (e.g., grouped notification safety),
-      // return that result instead of trying fallback strategies
-      if (primaryResult.strategy === 'database_id_lookup' && primaryResult.confidence === 100) {
-        logger.info('[NotificationDismissal] Primary strategy found match but decided not to dismiss', {
+      // If database lookup found a match but decided not to dismiss (e.g., grouped notification safety),
+      // return that result with clear context
+      if (result.strategy === 'database_id_lookup' && result.confidence === 100) {
+        logger.info('[NotificationDismissal] Database lookup found match but not dismissing', {
           notificationId,
-          strategy: primaryResult.strategy,
-          confidence: primaryResult.confidence,
-          context: primaryResult.context,
+          strategy: result.strategy,
+          confidence: result.confidence,
+          context: result.context,
           component: 'NotificationDismissalService',
         });
-        return primaryResult;
+        return result;
       }
 
-      // Strategy 2: Time-based matching
-      const timeBasedResult = await this.checkTimeBasedMatching(
-        targetMedicationId,
-        targetScheduleId,
-        loggedTime
-      );
-
-      if (timeBasedResult.shouldDismiss && timeBasedResult.confidence >= this.config.minConfidenceThreshold) {
-        logger.info('[NotificationDismissal] Time-based strategy succeeded', {
-          notificationId,
-          strategy: timeBasedResult.strategy,
-          confidence: timeBasedResult.confidence,
-          component: 'NotificationDismissalService',
-        });
-        return timeBasedResult;
-      }
-
-      // Strategy 3: Content-based matching
-      const contentBasedResult = await this.checkContentBasedMatching(
-        notificationId,
-        targetMedicationId
-      );
-
-      if (contentBasedResult.shouldDismiss && contentBasedResult.confidence >= this.config.minConfidenceThreshold) {
-        logger.info('[NotificationDismissal] Content-based strategy succeeded', {
-          notificationId,
-          strategy: contentBasedResult.strategy,
-          confidence: contentBasedResult.confidence,
-          component: 'NotificationDismissalService',
-        });
-        return contentBasedResult;
-      }
-
-      // Strategy 4: Category-based matching
-      const categoryBasedResult = await this.checkCategoryBasedMatching(
-        notificationId,
-        targetMedicationId,
-        loggedTime
-      );
-
-      if (categoryBasedResult.shouldDismiss && categoryBasedResult.confidence >= this.config.minConfidenceThreshold) {
-        logger.info('[NotificationDismissal] Category-based strategy succeeded', {
-          notificationId,
-          strategy: categoryBasedResult.strategy,
-          confidence: categoryBasedResult.confidence,
-          component: 'NotificationDismissalService',
-        });
-        return categoryBasedResult;
-      }
-
-      // No strategy succeeded
-      logger.debug('[NotificationDismissal] No strategy succeeded, not dismissing', {
+      // Database lookup failed - log warning for diagnostics
+      logger.warn('[NotificationDismissal] Database lookup failed - notification will NOT be dismissed', {
         notificationId,
         targetMedicationId,
         targetScheduleId,
-        strategies: {
-          primary: primaryResult.confidence,
-          timeBased: timeBasedResult.confidence,
-          contentBased: contentBasedResult.confidence,
-          categoryBased: categoryBasedResult.confidence,
-        },
+        confidence: result.confidence,
+        context: result.context,
         component: 'NotificationDismissalService',
       });
 
@@ -173,7 +100,7 @@ export class NotificationDismissalService {
         shouldDismiss: false,
         strategy: 'none',
         confidence: 0,
-        context: 'All strategies failed to meet confidence threshold',
+        context: result.context || 'Database lookup failed',
       };
     } catch (error) {
       logger.error('[NotificationDismissal] Error evaluating dismissal', error instanceof Error ? error : new Error(String(error)), {
@@ -193,10 +120,10 @@ export class NotificationDismissalService {
   }
 
   /**
-   * Strategy 1: Database ID Lookup
+   * Database ID Lookup
    *
-   * Primary strategy that uses the scheduled notification repository to find
-   * exact matches based on notification ID and cross-reference with medication/schedule IDs.
+   * Uses the scheduled notification repository to find exact matches based on
+   * notification ID and cross-reference with medication/schedule IDs.
    */
   private async checkDatabaseIdLookup(
     notificationId: string,
@@ -256,7 +183,7 @@ export class NotificationDismissalService {
         context: 'No matching mapping found in database',
       };
     } catch (error) {
-      logger.warn('[NotificationDismissal] Database lookup failed', error instanceof Error ? error : new Error(String(error)), {
+      logger.error('[NotificationDismissal] Database lookup failed', error instanceof Error ? error : new Error(String(error)), {
         notificationId,
         targetMedicationId,
         targetScheduleId,
@@ -268,263 +195,6 @@ export class NotificationDismissalService {
         strategy: 'database_id_lookup',
         confidence: 0,
         context: 'Database lookup error',
-      };
-    }
-  }
-
-  /**
-   * Strategy 2: Time-based Matching
-   *
-   * Fallback strategy that matches notifications within a time window of the logged dose.
-   * Uses notification metadata stored in the database for precise time matching.
-   */
-  private async checkTimeBasedMatching(
-    targetMedicationId: string,
-    targetScheduleId: string,
-    loggedTime: Date
-  ): Promise<DismissalResult> {
-    try {
-      // Find notifications within time window
-      const windowMappings = await scheduledNotificationRepository.findByTimeWindow(
-        loggedTime,
-        this.config.timeWindowMinutes
-      );
-
-      logger.debug('[NotificationDismissal] Time-based search found mappings', {
-        targetMedicationId,
-        targetScheduleId,
-        loggedTime: loggedTime.toISOString(),
-        windowMinutes: this.config.timeWindowMinutes,
-        mappingCount: windowMappings.length,
-        component: 'NotificationDismissalService',
-      });
-
-      // Look for matches with our target medication/schedule
-      for (const mapping of windowMappings) {
-        if (mapping.medicationId === targetMedicationId && mapping.scheduleId === targetScheduleId) {
-          // Calculate confidence based on time proximity
-          const timeDiff = Math.abs(loggedTime.getTime() - (mapping.scheduledTriggerTime?.getTime() || 0));
-          const maxDiff = this.config.timeWindowMinutes * 60 * 1000;
-          const confidence = Math.max(60, Math.round(100 - (timeDiff / maxDiff) * 40));
-
-          return {
-            shouldDismiss: true,
-            strategy: 'time_based',
-            confidence,
-            context: `Matched within ${Math.round(timeDiff / 60000)} minute window`,
-          };
-        }
-      }
-
-      return {
-        shouldDismiss: false,
-        strategy: 'time_based',
-        confidence: 30,
-        context: 'No time-based match found within window',
-      };
-    } catch (error) {
-      logger.warn('[NotificationDismissal] Time-based matching failed', error instanceof Error ? error : new Error(String(error)), {
-        targetMedicationId,
-        targetScheduleId,
-        component: 'NotificationDismissalService',
-      });
-
-      return {
-        shouldDismiss: false,
-        strategy: 'time_based',
-        confidence: 0,
-        context: 'Time-based matching error',
-      };
-    }
-  }
-
-  /**
-   * Strategy 3: Content-based Matching
-   *
-   * Fallback strategy that matches notifications based on medication name in notification content.
-   * Uses both database metadata and live notification inspection.
-   */
-  private async checkContentBasedMatching(
-    notificationId: string,
-    targetMedicationId: string
-  ): Promise<DismissalResult> {
-    try {
-      // Get medication name for comparison
-      const medication = await medicationRepository.getById(targetMedicationId);
-      if (!medication) {
-        return {
-          shouldDismiss: false,
-          strategy: 'content_based',
-          confidence: 0,
-          context: 'Medication not found',
-        };
-      }
-
-      // First try: Check database metadata
-      const today = new Date();
-      const dateRange: [Date, Date] = [
-        new Date(today.getTime() - 24 * 60 * 60 * 1000), // Yesterday
-        new Date(today.getTime() + 24 * 60 * 60 * 1000), // Tomorrow
-      ];
-
-      const nameMatches = await scheduledNotificationRepository.findByMedicationName(
-        medication.name,
-        dateRange
-      );
-
-      logger.debug('[NotificationDismissal] Content-based search results', {
-        medicationName: medication.name,
-        targetMedicationId,
-        nameMatches: nameMatches.length,
-        component: 'NotificationDismissalService',
-      });
-
-      // Check if any matches correspond to our notification ID
-      for (const mapping of nameMatches) {
-        if (mapping.notificationId === notificationId) {
-          return {
-            shouldDismiss: true,
-            strategy: 'content_based',
-            confidence: 85,
-            context: `Medication name matched: ${medication.name}`,
-          };
-        }
-      }
-
-      // Second try: Check live notification content
-      const presentedNotifications = await Notifications.getPresentedNotificationsAsync();
-      for (const notification of presentedNotifications) {
-        if (notification.request.identifier === notificationId) {
-          const { title, body } = notification.request.content;
-          const titleLower = title?.toLowerCase() || '';
-          const bodyLower = body?.toLowerCase() || '';
-          const medNameLower = medication.name.toLowerCase();
-
-          if (titleLower.includes(medNameLower) || bodyLower.includes(medNameLower)) {
-            return {
-              shouldDismiss: true,
-              strategy: 'content_based',
-              confidence: 75,
-              context: `Medication name found in notification content: ${medication.name}`,
-            };
-          }
-        }
-      }
-
-      return {
-        shouldDismiss: false,
-        strategy: 'content_based',
-        confidence: 20,
-        context: 'No content-based match found',
-      };
-    } catch (error) {
-      logger.warn('[NotificationDismissal] Content-based matching failed', error instanceof Error ? error : new Error(String(error)), {
-        notificationId,
-        targetMedicationId,
-        component: 'NotificationDismissalService',
-      });
-
-      return {
-        shouldDismiss: false,
-        strategy: 'content_based',
-        confidence: 0,
-        context: 'Content-based matching error',
-      };
-    }
-  }
-
-  /**
-   * Strategy 4: Category-based Matching
-   *
-   * Fallback strategy that matches notifications based on category and time correlation.
-   * Uses notification category identifiers with time window validation.
-   */
-  private async checkCategoryBasedMatching(
-    notificationId: string,
-    targetMedicationId: string,
-    loggedTime: Date
-  ): Promise<DismissalResult> {
-    try {
-      // Get the notification to check its category
-      const presentedNotifications = await Notifications.getPresentedNotificationsAsync();
-      let targetNotification = null;
-
-      for (const notification of presentedNotifications) {
-        if (notification.request.identifier === notificationId) {
-          targetNotification = notification;
-          break;
-        }
-      }
-
-      if (!targetNotification) {
-        return {
-          shouldDismiss: false,
-          strategy: 'category_based',
-          confidence: 0,
-          context: 'Notification not found in presented list',
-        };
-      }
-
-      const category = targetNotification.request.content.categoryIdentifier;
-      if (!category || ![MEDICATION_REMINDER_CATEGORY, MULTIPLE_MEDICATION_REMINDER_CATEGORY].includes(category)) {
-        return {
-          shouldDismiss: false,
-          strategy: 'category_based',
-          confidence: 0,
-          context: 'Not a medication reminder category',
-        };
-      }
-
-      // Find notifications by category within time window
-      const timeWindow: [Date, Date] = [
-        new Date(loggedTime.getTime() - this.config.timeWindowMinutes * 60 * 1000),
-        new Date(loggedTime.getTime() + this.config.timeWindowMinutes * 60 * 1000),
-      ];
-
-      const categoryMatches = await scheduledNotificationRepository.findByCategoryAndTime(
-        category,
-        timeWindow
-      );
-
-      logger.debug('[NotificationDismissal] Category-based search results', {
-        category,
-        timeWindow: timeWindow.map(t => t.toISOString()),
-        matches: categoryMatches.length,
-        targetMedicationId,
-        component: 'NotificationDismissalService',
-      });
-
-      // Check for medication match within category results
-      for (const mapping of categoryMatches) {
-        if (mapping.medicationId === targetMedicationId && mapping.notificationId === notificationId) {
-          const confidence = category === MEDICATION_REMINDER_CATEGORY ? 70 : 60; // Single med higher confidence
-          return {
-            shouldDismiss: true,
-            strategy: 'category_based',
-            confidence,
-            context: `Category and time match: ${category}`,
-          };
-        }
-      }
-
-      return {
-        shouldDismiss: false,
-        strategy: 'category_based',
-        confidence: 25,
-        context: 'No category-based match found',
-      };
-    } catch (error) {
-      logger.warn('[NotificationDismissal] Category-based matching failed', error instanceof Error ? error : new Error(String(error)), {
-        notificationId,
-        targetMedicationId,
-        component: 'NotificationDismissalService',
-      });
-
-      return {
-        shouldDismiss: false,
-        strategy: 'category_based',
-        confidence: 0,
-        context: 'Category-based matching error',
       };
     }
   }
@@ -694,9 +364,6 @@ export class NotificationDismissalService {
     presentedNotification: Record<string, unknown> | null;
     strategies: {
       database: DismissalResult;
-      timeBased?: DismissalResult;
-      contentBased?: DismissalResult;
-      categoryBased?: DismissalResult;
     };
   }> {
     try {
@@ -709,47 +376,16 @@ export class NotificationDismissalService {
         n => n.request.identifier === notificationId
       );
 
-      // Run diagnostic checks
-      const strategies: {
-        database: DismissalResult;
-        timeBased?: DismissalResult;
-        contentBased?: DismissalResult;
-        categoryBased?: DismissalResult;
-      } = {
-        database: {
-          shouldDismiss: false,
-          strategy: 'database_id_lookup',
-          confidence: 0,
-          context: 'Not initialized',
-        },
-      };
-
-      // Database strategy
+      // Run diagnostic check for database strategy
+      let databaseResult: DismissalResult;
       if (targetMedicationId && targetScheduleId) {
-        strategies.database = await this.checkDatabaseIdLookup(
+        databaseResult = await this.checkDatabaseIdLookup(
           notificationId,
           targetMedicationId,
           targetScheduleId
         );
-
-        strategies.timeBased = await this.checkTimeBasedMatching(
-          targetMedicationId,
-          targetScheduleId,
-          new Date()
-        );
-
-        strategies.contentBased = await this.checkContentBasedMatching(
-          notificationId,
-          targetMedicationId
-        );
-
-        strategies.categoryBased = await this.checkCategoryBasedMatching(
-          notificationId,
-          targetMedicationId,
-          new Date()
-        );
       } else {
-        strategies.database = {
+        databaseResult = {
           shouldDismiss: false,
           strategy: 'database_id_lookup',
           confidence: 0,
@@ -760,7 +396,9 @@ export class NotificationDismissalService {
       return {
         mappings: mappings.map(m => ({ ...m }) as Record<string, unknown>),
         presentedNotification: presentedNotification ? ({ ...presentedNotification }) as Record<string, unknown> : null,
-        strategies,
+        strategies: {
+          database: databaseResult,
+        },
       };
     } catch (error) {
       logger.error('[NotificationDismissal] Error getting diagnostic info', error instanceof Error ? error : new Error(String(error)), {


### PR DESCRIPTION
## Summary

- Removes all fallback strategies from NotificationDismissalService
- Keeps only the database ID lookup (primary strategy)
- Fail-safe: does NOT dismiss if database mapping not found
- Adds warning log when database lookup fails for diagnosis

## Problem

The fallback strategies (time-based, content-based, category-based) were **hiding defects** and causing incorrect behavior. When user logged one medication (Migraine MD), the time-based fallback strategy incorrectly dismissed notifications for OTHER medications (Magnesium) because they happened to be scheduled at the same time. This caused:
- All 4 notifications to be dismissed
- But only one medication (Migraine MD) was actually logged in the app

The time-based strategy was checking if any notification for the target medication existed in the 30-minute time window, and if so, returning `shouldDismiss: true` - but this result was being applied to WHATEVER notification was being evaluated, even if it was for a different medication.

## Changes

1. **Removed fallback strategies**:
   - `checkTimeBasedMatching` (Strategy 2) - removed
   - `checkContentBasedMatching` (Strategy 3) - removed
   - `checkCategoryBasedMatching` (Strategy 4) - removed
   - `FallbackConfig` interface and class property - removed

2. **Updated DismissalResult interface**:
   - Strategy type changed from `'database_id_lookup' | 'time_based' | 'content_based' | 'category_based' | 'none'` to `'database_id_lookup' | 'none'`

3. **Fail-safe behavior**:
   - When database lookup fails to find a mapping, return `shouldDismiss: false`
   - Add warning log when database lookup fails (for diagnosis)

4. **Preserved grouped notification safety check** (`checkGroupedNotificationSafety`) as it's part of the database lookup strategy

5. **Updated tests** to verify fail-safe behavior and removed tests for deleted fallback strategies

## New Behavior

| Scenario | Old Behavior | New Behavior |
|----------|-------------|--------------|
| Database mapping found | Dismiss ✅ | Dismiss ✅ |
| Database mapping not found | Try fallbacks, might dismiss wrong notification ⚠️ | Do NOT dismiss, log warning ✅ |
| Grouped notification, not all logged | Don't dismiss ✅ | Don't dismiss ✅ |

## Test plan
- [ ] Verify notification is dismissed when exact database mapping exists
- [ ] Verify notification is NOT dismissed when database mapping is missing
- [ ] Verify warning is logged when database lookup fails
- [ ] Verify grouped notification safety check still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)