### PR TITLE
fix: associate rescue meds with active episode + UI test IDs

### DIFF
--- a/mobile-apps/ios/MigraLog/Repositories/EpisodeRepository.swift
+++ b/mobile-apps/ios/MigraLog/Repositories/EpisodeRepository.swift
@@ -80,6 +80,23 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
         }
     }
 
+    func getEpisodeByTimestamp(_ timestamp: Int64) throws -> Episode? {
+        try dbManager.dbQueue.read { db in
+            let row = try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT * FROM episodes
+                    WHERE start_time <= ?
+                    AND (end_time IS NULL OR end_time >= ?)
+                    ORDER BY start_time DESC
+                    LIMIT 1
+                    """,
+                arguments: [timestamp, timestamp]
+            )
+            return row.map { Self.episodeFromRow($0) }
+        }
+    }
+
     func updateEpisode(_ episode: Episode) throws -> Episode {
         let now = TimestampHelper.now
         var updated = episode

--- a/mobile-apps/ios/MigraLog/Repositories/Protocols.swift
+++ b/mobile-apps/ios/MigraLog/Repositories/Protocols.swift
@@ -9,6 +9,7 @@ protocol EpisodeRepositoryProtocol: Sendable {
     func getAllEpisodes() throws -> [Episode]
     func getEpisodesByDateRange(start: Int64, end: Int64) throws -> [Episode]
     func getCurrentEpisode() throws -> Episode?
+    func getEpisodeByTimestamp(_ timestamp: Int64) throws -> Episode?
     func updateEpisode(_ episode: Episode) throws -> Episode
     func updateEpisodeTimestamps(episodeId: String, offset: Int64) throws
     func deleteEpisode(_ id: String) throws

--- a/mobile-apps/ios/MigraLog/Views/DailyStatus/DailyStatusPromptScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/DailyStatus/DailyStatusPromptScreen.swift
@@ -54,6 +54,7 @@ struct DailyStatusPromptScreen: View {
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button("Done") { dismiss() }
+                    .accessibilityIdentifier("skip-button")
             }
         }
         .task { await loadDayData() }
@@ -228,6 +229,7 @@ struct DailyStatusPromptScreen: View {
                 Button("Save") {
                     Task { await save() }
                 }
+                .accessibilityIdentifier("save-status-button")
                 .buttonStyle(.borderedProminent)
                 .disabled(selectedStatus == nil || isSaving)
                 .frame(maxWidth: .infinity)

--- a/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
@@ -62,8 +62,10 @@ struct LogMedicationScreen: View {
     }
 
     private func quickLog(_ med: Medication) async {
-        let repo = MedicationRepository(dbManager: DatabaseManager.shared)
+        let medicationRepo = MedicationRepository(dbManager: DatabaseManager.shared)
+        let episodeRepo = EpisodeRepository(dbManager: DatabaseManager.shared)
         let now = TimestampHelper.now
+        let activeEpisode = try? episodeRepo.getEpisodeByTimestamp(now)
         let dose = MedicationDose(
             id: UUID().uuidString,
             medicationId: med.id,
@@ -72,7 +74,7 @@ struct LogMedicationScreen: View {
             dosageAmount: med.dosageAmount,
             dosageUnit: med.dosageUnit,
             status: .taken,
-            episodeId: nil,
+            episodeId: activeEpisode?.id,
             effectivenessRating: nil,
             timeToRelief: nil,
             sideEffects: [],
@@ -80,7 +82,7 @@ struct LogMedicationScreen: View {
             createdAt: now,
             updatedAt: now
         )
-        try? await repo.createDose(dose)
+        try? await medicationRepo.createDose(dose)
         dismiss()
     }
 }
@@ -170,15 +172,18 @@ struct LogMedicationDetailSheet: View {
             ToolbarItem(placement: .confirmationAction) {
                 Button("Save") {
                     let now = TimestampHelper.now
+                    let doseTimestamp = TimestampHelper.fromDate(timestamp)
+                    let episodeRepo = EpisodeRepository(dbManager: DatabaseManager.shared)
+                    let activeEpisode = try? episodeRepo.getEpisodeByTimestamp(doseTimestamp)
                     let dose = MedicationDose(
                         id: UUID().uuidString,
                         medicationId: medication.id,
-                        timestamp: TimestampHelper.fromDate(timestamp),
+                        timestamp: doseTimestamp,
                         quantity: quantity,
                         dosageAmount: medication.dosageAmount,
                         dosageUnit: medication.dosageUnit,
                         status: .taken,
-                        episodeId: nil,
+                        episodeId: activeEpisode?.id,
                         effectivenessRating: nil,
                         timeToRelief: nil,
                         sideEffects: [],


### PR DESCRIPTION
## Summary
- Rescue meds logged from homescreen now auto-associate with active episode via `getEpisodeByTimestamp()`
- Add missing `save-status-button` and `skip-button` accessibility identifiers to DailyStatusPromptScreen
- Add `getEpisodeByTimestamp()` to EpisodeRepository protocol and implementation

## Test plan
- [x] Local build passes
- [ ] Full test suite via /release

🤖 Generated with [Claude Code](https://claude.com/claude-code)