### PR TITLE
fix: remove iCloud entitlements from provisioning profile

### DIFF
--- a/mobile-apps/ios/MigraLog/App/MigraLog.entitlements
+++ b/mobile-apps/ios/MigraLog/App/MigraLog.entitlements
@@ -8,18 +8,6 @@
 	<true/>
 	<key>com.apple.developer.healthkit.access</key>
 	<array/>
-	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array>
-		<string>iCloud.com.eff3.migralog</string>
-	</array>
-	<key>com.apple.developer.icloud-services</key>
-	<array>
-		<string>CloudKit</string>
-	</array>
-	<key>com.apple.developer.ubiquity-container-identifiers</key>
-	<array>
-		<string>iCloud.com.eff3.migralog</string>
-	</array>
 	<key>com.apple.developer.weatherkit</key>
 	<true/>
 	<key>aps-environment</key>


### PR DESCRIPTION
## Summary
- Remove iCloud/CloudKit/ubiquity entitlements that aren't yet in the provisioning profile
- Fixes TestFlight deploy failure: profile doesn't match entitlements

## Test plan
- [ ] Merge and re-trigger "Deploy Swift to TestFlight" workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)