### PR TITLE
fix: rescue med timeline + code review fixes

### DIFF
--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -24,9 +24,11 @@ final class DatabaseManager: Sendable {
             let dbURL = appSupport.appendingPathComponent("migralog.db")
             var config = Configuration()
             config.foreignKeysEnabled = true
+            #if DEBUG
             config.prepareDatabase { db in
                 db.trace { print("SQL: \($0)") }
             }
+            #endif
             dbQueue = try DatabaseQueue(path: dbURL.path, configuration: config)
             try migrator.migrate(dbQueue)
         } catch {

--- a/mobile-apps/ios/MigraLog/ViewModels/AnalyticsViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/AnalyticsViewModel.swift
@@ -29,7 +29,7 @@ final class AnalyticsViewModel {
 
     // MARK: - Cache
 
-    private static let cacheTTL: TimeInterval = 30
+    private static let cacheTTL: TimeInterval = 300
     private var cacheKey: String { "analytics_\(selectedRange.rawValue)" }
     private let cache = CacheManager.shared
 

--- a/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
@@ -349,8 +349,23 @@ final class EpisodeDetailViewModel {
     // MARK: - Private
 
     private func loadDosesForEpisode(_ episodeId: String) throws -> [DoseWithMedication] {
-        let doses = try medicationRepository.getDosesByEpisodeId(episodeId)
-        return doses.compactMap { dose in
+        // Get doses explicitly linked to this episode
+        var allDoses = try medicationRepository.getDosesByEpisodeId(episodeId)
+        let linkedIds = Set(allDoses.map(\.id))
+
+        // Also get doses that fall within the episode's time window but lack episode_id
+        // (e.g. logged from homescreen before the association fix, or imported from RN)
+        if let episode = details?.episode {
+            let endTime = episode.endTime ?? Int64(Date().timeIntervalSince1970 * 1000)
+            let windowDoses = try medicationRepository.getDosesByDateRange(
+                start: episode.startTime, end: endTime
+            )
+            for dose in windowDoses where !linkedIds.contains(dose.id) {
+                allDoses.append(dose)
+            }
+        }
+
+        return allDoses.compactMap { dose in
             guard let med = try? medicationRepository.getMedicationById(dose.medicationId) else {
                 return nil
             }

--- a/mobile-apps/ios/MigraLog/ViewModels/MedicationDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/MedicationDetailViewModel.swift
@@ -47,7 +47,6 @@ final class MedicationDetailViewModel {
             isLoading = false
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "MedicationDetailViewModel", "action": "loadMedication"])
-            ErrorLogger.shared.logError(error, context: ["viewModel": "MedicationDetailViewModel"])
             self.error = error.localizedDescription
             isLoading = false
         }
@@ -67,7 +66,6 @@ final class MedicationDetailViewModel {
             isLoading = false
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "MedicationDetailViewModel", "action": "loadMedication"])
-            ErrorLogger.shared.logError(error, context: ["viewModel": "MedicationDetailViewModel"])
             self.error = error.localizedDescription
             isLoading = false
         }

--- a/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
@@ -82,7 +82,11 @@ struct LogMedicationScreen: View {
             createdAt: now,
             updatedAt: now
         )
-        try? await medicationRepo.createDose(dose)
+        do {
+            try await medicationRepo.createDose(dose)
+        } catch {
+            ErrorLogger.shared.logError(error, context: ["action": "quickLog", "medication": med.name])
+        }
         dismiss()
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Medications/MedicationsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/MedicationsScreen.swift
@@ -81,11 +81,9 @@ struct MedicationsScreen: View {
             await viewModel.loadMedications()
         }
         .onAppear {
-            print("[MedicationsScreen] onAppear - reloading")
             Task { await viewModel.loadMedications() }
         }
         .onReceive(NotificationCenter.default.publisher(for: .medicationDataChanged)) { _ in
-            print("[MedicationsScreen] notification - reloading")
             Task { await viewModel.loadMedications() }
         }
     }


### PR DESCRIPTION
## Summary

**Rescue med bug fix:**
- Episode timeline now queries doses by time window in addition to episode_id
- Catches doses logged before the association fix or imported from RN without episode_id

**Code review fixes:**
- Disable SQL tracing in production (`#if DEBUG`) - was leaking health data to logs
- Replace silent `try?` with proper error logging in LogMedicationScreen
- Remove debug `print()` statements from MedicationsScreen
- Remove duplicate ErrorLogger calls in MedicationDetailViewModel
- Increase analytics cache TTL from 30s to 5 minutes

## Test plan
- [x] Local build passes
- [ ] Full test suite via /release

🤖 Generated with [Claude Code](https://claude.com/claude-code)