### PR TITLE
feat: edit/delete medication doses and initial locations on timeline

### DIFF
--- a/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		BB11CC22DD33EE44FF550003 /* EditSymptomLogScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB11CC22DD33EE44FF550004 /* EditSymptomLogScreen.swift */; };
 		BB11CC22DD33EE44FF550005 /* EditPainLocationLogScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB11CC22DD33EE44FF550006 /* EditPainLocationLogScreen.swift */; };
 		BB11CC22DD33EE44FF550007 /* EditEpisodeNoteScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB11CC22DD33EE44FF550008 /* EditEpisodeNoteScreen.swift */; };
+		CC22DD33EE44FF550009 /* EditDoseFromTimelineScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC22DD33EE44FF55000A /* EditDoseFromTimelineScreen.swift */; };
 		AA00BB11CC22DD33EE44FF01 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA00BB11CC22DD33EE44FF02 /* Assets.xcassets */; };
 		01A2B3C4D5E6F70800000001 /* EpisodesListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A2B3C4D5E6F70800000002 /* EpisodesListViewModelTests.swift */; };
 		01A2B3C4D5E6F70800000003 /* MedicationsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A2B3C4D5E6F70800000004 /* MedicationsListViewModelTests.swift */; };
@@ -168,6 +169,7 @@
 		BB11CC22DD33EE44FF550004 /* EditSymptomLogScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSymptomLogScreen.swift; sourceTree = "<group>"; };
 		BB11CC22DD33EE44FF550006 /* EditPainLocationLogScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPainLocationLogScreen.swift; sourceTree = "<group>"; };
 		BB11CC22DD33EE44FF550008 /* EditEpisodeNoteScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditEpisodeNoteScreen.swift; sourceTree = "<group>"; };
+		CC22DD33EE44FF55000A /* EditDoseFromTimelineScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDoseFromTimelineScreen.swift; sourceTree = "<group>"; };
 		AA00BB11CC22DD33EE44FF02 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		01A2B3C4D5E6F70800000002 /* EpisodesListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodesListViewModelTests.swift; sourceTree = "<group>"; };
 		01A2B3C4D5E6F70800000004 /* MedicationsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationsListViewModelTests.swift; sourceTree = "<group>"; };
@@ -374,6 +376,7 @@
 			isa = PBXGroup;
 			children = (
 				ABEC0599D7949FE34645717A /* EditEpisodeScreen.swift */,
+				CC22DD33EE44FF55000A /* EditDoseFromTimelineScreen.swift */,
 				BB11CC22DD33EE44FF550008 /* EditEpisodeNoteScreen.swift */,
 				BB11CC22DD33EE44FF550002 /* EditIntensityReadingScreen.swift */,
 				BB11CC22DD33EE44FF550006 /* EditPainLocationLogScreen.swift */,
@@ -898,6 +901,7 @@
 				BB11CC22DD33EE44FF550001 /* EditIntensityReadingScreen.swift in Sources */,
 				BB11CC22DD33EE44FF550003 /* EditSymptomLogScreen.swift in Sources */,
 				BB11CC22DD33EE44FF550005 /* EditPainLocationLogScreen.swift in Sources */,
+				CC22DD33EE44FF550009 /* EditDoseFromTimelineScreen.swift in Sources */,
 				BB11CC22DD33EE44FF550007 /* EditEpisodeNoteScreen.swift in Sources */,
 				A7D5C82C319DA925E7BA5193 /* EpisodeDetailScreen.swift in Sources */,
 				CC11AA22BB33DD44EE550001 /* TimelineView.swift in Sources */,

--- a/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
@@ -346,6 +346,34 @@ final class EpisodeDetailViewModel {
         }
     }
 
+    // MARK: - Dose Editing
+
+    @MainActor
+    func updateDose(_ dose: MedicationDose) async {
+        do {
+            var updated = dose
+            updated.updatedAt = TimestampHelper.now
+            _ = try medicationRepository.updateDose(updated)
+            if let index = episodeDoses.firstIndex(where: { $0.dose.id == dose.id }) {
+                episodeDoses[index] = DoseWithMedication(dose: updated, medication: episodeDoses[index].medication)
+            }
+        } catch {
+            ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "updateDose"])
+            self.error = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    func deleteDose(_ id: String) async {
+        do {
+            try medicationRepository.deleteDose(id)
+            episodeDoses.removeAll { $0.dose.id == id }
+        } catch {
+            ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "deleteDose"])
+            self.error = error.localizedDescription
+        }
+    }
+
     // MARK: - Private
 
     private func loadDosesForEpisode(_ episodeId: String) throws -> [DoseWithMedication] {

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EditDoseFromTimelineScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EditDoseFromTimelineScreen.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct EditDoseFromTimelineScreen: View {
+    let dose: MedicationDose
+    let medicationName: String
+    @Bindable var viewModel: EpisodeDetailViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedDate: Date
+    @State private var notes: String
+    @State private var isSaving = false
+
+    init(dose: MedicationDose, medicationName: String, viewModel: EpisodeDetailViewModel) {
+        self.dose = dose
+        self.medicationName = medicationName
+        self.viewModel = viewModel
+        _selectedDate = State(initialValue: Date(timeIntervalSince1970: Double(dose.timestamp) / 1000.0))
+        _notes = State(initialValue: dose.notes ?? "")
+    }
+
+    var body: some View {
+        Form {
+            Section("Medication") {
+                Text(medicationName)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Time") {
+                DatePicker("When", selection: $selectedDate)
+            }
+
+            Section("Notes") {
+                TextEditor(text: $notes)
+                    .frame(minHeight: 60)
+            }
+        }
+        .navigationTitle("Edit Dose")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") {
+                    Task { await save() }
+                }
+                .disabled(isSaving)
+            }
+        }
+    }
+
+    private func save() async {
+        isSaving = true
+        defer { isSaving = false }
+
+        var updated = dose
+        updated.timestamp = TimestampHelper.fromDate(selectedDate)
+        updated.notes = notes.isEmpty ? nil : notes
+        await viewModel.updateDose(updated)
+        dismiss()
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -13,6 +13,7 @@ struct EpisodeDetailScreen: View {
     @State private var editingSymptomLog: SymptomLog?
     @State private var editingPainLocationLog: PainLocationLog?
     @State private var editingNote: EpisodeNote?
+    @State private var editingDose: DoseWithMedication?
     @State private var showDeleteConfirmation = false
     @State private var pendingDeleteAction: (() async -> Void)?
     @State private var pendingDeleteLabel: String = ""
@@ -38,7 +39,9 @@ struct EpisodeDetailScreen: View {
                                 pendingDeleteAction: $pendingDeleteAction,
                                 pendingDeleteLabel: $pendingDeleteLabel,
                                 customEndTime: $customEndTime,
-                                showEndTimePicker: $showEndTimePicker
+                                showEndTimePicker: $showEndTimePicker,
+                                editingDose: $editingDose,
+                                showEditEpisodeSheet: $showEditSheet
                             )
                         }
 
@@ -123,6 +126,15 @@ struct EpisodeDetailScreen: View {
         .sheet(item: $editingNote) { note in
             NavigationStack {
                 EditEpisodeNoteScreen(note: note, viewModel: viewModel)
+            }
+        }
+        .sheet(item: $editingDose) { doseWithMed in
+            NavigationStack {
+                EditDoseFromTimelineScreen(
+                    dose: doseWithMed.dose,
+                    medicationName: doseWithMed.medication.name,
+                    viewModel: viewModel
+                )
             }
         }
         .alert("Delete \(pendingDeleteLabel)?", isPresented: $showDeleteConfirmation) {

--- a/mobile-apps/ios/MigraLog/Views/Episodes/TimelineView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/TimelineView.swift
@@ -52,6 +52,8 @@ struct TimelineView: View {
     @Binding var pendingDeleteLabel: String
     @Binding var customEndTime: Date
     @Binding var showEndTimePicker: Bool
+    @Binding var editingDose: DoseWithMedication?
+    @Binding var showEditEpisodeSheet: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -361,7 +363,11 @@ struct TimelineView: View {
             }
 
         case .painLocation(let log, let delta):
-            if !delta.isInitial {
+            if delta.isInitial {
+                Button { showEditEpisodeSheet = true } label: {
+                    Label("Edit Episode Details", systemImage: "pencil")
+                }
+            } else {
                 Button { editingPainLocationLog = log } label: {
                     Label("Edit Pain Locations", systemImage: "pencil")
                 }
@@ -386,9 +392,17 @@ struct TimelineView: View {
                 Label("Delete", systemImage: "trash")
             }
 
-        case .medication:
-            // Dose editing handled via medication detail screen
-            EmptyView()
+        case .medication(let doseWithMed):
+            Button { editingDose = doseWithMed } label: {
+                Label("Edit Dose", systemImage: "pencil")
+            }
+            Button(role: .destructive) {
+                pendingDeleteLabel = "medication dose"
+                pendingDeleteAction = { await viewModel.deleteDose(doseWithMed.dose.id) }
+                showDeleteConfirmation = true
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
 
         case .episodeEnded:
             Button {


### PR DESCRIPTION
## Summary
- Long-press medication doses on timeline to edit timestamp/notes or delete
- Long-press initial pain locations to navigate to Edit Episode Details
- New EditDoseFromTimelineScreen for lightweight dose editing
- Added updateDose/deleteDose to EpisodeDetailViewModel

## Test plan
- [x] Local build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)