### PR TITLE
fix: add export compliance flag for encryption

### DIFF
--- a/mobile-apps/ios/MigraLog/App/Info.plist
+++ b/mobile-apps/ios/MigraLog/App/Info.plist
@@ -44,6 +44,8 @@
 	<string>MigraLog uses your location to help identify environmental triggers for your migraines.</string>
 	<key>NSUserNotificationsUsageDescription</key>
 	<string>MigraLog sends reminders for medications and daily check-ins.</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>


### PR DESCRIPTION
Adds ITSAppUsesNonExemptEncryption=NO to Info.plist so TestFlight builds don't require manual export compliance approval each time.