### PR TITLE
fix: skip invalid medication schedule times during backup restore

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/BackupService.swift
+++ b/mobile-apps/ios/MigraLog/Services/BackupService.swift
@@ -380,8 +380,15 @@ final class BackupService: BackupServiceProtocol {
                 }
 
                 // Restore medication schedules
+                let timePattern = try! NSRegularExpression(pattern: "^[0-2][0-9]:[0-5][0-9]$")
                 let scheduleRows = try Row.fetchAll(sourceDb, sql: "SELECT * FROM medication_schedules")
                 for row in scheduleRows {
+                    let timeValue = row["time"] as? String ?? ""
+                    let range = NSRange(timeValue.startIndex..., in: timeValue)
+                    guard timePattern.firstMatch(in: timeValue, range: range) != nil else {
+                        logger.warn("Skipping medication schedule \(row["id"] as? String ?? "?") with invalid time: \(timeValue)")
+                        continue
+                    }
                     try destDb.execute(
                         sql: """
                             INSERT INTO medication_schedules (id, medication_id, time, timezone,


### PR DESCRIPTION
## Summary
- Skip medication_schedules rows with time values that don't match `HH:MM` format during restore
- Logs a warning for skipped rows instead of failing the entire restore
- One row in real backup data had `time = "2025-09-09"` (a date instead of time)

## Context
Follow-up to PR #375. MIGRALOG-16 hit a second constraint: `CHECK(time GLOB '[0-2][0-9]:[0-5][0-9]')` on medication_schedules.

## Test plan
- [x] Local build passes
- [ ] Deploy and verify restore completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)