### PR TITLE
fix: use Xcode 26 / iOS 26 SDK for Swift builds

### DIFF
--- a/.github/workflows/ci-swift.yml
+++ b/.github/workflows/ci-swift.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   test:
     name: Build & Test
-    runs-on: macos-15
+    runs-on: macos-26
     defaults:
       run:
         working-directory: ./mobile-apps/ios
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
       - name: Resolve SPM dependencies
         run: xcodebuild -resolvePackageDependencies -scheme MigraLog

--- a/.github/workflows/deploy-swift-testflight.yml
+++ b/.github/workflows/deploy-swift-testflight.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    runs-on: macos-15
+    runs-on: macos-26
     defaults:
       run:
         working-directory: mobile-apps/ios
@@ -33,6 +33,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
       - name: Resolve Swift packages
         run: xcodebuild -resolvePackageDependencies -scheme $SCHEME -project $PROJECT


### PR DESCRIPTION
## Summary
- Update both Swift CI and deploy workflows to `macos-26` runner with Xcode 26.2
- Required by App Store Connect starting April 28, 2026 (ITMS-90725)

🤖 Generated with [Claude Code](https://claude.com/claude-code)