### PR TITLE
feat: long-press context menus for episode timeline editing

### DIFF
--- a/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BB11CC22DD33EE44FF550001 /* EditIntensityReadingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB11CC22DD33EE44FF550002 /* EditIntensityReadingScreen.swift */; };
+		BB11CC22DD33EE44FF550003 /* EditSymptomLogScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB11CC22DD33EE44FF550004 /* EditSymptomLogScreen.swift */; };
+		BB11CC22DD33EE44FF550005 /* EditPainLocationLogScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB11CC22DD33EE44FF550006 /* EditPainLocationLogScreen.swift */; };
+		BB11CC22DD33EE44FF550007 /* EditEpisodeNoteScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB11CC22DD33EE44FF550008 /* EditEpisodeNoteScreen.swift */; };
 		AA00BB11CC22DD33EE44FF01 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA00BB11CC22DD33EE44FF02 /* Assets.xcassets */; };
 		01A2B3C4D5E6F70800000001 /* EpisodesListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A2B3C4D5E6F70800000002 /* EpisodesListViewModelTests.swift */; };
 		01A2B3C4D5E6F70800000003 /* MedicationsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A2B3C4D5E6F70800000004 /* MedicationsListViewModelTests.swift */; };
@@ -155,6 +159,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BB11CC22DD33EE44FF550002 /* EditIntensityReadingScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditIntensityReadingScreen.swift; sourceTree = "<group>"; };
+		BB11CC22DD33EE44FF550004 /* EditSymptomLogScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSymptomLogScreen.swift; sourceTree = "<group>"; };
+		BB11CC22DD33EE44FF550006 /* EditPainLocationLogScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPainLocationLogScreen.swift; sourceTree = "<group>"; };
+		BB11CC22DD33EE44FF550008 /* EditEpisodeNoteScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditEpisodeNoteScreen.swift; sourceTree = "<group>"; };
 		AA00BB11CC22DD33EE44FF02 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		01A2B3C4D5E6F70800000002 /* EpisodesListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodesListViewModelTests.swift; sourceTree = "<group>"; };
 		01A2B3C4D5E6F70800000004 /* MedicationsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationsListViewModelTests.swift; sourceTree = "<group>"; };
@@ -356,6 +364,10 @@
 			isa = PBXGroup;
 			children = (
 				ABEC0599D7949FE34645717A /* EditEpisodeScreen.swift */,
+				BB11CC22DD33EE44FF550008 /* EditEpisodeNoteScreen.swift */,
+				BB11CC22DD33EE44FF550002 /* EditIntensityReadingScreen.swift */,
+				BB11CC22DD33EE44FF550006 /* EditPainLocationLogScreen.swift */,
+				BB11CC22DD33EE44FF550004 /* EditSymptomLogScreen.swift */,
 				113CA1FF77A2157F0AA0DD18 /* EpisodeDetailScreen.swift */,
 				1EE092383622BB8F899CBA49 /* EpisodesScreen.swift */,
 				73F297C313657784597A4A5B /* LogUpdateScreen.swift */,
@@ -866,6 +878,10 @@
 				C92407F07354225DFC3C408F /* EditEpisodeScreen.swift in Sources */,
 				EA05D454D080FAB6E085E9C1 /* EditMedicationScreen.swift in Sources */,
 				65A81759C47FC910A264AD25 /* Enums.swift in Sources */,
+				BB11CC22DD33EE44FF550001 /* EditIntensityReadingScreen.swift in Sources */,
+				BB11CC22DD33EE44FF550003 /* EditSymptomLogScreen.swift in Sources */,
+				BB11CC22DD33EE44FF550005 /* EditPainLocationLogScreen.swift in Sources */,
+				BB11CC22DD33EE44FF550007 /* EditEpisodeNoteScreen.swift in Sources */,
 				A7D5C82C319DA925E7BA5193 /* EpisodeDetailScreen.swift in Sources */,
 				81D0543475BA0D1E9C380EB7 /* EpisodeDetailViewModel.swift in Sources */,
 				CE89028DFCD76F0258993640 /* EpisodeRepository.swift in Sources */,

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EditEpisodeNoteScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EditEpisodeNoteScreen.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct EditEpisodeNoteScreen: View {
+    let note: EpisodeNote
+    @Bindable var viewModel: EpisodeDetailViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var noteText: String
+    @State private var selectedDate: Date
+    @State private var isSaving = false
+
+    init(note: EpisodeNote, viewModel: EpisodeDetailViewModel) {
+        self.note = note
+        self.viewModel = viewModel
+        _noteText = State(initialValue: note.note)
+        _selectedDate = State(initialValue: Date(timeIntervalSince1970: Double(note.timestamp) / 1000.0))
+    }
+
+    var body: some View {
+        Form {
+            Section("Note") {
+                TextEditor(text: $noteText)
+                    .frame(minHeight: 100)
+                    .accessibilityIdentifier("note-text-input")
+            }
+
+            Section("Time") {
+                DatePicker("Time", selection: $selectedDate)
+                    .accessibilityIdentifier("note-time-picker")
+            }
+        }
+        .navigationTitle("Edit Note")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") {
+                    Task { await save() }
+                }
+                .disabled(noteText.isEmpty || isSaving)
+            }
+        }
+    }
+
+    private func save() async {
+        isSaving = true
+        defer { isSaving = false }
+
+        var updated = note
+        updated.note = noteText
+        updated.timestamp = TimestampHelper.fromDate(selectedDate)
+        await viewModel.updateNote(updated)
+        dismiss()
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EditIntensityReadingScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EditIntensityReadingScreen.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct EditIntensityReadingScreen: View {
+    let reading: IntensityReading
+    @Bindable var viewModel: EpisodeDetailViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var intensity: Double
+    @State private var selectedDate: Date
+    @State private var isSaving = false
+
+    init(reading: IntensityReading, viewModel: EpisodeDetailViewModel) {
+        self.reading = reading
+        self.viewModel = viewModel
+        _intensity = State(initialValue: reading.intensity)
+        _selectedDate = State(initialValue: Date(timeIntervalSince1970: Double(reading.timestamp) / 1000.0))
+    }
+
+    var body: some View {
+        Form {
+            Section("Pain Intensity") {
+                PainIntensitySlider(intensity: $intensity)
+            }
+
+            Section("Time") {
+                DatePicker("Time", selection: $selectedDate)
+            }
+        }
+        .navigationTitle("Edit Reading")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") {
+                    Task { await save() }
+                }
+                .disabled(isSaving)
+            }
+        }
+    }
+
+    private func save() async {
+        isSaving = true
+        defer { isSaving = false }
+
+        var updated = reading
+        updated.intensity = intensity
+        updated.timestamp = TimestampHelper.fromDate(selectedDate)
+        updated.updatedAt = TimestampHelper.now
+
+        await viewModel.updateReading(updated)
+        dismiss()
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EditPainLocationLogScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EditPainLocationLogScreen.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct EditPainLocationLogScreen: View {
+    let log: PainLocationLog
+    @Bindable var viewModel: EpisodeDetailViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedLocations: Set<PainLocation>
+    @State private var selectedDate: Date
+    @State private var isSaving = false
+
+    init(log: PainLocationLog, viewModel: EpisodeDetailViewModel) {
+        self.log = log
+        self.viewModel = viewModel
+        _selectedLocations = State(initialValue: Set(log.painLocations))
+        _selectedDate = State(initialValue: Date(timeIntervalSince1970: Double(log.timestamp) / 1000.0))
+    }
+
+    var body: some View {
+        Form {
+            Section("Pain Locations") {
+                PainLocationGrid(selectedLocations: $selectedLocations)
+            }
+
+            Section("Time") {
+                DatePicker("Time", selection: $selectedDate)
+            }
+        }
+        .navigationTitle("Edit Pain Location")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") {
+                    Task { await save() }
+                }
+                .disabled(isSaving)
+            }
+        }
+    }
+
+    private func save() async {
+        isSaving = true
+        defer { isSaving = false }
+
+        var updated = log
+        updated.painLocations = Array(selectedLocations)
+        updated.timestamp = TimestampHelper.fromDate(selectedDate)
+        updated.updatedAt = TimestampHelper.now
+
+        await viewModel.updatePainLocationLog(updated)
+        dismiss()
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EditSymptomLogScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EditSymptomLogScreen.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+struct EditSymptomLogScreen: View {
+    let log: SymptomLog
+    @Bindable var viewModel: EpisodeDetailViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var onsetDate: Date
+    @State private var hasResolution: Bool
+    @State private var resolutionDate: Date
+    @State private var hasSeverity: Bool
+    @State private var severity: Double
+    @State private var isSaving = false
+    @State private var showValidationAlert = false
+
+    init(log: SymptomLog, viewModel: EpisodeDetailViewModel) {
+        self.log = log
+        self.viewModel = viewModel
+        _onsetDate = State(initialValue: Date(timeIntervalSince1970: Double(log.onsetTime) / 1000.0))
+        _hasResolution = State(initialValue: log.resolutionTime != nil)
+        _resolutionDate = State(initialValue: log.resolutionTime.map { Date(timeIntervalSince1970: Double($0) / 1000.0) } ?? Date())
+        _hasSeverity = State(initialValue: log.severity != nil)
+        _severity = State(initialValue: log.severity ?? 5.0)
+    }
+
+    var body: some View {
+        Form {
+            Section("Symptom") {
+                Text(log.symptom.displayName)
+            }
+
+            Section("Onset Time") {
+                DatePicker("Onset", selection: $onsetDate)
+                    .accessibilityIdentifier("symptom-onset-picker")
+            }
+
+            Section("Resolution Time") {
+                Toggle("Has resolution", isOn: $hasResolution)
+                    .accessibilityIdentifier("symptom-resolution-toggle")
+                if hasResolution {
+                    DatePicker("Resolution", selection: $resolutionDate)
+                        .accessibilityIdentifier("symptom-resolution-picker")
+                }
+            }
+
+            Section("Severity") {
+                Toggle("Rate severity", isOn: $hasSeverity)
+                    .accessibilityIdentifier("symptom-severity-toggle")
+                if hasSeverity {
+                    VStack {
+                        Text(String(format: "%.0f", severity))
+                            .font(.title3.weight(.bold))
+                        Slider(value: $severity, in: 0...10, step: 1)
+                            .accessibilityIdentifier("symptom-severity-slider")
+                    }
+                }
+            }
+        }
+        .navigationTitle("Edit Symptom")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") {
+                    Task { await save() }
+                }
+                .disabled(isSaving)
+            }
+        }
+        .alert("Invalid Times", isPresented: $showValidationAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Resolution time must be after onset time.")
+        }
+    }
+
+    private func save() async {
+        if hasResolution && resolutionDate <= onsetDate {
+            showValidationAlert = true
+            return
+        }
+
+        isSaving = true
+        defer { isSaving = false }
+
+        var updated = log
+        updated.onsetTime = TimestampHelper.fromDate(onsetDate)
+        updated.resolutionTime = hasResolution ? TimestampHelper.fromDate(resolutionDate) : nil
+        updated.severity = hasSeverity ? severity : nil
+        await viewModel.updateSymptomLog(updated)
+        dismiss()
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -8,6 +8,15 @@ struct EpisodeDetailScreen: View {
     @State private var showLogUpdate = false
     @State private var customEndTime = Date()
 
+    // Timeline editing state
+    @State private var editingReading: IntensityReading?
+    @State private var editingSymptomLog: SymptomLog?
+    @State private var editingPainLocationLog: PainLocationLog?
+    @State private var editingNote: EpisodeNote?
+    @State private var showDeleteConfirmation = false
+    @State private var pendingDeleteAction: (() async -> Void)?
+    @State private var pendingDeleteLabel: String = ""
+
     var body: some View {
         Group {
             if let details = viewModel.details {
@@ -76,6 +85,36 @@ struct EpisodeDetailScreen: View {
                     onCancel: { showEndTimePicker = false }
                 )
             }
+        }
+        .sheet(item: $editingReading) { reading in
+            NavigationStack {
+                EditIntensityReadingScreen(reading: reading, viewModel: viewModel)
+            }
+        }
+        .sheet(item: $editingSymptomLog) { log in
+            NavigationStack {
+                EditSymptomLogScreen(log: log, viewModel: viewModel)
+            }
+        }
+        .sheet(item: $editingPainLocationLog) { log in
+            NavigationStack {
+                EditPainLocationLogScreen(log: log, viewModel: viewModel)
+            }
+        }
+        .sheet(item: $editingNote) { note in
+            NavigationStack {
+                EditEpisodeNoteScreen(note: note, viewModel: viewModel)
+            }
+        }
+        .alert("Delete \(pendingDeleteLabel)?", isPresented: $showDeleteConfirmation) {
+            Button("Delete", role: .destructive) {
+                if let action = pendingDeleteAction {
+                    Task { await action() }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This cannot be undone.")
         }
         .task {
             await viewModel.loadEpisode(episodeId)
@@ -251,6 +290,7 @@ struct EpisodeDetailScreen: View {
                     }
                 }
                 .padding(.vertical, 6)
+                .contextMenu { timelineContextMenu(for: event) }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -466,6 +506,82 @@ struct EpisodeDetailScreen: View {
 
         case .episodeEnded:
             EmptyView()
+        }
+    }
+
+    // MARK: - Context Menus
+
+    @ViewBuilder
+    private func timelineContextMenu(for event: TimelineEvent) -> some View {
+        switch event.kind {
+        case .intensity(let reading):
+            Button { editingReading = reading } label: {
+                Label("Edit Intensity", systemImage: "pencil")
+            }
+            Button(role: .destructive) {
+                pendingDeleteLabel = "intensity reading"
+                pendingDeleteAction = { await viewModel.deleteReading(reading.id) }
+                showDeleteConfirmation = true
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+
+        case .symptomOnset(let log), .symptomResolved(let log):
+            Button { editingSymptomLog = log } label: {
+                Label("Edit Symptom", systemImage: "pencil")
+            }
+            Button(role: .destructive) {
+                pendingDeleteLabel = "symptom log"
+                pendingDeleteAction = { await viewModel.deleteSymptomLog(log.id) }
+                showDeleteConfirmation = true
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+
+        case .painLocation(let log, let delta):
+            if !delta.isInitial {
+                Button { editingPainLocationLog = log } label: {
+                    Label("Edit Pain Locations", systemImage: "pencil")
+                }
+                Button(role: .destructive) {
+                    pendingDeleteLabel = "pain location log"
+                    pendingDeleteAction = { await viewModel.deletePainLocationLog(log.id) }
+                    showDeleteConfirmation = true
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+
+        case .note(let note):
+            Button { editingNote = note } label: {
+                Label("Edit Note", systemImage: "pencil")
+            }
+            Button(role: .destructive) {
+                pendingDeleteLabel = "note"
+                pendingDeleteAction = { await viewModel.deleteNote(note.id) }
+                showDeleteConfirmation = true
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+
+        case .medication:
+            // Dose editing handled via medication detail screen
+            EmptyView()
+
+        case .episodeEnded:
+            Button {
+                if let endTime = viewModel.episode?.endTime {
+                    customEndTime = Date(timeIntervalSince1970: Double(endTime) / 1000.0)
+                }
+                showEndTimePicker = true
+            } label: {
+                Label("Edit End Time", systemImage: "clock")
+            }
+            Button {
+                Task { await viewModel.reopenEpisode() }
+            } label: {
+                Label("Reopen Episode", systemImage: "arrow.uturn.backward")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Long-press any timeline element to edit or delete it
- 4 new edit screens: EditIntensityReadingScreen, EditSymptomLogScreen, EditPainLocationLogScreen, EditEpisodeNoteScreen
- Context menus for: intensity readings, symptom logs, pain location logs, notes, episode end marker
- Delete confirmation alert for all destructive actions
- Episode end marker supports "Edit End Time" and "Reopen Episode"

## Test plan
- [x] Local build passes
- [ ] Full test suite via /release

🤖 Generated with [Claude Code](https://claude.com/claude-code)