### PR TITLE
fix: update Swift CI simulator for macos-26

### DIFF
--- a/.github/workflows/ci-swift.yml
+++ b/.github/workflows/ci-swift.yml
@@ -37,14 +37,14 @@ jobs:
         run: >
           xcodebuild build
           -scheme MigraLog
-          -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
+          -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'
           -quiet
 
       - name: Run unit tests
         run: >
           xcodebuild test
           -scheme MigraLog
-          -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
+          -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'
           -only-testing:MigraLogTests
           -resultBundlePath TestResults.xcresult
 


### PR DESCRIPTION
iPhone 16 simulator doesn't exist on macos-26 runners. Switch to iPhone 17 Pro.