### PR TITLE
fix: add missing protocol method to test mocks

### DIFF
--- a/mobile-apps/ios/MigraLogTests/MockRepositories.swift
+++ b/mobile-apps/ios/MigraLogTests/MockRepositories.swift
@@ -69,6 +69,13 @@ final class MockEpisodeRepository: EpisodeRepositoryProtocol, @unchecked Sendabl
         return episodes.first { $0.isActive }
     }
 
+    func getEpisodeByTimestamp(_ timestamp: Int64) throws -> Episode? {
+        try throwIfNeeded()
+        return episodes.first { ep in
+            ep.startTime <= timestamp && (ep.endTime ?? Int64.max) >= timestamp
+        }
+    }
+
     func updateEpisode(_ episode: Episode) throws -> Episode {
         try throwIfNeeded()
         updateEpisodeCalled = true

--- a/mobile-apps/ios/MigraLogTests/ViewModels/NewEpisodeViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/NewEpisodeViewModelTests.swift
@@ -287,6 +287,7 @@ private final class ReadingFailRepository: EpisodeRepositoryProtocol, @unchecked
     func getAllEpisodes() throws -> [Episode] { [] }
     func getEpisodesByDateRange(start: Int64, end: Int64) throws -> [Episode] { [] }
     func getCurrentEpisode() throws -> Episode? { nil }
+    func getEpisodeByTimestamp(_ timestamp: Int64) throws -> Episode? { nil }
     func updateEpisode(_ episode: Episode) throws -> Episode { episode }
     func updateEpisodeTimestamps(episodeId: String, offset: Int64) throws {}
     func deleteEpisode(_ id: String) throws {}


### PR DESCRIPTION
Adds getEpisodeByTimestamp stub to MockEpisodeRepository and ReadingFailRepository to match updated protocol from #381.