### PR TITLE
fix: use dynamic imports for devTestHelpers to fix production builds

### DIFF
--- a/app/src/screens/settings/hooks/useNotificationTesting.ts
+++ b/app/src/screens/settings/hooks/useNotificationTesting.ts
@@ -5,7 +5,6 @@ import { dailyCheckinService } from '../../../services/notifications/dailyChecki
 import * as Notifications from 'expo-notifications';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../../navigation/types';
-import { confirmAndSetupNotificationTests, confirmAndSetupNotificationTestsBurst, confirmAndSetupGroupedNotificationTest } from '../../../utils/devTestHelpers';
 
 export function useNotificationTesting(
   navigation: NativeStackNavigationProp<RootStackParamList, 'DeveloperToolsScreen'>
@@ -282,6 +281,8 @@ If Critical Alerts didn't change, check:
         return;
       }
 
+      // Dynamic import to avoid bundling in production
+      const { confirmAndSetupNotificationTests } = await import('../../../utils/devTestHelpers');
       await confirmAndSetupNotificationTests();
     } catch (error) {
       logger.error('[DeveloperTools] Failed to setup notification tests:', error);
@@ -302,6 +303,8 @@ If Critical Alerts didn't change, check:
         return;
       }
 
+      // Dynamic import to avoid bundling in production
+      const { confirmAndSetupNotificationTestsBurst } = await import('../../../utils/devTestHelpers');
       await confirmAndSetupNotificationTestsBurst();
     } catch (error) {
       logger.error('[DeveloperTools] Failed to setup burst notification tests:', error);
@@ -322,6 +325,8 @@ If Critical Alerts didn't change, check:
         return;
       }
 
+      // Dynamic import to avoid bundling in production
+      const { confirmAndSetupGroupedNotificationTest } = await import('../../../utils/devTestHelpers');
       await confirmAndSetupGroupedNotificationTest();
     } catch (error) {
       logger.error('[DeveloperTools] Failed to setup grouped notification test:', error);


### PR DESCRIPTION
## Summary
- Fixed production build failure caused by static imports of `devTestHelpers`
- Metro config excludes `devTestHelpers` from production bundles, but static imports are resolved at bundle time before exclusions apply
- Changed to dynamic imports so the module is only loaded at runtime when dev tools functions are actually called

## Root Cause
The build failed with:
```
Unable to resolve module ../../../utils/devTestHelpers from useNotificationTesting.ts
```

This happened because `useNotificationTesting.ts` had a static import at the top of the file, which Metro tries to resolve before applying the production exclusion rules.

## Test plan
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Linting passes (`npm run test:lint`)
- [x] All 3272 tests pass (`npm run precommit`)
- [x] EAS preview build passes the Metro bundling step that previously failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)