### PR TITLE
fix: improve developer tools UI and notification display

### DIFF
--- a/app/src/screens/settings/DeveloperToolsScreen.tsx
+++ b/app/src/screens/settings/DeveloperToolsScreen.tsx
@@ -330,19 +330,36 @@ export default function DeveloperToolsScreen({ navigation }: Props) {
                 <View
                   style={[
                     styles.developerButton,
-                    sentryStatus.isConfigured
-                      ? { backgroundColor: theme.background }
-                      : { backgroundColor: theme.background, borderColor: theme.danger, borderWidth: 1 },
+                    !sentryStatus.isConfigured
+                      ? { backgroundColor: theme.background, borderColor: theme.danger, borderWidth: 1 }
+                      : { backgroundColor: theme.background },
                   ]}
                 >
                   <Ionicons
-                    name={sentryStatus.isConfigured ? 'checkmark-circle' : 'alert-circle'}
+                    name={
+                      sentryStatus.isEnabled
+                        ? 'checkmark-circle'
+                        : sentryStatus.isConfigured
+                          ? 'pause-circle'
+                          : 'alert-circle'
+                    }
                     size={24}
-                    color={sentryStatus.isConfigured ? '#34C759' : theme.danger}
+                    color={
+                      sentryStatus.isEnabled
+                        ? '#34C759'
+                        : sentryStatus.isConfigured
+                          ? theme.warning
+                          : theme.danger
+                    }
                   />
                   <View style={{ flex: 1, marginLeft: 12 }}>
                     <Text style={styles.developerButtonText}>
-                      Sentry: {sentryStatus.isConfigured ? '✅ Active' : '❌ Not Configured'}
+                      Sentry:{' '}
+                      {sentryStatus.isEnabled
+                        ? '✅ Active'
+                        : sentryStatus.isConfigured
+                          ? '⏸️ Configured (Disabled)'
+                          : '❌ Not Configured'}
                     </Text>
                     <Text style={{ fontSize: 12, color: theme.textTertiary, marginTop: 4 }}>
                       Environment: {sentryStatus.environment}
@@ -350,7 +367,7 @@ export default function DeveloperToolsScreen({ navigation }: Props) {
                   </View>
                 </View>
 
-                {!sentryStatus.isConfigured && sentryStatus.reason && (
+                {sentryStatus.reason && (
                   <View
                     style={{
                       backgroundColor: theme.card,
@@ -359,7 +376,7 @@ export default function DeveloperToolsScreen({ navigation }: Props) {
                       marginTop: 8,
                       marginBottom: 12,
                       borderLeftWidth: 4,
-                      borderLeftColor: theme.danger,
+                      borderLeftColor: sentryStatus.isConfigured ? theme.warning : theme.danger,
                     }}
                   >
                     <Text style={{ fontSize: 13, color: theme.text, lineHeight: 20 }}>


### PR DESCRIPTION
## Summary

- Fix scheduled notifications screen to show proper formatted date/time instead of raw seconds (e.g., "12/19/25, 9:20 PM (in 1 day)" instead of "In 86421.4442460537 seconds")
- Sort notifications chronologically by actual trigger time (soonest first)
- Remove unused "Other" filter option from scheduled notifications
- Fix misleading Sentry status display to properly distinguish between "Not Configured", "Configured but Disabled", and "Active" states

## Test plan

- [x] Open Developer Tools > View Scheduled Notifications
- [x] Verify notifications show formatted date/time with relative time (e.g., "12/19/25, 9:20 PM (in 1 day)")
- [x] Verify notifications are sorted by time (soonest first), not grouped by medication
- [x] Verify only 4 filter tabs: All, Remind, Follow, Check-in (no "Other")
- [ ] Open Developer Tools and verify Sentry status shows "⏸️ Configured (Disabled)" in development builds with appropriate message

🤖 Generated with [Claude Code](https://claude.com/claude-code)