### PR TITLE
fix: pre-populate LogUpdateScreen with current episode state

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/Episodes/LogUpdateScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/LogUpdateScreen.swift
@@ -7,9 +7,12 @@ struct LogUpdateScreen: View {
 
     @State private var intensity: Double = 5.0
     @State private var selectedLocations: Set<PainLocation> = []
+    @State private var initialLocations: Set<PainLocation> = []
     @State private var selectedSymptoms: Set<Symptom> = []
+    @State private var initialSymptoms: Set<Symptom> = []
     @State private var noteText: String = ""
     @State private var isSaving = false
+    @State private var didLoadState = false
 
     var body: some View {
         Form {
@@ -56,6 +59,42 @@ struct LogUpdateScreen: View {
                 .disabled(isSaving)
             }
         }
+        .onAppear { prefillFromCurrentState() }
+    }
+
+    private func prefillFromCurrentState() {
+        guard !didLoadState else { return }
+        didLoadState = true
+
+        // Pre-fill intensity from latest reading
+        if let latestReading = viewModel.intensityReadings.last {
+            intensity = latestReading.intensity
+        }
+
+        // Pre-fill pain locations from most recent log, or episode's initial locations
+        if let latestLocationLog = viewModel.painLocationLogs.last {
+            let locations = Set(latestLocationLog.painLocations)
+            selectedLocations = locations
+            initialLocations = locations
+        } else if let episode = viewModel.episode {
+            let locations = Set(episode.locations)
+            selectedLocations = locations
+            initialLocations = locations
+        }
+
+        // Pre-fill symptoms from active (unresolved) symptom logs, or episode's initial symptoms
+        let activeSymptoms = viewModel.symptomLogs
+            .filter { $0.resolutionTime == nil }
+            .map { $0.symptom }
+        if !activeSymptoms.isEmpty {
+            let symptoms = Set(activeSymptoms)
+            selectedSymptoms = symptoms
+            initialSymptoms = symptoms
+        } else if let episode = viewModel.episode {
+            let symptoms = Set(episode.symptoms)
+            selectedSymptoms = symptoms
+            initialSymptoms = symptoms
+        }
     }
 
     private func save() async {
@@ -69,16 +108,17 @@ struct LogUpdateScreen: View {
             timestamp: now
         )
 
-        // Add symptom logs
-        for symptom in selectedSymptoms {
+        // Add symptom logs only for newly added symptoms
+        let newSymptoms = selectedSymptoms.subtracting(initialSymptoms)
+        for symptom in newSymptoms {
             await viewModel.addSymptomLog(
                 symptom: symptom,
                 timestamp: now
             )
         }
 
-        // Add pain location log
-        if !selectedLocations.isEmpty {
+        // Add pain location log if locations changed
+        if selectedLocations != initialLocations {
             await viewModel.addPainLocationLog(
                 locations: Array(selectedLocations),
                 timestamp: now


### PR DESCRIPTION
## Summary
When logging an update to an active episode, the screen now pre-fills:
- Pain intensity from the latest intensity reading
- Pain locations from the most recent pain location log (or episode initial locations)
- Active (unresolved) symptoms from symptom logs (or episode initial symptoms)

Only saves changes: new symptoms are logged, pain locations only saved if different from initial state.

## Test plan
- [x] Local build passes
- [ ] Full test via /release

🤖 Generated with [Claude Code](https://claude.com/claude-code)