### PR TITLE
fix: add payload fallback for notification dismissal when DB lookup fails (MIGRALOG-V)

### DIFF
--- a/app/src/services/__tests__/medicationNotifications.test.ts
+++ b/app/src/services/__tests__/medicationNotifications.test.ts
@@ -287,7 +287,13 @@ describe('Medication Notification Scheduling', () => {
         'presented-1',
         'med-123',
         'sched-1',
-        expect.any(Date)
+        expect.any(Date),
+        {
+          medicationId: 'med-123',
+          scheduleId: 'sched-1',
+          medicationIds: undefined,
+          scheduleIds: undefined,
+        }
       );
       expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('presented-1');
     });

--- a/app/src/services/notifications/NotificationDismissalService.ts
+++ b/app/src/services/notifications/NotificationDismissalService.ts
@@ -4,13 +4,23 @@ import { medicationRepository, medicationDoseRepository, medicationScheduleRepos
 import { scheduledNotificationRepository } from '../../database/scheduledNotificationRepository';
 
 /**
+ * Notification payload data for payload-based matching fallback
+ */
+export interface NotificationPayloadData {
+  medicationId?: string;
+  scheduleId?: string;
+  medicationIds?: string[];
+  scheduleIds?: string[];
+}
+
+/**
  * Result of a notification dismissal check
  */
 export interface DismissalResult {
   /** Whether the notification should be dismissed */
   shouldDismiss: boolean;
   /** Strategy that determined the dismissal decision */
-  strategy: 'database_id_lookup' | 'none';
+  strategy: 'database_id_lookup' | 'payload_match' | 'none';
   /** Confidence score for the dismissal decision (0-100) */
   confidence: number;
   /** Additional context about the decision */
@@ -39,13 +49,15 @@ export class NotificationDismissalService {
    * @param targetMedicationId - Medication ID that was logged/acted upon
    * @param targetScheduleId - Schedule ID that was logged/acted upon
    * @param loggedTime - Time when the dose was logged (unused, kept for API compatibility)
+   * @param notificationPayload - Optional payload data from the notification for fallback matching
    * @returns Promise<DismissalResult> - Decision and reasoning
    */
   async shouldDismissNotification(
     notificationId: string,
     targetMedicationId: string,
     targetScheduleId: string,
-    loggedTime: Date = new Date()
+    loggedTime: Date = new Date(),
+    notificationPayload?: NotificationPayloadData
   ): Promise<DismissalResult> {
     try {
       logger.debug('[NotificationDismissal] Evaluating notification for dismissal', {
@@ -53,10 +65,11 @@ export class NotificationDismissalService {
         targetMedicationId,
         targetScheduleId,
         loggedTime: loggedTime.toISOString(),
+        hasPayload: !!notificationPayload,
         component: 'NotificationDismissalService',
       });
 
-      // Database ID Lookup (ONLY strategy)
+      // Database ID Lookup (primary strategy)
       const result = await this.checkDatabaseIdLookup(
         notificationId,
         targetMedicationId,
@@ -86,11 +99,44 @@ export class NotificationDismissalService {
         return result;
       }
 
-      // Database lookup failed - log warning for diagnostics
-      logger.warn('[NotificationDismissal] Database lookup failed - notification will NOT be dismissed', {
+      // Database lookup failed - try payload fallback (MIGRALOG-V fix)
+      if (notificationPayload) {
+        const payloadResult = this.checkPayloadMatch(
+          notificationPayload,
+          targetMedicationId,
+          targetScheduleId
+        );
+
+        if (payloadResult.shouldDismiss) {
+          logger.info('[NotificationDismissal] Payload match succeeded - dismissing notification (MIGRALOG-V fallback)', {
+            notificationId,
+            strategy: payloadResult.strategy,
+            confidence: payloadResult.confidence,
+            context: payloadResult.context,
+            component: 'NotificationDismissalService',
+          });
+          return payloadResult;
+        }
+
+        // Payload did not match - log at debug level
+        logger.debug('[NotificationDismissal] Payload fallback did not match', {
+          notificationId,
+          targetMedicationId,
+          targetScheduleId,
+          payloadMedicationId: notificationPayload.medicationId,
+          payloadScheduleId: notificationPayload.scheduleId,
+          isGrouped: !!(notificationPayload.medicationIds?.length),
+          context: payloadResult.context,
+          component: 'NotificationDismissalService',
+        });
+      }
+
+      // All strategies failed - log warning for diagnostics
+      logger.warn('[NotificationDismissal] All strategies failed - notification will NOT be dismissed', {
         notificationId,
         targetMedicationId,
         targetScheduleId,
+        hasPayload: !!notificationPayload,
         confidence: result.confidence,
         context: result.context,
         component: 'NotificationDismissalService',
@@ -100,7 +146,7 @@ export class NotificationDismissalService {
         shouldDismiss: false,
         strategy: 'none',
         confidence: 0,
-        context: result.context || 'Database lookup failed',
+        context: result.context || 'Database lookup failed and no payload fallback available',
       };
     } catch (error) {
       logger.error('[NotificationDismissal] Error evaluating dismissal', error instanceof Error ? error : new Error(String(error)), {
@@ -197,6 +243,51 @@ export class NotificationDismissalService {
         context: 'Database lookup error',
       };
     }
+  }
+
+  /**
+   * Payload-based matching fallback (MIGRALOG-V fix)
+   *
+   * When database lookup fails (e.g., mapping cleaned up by reconciliation),
+   * use the notification's embedded payload to verify the match.
+   *
+   * SAFETY: Only applies to single medication notifications.
+   * Grouped notifications are NOT auto-dismissed via payload because
+   * we cannot verify all medications in the group were logged.
+   */
+  private checkPayloadMatch(
+    payload: NotificationPayloadData,
+    targetMedicationId: string,
+    targetScheduleId: string
+  ): DismissalResult {
+    // Safety check: Do NOT dismiss grouped notifications via payload
+    // We can't verify all medications in the group were logged without DB lookup
+    if (payload.medicationIds && payload.medicationIds.length > 0) {
+      return {
+        shouldDismiss: false,
+        strategy: 'payload_match',
+        confidence: 0,
+        context: 'Grouped notification - cannot verify all medications logged via payload only',
+      };
+    }
+
+    // Single medication notification - check exact match
+    if (payload.medicationId === targetMedicationId && payload.scheduleId === targetScheduleId) {
+      return {
+        shouldDismiss: true,
+        strategy: 'payload_match',
+        confidence: 95, // Slightly lower than DB lookup since mapping was missing
+        context: 'Payload match - DB mapping missing but notification payload matches target',
+      };
+    }
+
+    // No match
+    return {
+      shouldDismiss: false,
+      strategy: 'payload_match',
+      confidence: 0,
+      context: 'Payload does not match target medication/schedule',
+    };
   }
 
   /**

--- a/app/src/services/notifications/__tests__/NotificationDismissalService.test.ts
+++ b/app/src/services/notifications/__tests__/NotificationDismissalService.test.ts
@@ -495,4 +495,152 @@ describe('NotificationDismissalService', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('payload fallback strategy (MIGRALOG-V fix)', () => {
+    it('should dismiss single medication notification when payload matches and DB lookup fails', async () => {
+      // Arrange
+      const notificationId = 'test-notification-id';
+      const medicationId = 'test-medication-id';
+      const scheduleId = 'test-schedule-id';
+
+      // No database mapping found (simulates reconciliation cleanup)
+      mockScheduledNotificationRepository.getMappingsByNotificationId.mockResolvedValue([]);
+
+      // Act
+      const result = await service.shouldDismissNotification(
+        notificationId,
+        medicationId,
+        scheduleId,
+        new Date(),
+        {
+          medicationId,
+          scheduleId,
+        }
+      );
+
+      // Assert - Should dismiss via payload fallback
+      expect(result.shouldDismiss).toBe(true);
+      expect(result.strategy).toBe('payload_match');
+      expect(result.confidence).toBe(95);
+      expect(result.context).toContain('Payload match');
+    });
+
+    it('should NOT dismiss when payload does not match target medication', async () => {
+      // Arrange
+      const notificationId = 'test-notification-id';
+      const targetMedicationId = 'target-medication-id';
+      const targetScheduleId = 'target-schedule-id';
+
+      // No database mapping found
+      mockScheduledNotificationRepository.getMappingsByNotificationId.mockResolvedValue([]);
+
+      // Act
+      const result = await service.shouldDismissNotification(
+        notificationId,
+        targetMedicationId,
+        targetScheduleId,
+        new Date(),
+        {
+          medicationId: 'different-medication-id',
+          scheduleId: 'different-schedule-id',
+        }
+      );
+
+      // Assert - Should NOT dismiss because payload doesn't match
+      expect(result.shouldDismiss).toBe(false);
+      expect(result.strategy).toBe('none');
+      expect(result.confidence).toBe(0);
+    });
+
+    it('should NOT dismiss grouped notifications via payload (safety)', async () => {
+      // Arrange
+      const notificationId = 'test-notification-id';
+      const medicationId = 'test-medication-id';
+      const scheduleId = 'test-schedule-id';
+
+      // No database mapping found
+      mockScheduledNotificationRepository.getMappingsByNotificationId.mockResolvedValue([]);
+
+      // Act - Grouped notification payload
+      const result = await service.shouldDismissNotification(
+        notificationId,
+        medicationId,
+        scheduleId,
+        new Date(),
+        {
+          medicationIds: ['test-medication-id', 'other-medication-id'],
+          scheduleIds: ['test-schedule-id', 'other-schedule-id'],
+        }
+      );
+
+      // Assert - Should NOT dismiss grouped notification via payload
+      expect(result.shouldDismiss).toBe(false);
+      expect(result.strategy).toBe('none');
+      expect(result.confidence).toBe(0);
+      // Verify we didn't dismiss due to safety
+    });
+
+    it('should not use payload fallback when no payload provided', async () => {
+      // Arrange
+      const notificationId = 'test-notification-id';
+      const medicationId = 'test-medication-id';
+      const scheduleId = 'test-schedule-id';
+
+      // No database mapping found
+      mockScheduledNotificationRepository.getMappingsByNotificationId.mockResolvedValue([]);
+
+      // Act - No payload provided
+      const result = await service.shouldDismissNotification(
+        notificationId,
+        medicationId,
+        scheduleId,
+        new Date()
+        // No payload parameter
+      );
+
+      // Assert - Should NOT dismiss (no fallback available)
+      expect(result.shouldDismiss).toBe(false);
+      expect(result.strategy).toBe('none');
+      expect(result.confidence).toBe(0);
+    });
+
+    it('should prefer database lookup over payload match when both available', async () => {
+      // Arrange
+      const notificationId = 'test-notification-id';
+      const medicationId = 'test-medication-id';
+      const scheduleId = 'test-schedule-id';
+
+      // Database mapping exists
+      mockScheduledNotificationRepository.getMappingsByNotificationId.mockResolvedValue([
+        {
+          id: 'mapping-1',
+          medicationId,
+          scheduleId,
+          date: '2024-01-01',
+          notificationId,
+          notificationType: 'reminder',
+          isGrouped: false,
+          sourceType: 'medication',
+          createdAt: '2024-01-01T00:00:00Z',
+        },
+      ]);
+
+      // Act - Both DB mapping and payload provided
+      const result = await service.shouldDismissNotification(
+        notificationId,
+        medicationId,
+        scheduleId,
+        new Date(),
+        {
+          medicationId,
+          scheduleId,
+        }
+      );
+
+      // Assert - Should use database lookup (primary strategy)
+      expect(result.shouldDismiss).toBe(true);
+      expect(result.strategy).toBe('database_id_lookup');
+      expect(result.confidence).toBe(100);
+    });
+  });
 });

--- a/app/src/services/notifications/index.ts
+++ b/app/src/services/notifications/index.ts
@@ -42,3 +42,9 @@ export {
 export {
   handleDailyCheckinNotification,
 } from './dailyCheckinNotifications';
+
+export {
+  NotificationDismissalService,
+  notificationDismissalService,
+} from './NotificationDismissalService';
+export type { DismissalResult, NotificationPayloadData } from './NotificationDismissalService';

--- a/app/src/services/notifications/medicationNotificationCancellation.ts
+++ b/app/src/services/notifications/medicationNotificationCancellation.ts
@@ -148,11 +148,9 @@ export async function dismissMedicationNotification(medicationId: string, schedu
     let dismissedCount = 0;
     let dismissedInitial = 0;
     let dismissedFollowUps = 0;
-    let strategyCounts = {
+    let strategyCounts: Record<string, number> = {
       database_id_lookup: 0,
-      time_based: 0,
-      content_based: 0,
-      category_based: 0,
+      payload_match: 0,
       none: 0,
     };
 
@@ -193,11 +191,18 @@ export async function dismissMedicationNotification(medicationId: string, schedu
       });
 
       // Use the cross-reference service to determine if this notification should be dismissed
+      // Pass the notification payload for fallback matching (MIGRALOG-V fix)
       const dismissalResult = await notificationDismissalService.shouldDismissNotification(
         notificationId,
         medicationId,
         scheduleId,
-        new Date()
+        new Date(),
+        {
+          medicationId: data.medicationId,
+          scheduleId: data.scheduleId,
+          medicationIds: data.medicationIds,
+          scheduleIds: data.scheduleIds,
+        }
       );
 
       strategyCounts[dismissalResult.strategy]++;


### PR DESCRIPTION
## Summary

- Adds payload fallback strategy for notification dismissal when database lookup fails
- When a notification mapping is missing (e.g., cleaned up by reconciliation before user interaction), uses the notification's embedded payload data to verify the match
- Single medication notifications are dismissed with 95% confidence if payload matches
- Grouped notifications are NOT auto-dismissed via payload (safety - cannot verify all medications logged)

## Changes

1. **NotificationDismissalService.ts**:
   - Added `NotificationPayloadData` interface for typed payload handling
   - Added `'payload_match'` to `DismissalResult.strategy` type
   - Updated `shouldDismissNotification()` to accept optional `notificationPayload` parameter
   - Implemented `checkPayloadMatch()` private method for payload-based matching
   - Updated logging: `logger.info` for payload match success, `logger.debug` when no match

2. **medicationNotificationCancellation.ts**:
   - Updated `dismissMedicationNotification()` to pass notification payload data to the dismissal service
   - Updated strategy counts type to include `payload_match`

3. **notifications/index.ts**:
   - Added exports for `NotificationDismissalService`, `notificationDismissalService`, `DismissalResult`, and `NotificationPayloadData`

4. **Tests**:
   - Added test suite for "payload fallback strategy (MIGRALOG-V fix)" with 5 tests
   - Updated existing test expectation to include the new payload parameter

## Test plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Linting passes (`npm run test:lint:ci`)
- [x] All notification-related tests pass (19 tests)
- [ ] Manual testing: Log medication dose when notification is presented but DB mapping was cleaned up
- [ ] Verify single medication notifications are dismissed via payload fallback
- [ ] Verify grouped notifications are NOT dismissed when only one medication is logged

Generated with [Claude Code](https://claude.ai/code)