### PR TITLE
fix: three Swift UI bugs - calendar colors, med sorting, sparkline

### DIFF
--- a/mobile-apps/ios/MigraLog/ViewModels/AnalyticsViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/AnalyticsViewModel.swift
@@ -201,11 +201,43 @@ final class AnalyticsViewModel {
         let components = calendar.dateComponents([.year, .month], from: month)
         guard let year = components.year, let monthNum = components.month else { return }
         do {
+            // Load manual daily statuses
             let statuses = try dailyStatusRepository.getMonthStats(year: year, month: monthNum)
             var statusMap: [String: DayStatus] = [:]
             for status in statuses {
                 statusMap[status.date] = status.status
             }
+
+            // Load episodes that may overlap this month and mark those days as red
+            guard let monthStart = calendar.date(from: DateComponents(year: year, month: monthNum, day: 1)),
+                  let monthEnd = calendar.date(byAdding: .month, value: 1, to: monthStart) else {
+                calendarStatuses = statusMap
+                return
+            }
+            let monthStartMs = TimestampHelper.fromDate(monthStart)
+            let monthEndMs = TimestampHelper.fromDate(monthEnd)
+
+            // Fetch episodes that could overlap: started before month end AND ended after month start (or still active)
+            let monthEpisodes = try episodeRepository.getEpisodesByDateRange(start: monthStartMs, end: monthEndMs)
+
+            // For each episode, mark every overlapping day as red
+            for episode in monthEpisodes {
+                let epStart = TimestampHelper.toDate(episode.startTime)
+                let epEnd = episode.endTime.map { TimestampHelper.toDate($0) } ?? Date()
+
+                // Clamp to month boundaries
+                let rangeStart = max(calendar.startOfDay(for: epStart), monthStart)
+                let rangeEnd = min(epEnd, monthEnd)
+
+                var day = calendar.startOfDay(for: rangeStart)
+                while day < rangeEnd {
+                    let dateString = TimestampHelper.dateString(from: day)
+                    statusMap[dateString] = .red
+                    guard let nextDay = calendar.date(byAdding: .day, value: 1, to: day) else { break }
+                    day = nextDay
+                }
+            }
+
             calendarStatuses = statusMap
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "AnalyticsViewModel", "action": "loadCalendarData"])

--- a/mobile-apps/ios/MigraLog/ViewModels/MedicationsListViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/MedicationsListViewModel.swift
@@ -37,8 +37,24 @@ final class MedicationsListViewModel {
         do {
             let active = try await medicationRepository.getActiveMedications()
             preventativeMedications = active.filter { $0.type == .preventative }
-            rescueMedications = active.filter { $0.type == .rescue }
             otherMedications = active.filter { $0.type == .other }
+
+            // Sort rescue medications by usage count (most used first),
+            // with alphabetical name as tiebreaker
+            let rescue = active.filter { $0.type == .rescue }
+            let usageCounts = try medicationRepository.getMedicationUsageCounts(
+                start: 0,
+                end: Int64.max
+            )
+            rescueMedications = rescue.sorted { a, b in
+                let usageA = usageCounts[a.id] ?? 0
+                let usageB = usageCounts[b.id] ?? 0
+                if usageA != usageB {
+                    return usageA > usageB
+                }
+                return a.name.localizedCompare(b.name) == .orderedAscending
+            }
+
             isLoading = false
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "MedicationsListViewModel"])

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -199,7 +199,11 @@ struct EpisodeDetailScreen: View {
 
             // Sparkline
             if !details.intensityReadings.isEmpty {
-                IntensitySparklineView(readings: details.intensityReadings)
+                IntensitySparklineView(
+                    readings: details.intensityReadings,
+                    episodeStartTime: details.episode.startTime,
+                    episodeEndTime: details.episode.endTime
+                )
                     .frame(height: 80)
             }
 
@@ -485,41 +489,52 @@ struct FlowLayout: Layout {
 
 struct IntensitySparklineView: View {
     let readings: [IntensityReading]
+    var episodeStartTime: Int64?
+    var episodeEndTime: Int64?
 
     var body: some View {
         GeometryReader { geo in
-            if readings.count > 1 {
-                let sorted = readings.sorted { $0.timestamp < $1.timestamp }
-                let minT = sorted.first!.timestamp
-                let maxT = sorted.last!.timestamp
-                let range = max(Double(maxT - minT), 1)
+            let sorted = readings.sorted { $0.timestamp < $1.timestamp }
 
+            if !sorted.isEmpty {
+                let startT = episodeStartTime ?? sorted.first!.timestamp
+                let endT = episodeEndTime ?? Int64(Date().timeIntervalSince1970 * 1000)
+                let range = max(Double(endT - startT), 1)
+
+                // Sample-and-hold path (step function)
                 Path { path in
                     for (index, reading) in sorted.enumerated() {
-                        let x = geo.size.width * CGFloat(Double(reading.timestamp - minT) / range)
+                        let x = geo.size.width * CGFloat(Double(reading.timestamp - startT) / range)
                         let y = geo.size.height * (1 - CGFloat(reading.intensity / 10.0))
+
                         if index == 0 {
                             path.move(to: CGPoint(x: x, y: y))
                         } else {
+                            // Horizontal line to the new x at the previous y (step)
+                            let prevY = geo.size.height * (1 - CGFloat(sorted[index - 1].intensity / 10.0))
+                            path.addLine(to: CGPoint(x: x, y: prevY))
+                            // Vertical line to the new y
                             path.addLine(to: CGPoint(x: x, y: y))
                         }
+                    }
+
+                    // Hold the last value to the end of the episode
+                    if let last = sorted.last {
+                        let lastY = geo.size.height * (1 - CGFloat(last.intensity / 10.0))
+                        path.addLine(to: CGPoint(x: geo.size.width, y: lastY))
                     }
                 }
                 .stroke(Color.red, lineWidth: 2)
 
+                // Data point markers
                 ForEach(sorted) { reading in
-                    let x = geo.size.width * CGFloat(Double(reading.timestamp - minT) / range)
+                    let x = geo.size.width * CGFloat(Double(reading.timestamp - startT) / range)
                     let y = geo.size.height * (1 - CGFloat(reading.intensity / 10.0))
                     Circle()
                         .fill(PainScale.color(for: reading.intensity))
                         .frame(width: 8, height: 8)
                         .position(x: x, y: y)
                 }
-            } else if let reading = readings.first {
-                Circle()
-                    .fill(PainScale.color(for: reading.intensity))
-                    .frame(width: 12, height: 12)
-                    .position(x: geo.size.width / 2, y: geo.size.height / 2)
             }
         }
     }

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodesScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodesScreen.swift
@@ -53,7 +53,11 @@ struct EpisodeCardView: View {
             }
 
             if !readings.isEmpty {
-                IntensitySparklineView(readings: readings)
+                IntensitySparklineView(
+                    readings: readings,
+                    episodeStartTime: episode.startTime,
+                    episodeEndTime: episode.endTime
+                )
                     .frame(height: 30)
             }
 


### PR DESCRIPTION
## Summary
- **Bug #1**: Trends monthly calendar now colors days red when migraine episodes overlap (overrides declared daily status)
- **Bug #2**: Rescue medications sorted by usage count (most used first) in log medication screen
- **Bug #3**: Intensity sparkline uses sample-and-hold rendering with proper episode time range mapping

## Test plan
- [x] 653 unit tests pass
- [x] 41 UI tests pass
- [ ] Visual verification on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)