### PR TITLE
fix: episode end time save, edit form constraints, and iOS main thread crash

### DIFF
--- a/mobile-apps/ios/MigraLog/ViewModels/AnalyticsViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/AnalyticsViewModel.swift
@@ -213,6 +213,7 @@ final class AnalyticsViewModel {
         }
     }
 
+    @MainActor
     func deleteOverlay(_ id: String) async {
         do {
             try overlayRepository.deleteOverlay(id)
@@ -221,6 +222,7 @@ final class AnalyticsViewModel {
         }
     }
 
+    @MainActor
     func loadCalendarData(for month: Date) async {
         let calendar = Calendar.current
         let components = calendar.dateComponents([.year, .month], from: month)

--- a/mobile-apps/ios/MigraLog/ViewModels/LogMedicationViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/LogMedicationViewModel.swift
@@ -30,6 +30,7 @@ final class LogMedicationViewModel {
         }
     }
 
+    @MainActor
     func quickLog(_ medication: Medication) async {
         let now = TimestampHelper.now
         let activeEpisode = try? episodeRepository.getEpisodeByTimestamp(now)

--- a/mobile-apps/ios/MigraLog/ViewModels/MedicationDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/MedicationDetailViewModel.swift
@@ -262,6 +262,7 @@ final class MedicationDetailViewModel {
 
     // MARK: - Notification Helpers
 
+    @MainActor
     private func rescheduleNotifications(for medication: Medication) async {
         do {
             // Reschedule all medication notifications (handles grouping across all meds)

--- a/mobile-apps/ios/MigraLog/ViewModels/NotificationSettingsViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/NotificationSettingsViewModel.swift
@@ -99,6 +99,7 @@ final class NotificationSettingsViewModel {
 
     /// Update daily check-in notification scheduling based on current settings.
     /// Call this after changing dailyCheckinEnabled or dailyCheckinTime.
+    @MainActor
     func syncDailyCheckinNotification() async {
         if dailyCheckinEnabled && notificationsEnabled {
             do {
@@ -140,6 +141,7 @@ final class NotificationSettingsViewModel {
 
     /// Reschedule all medication notifications when settings change.
     /// rescheduleAll cancels everything first, then re-schedules based on current active meds.
+    @MainActor
     func syncMedicationNotifications() async {
         do {
             try await medicationNotificationService?.rescheduleAllMedicationNotifications()

--- a/mobile-apps/react-native/src/components/episode/EpisodeModals.tsx
+++ b/mobile-apps/react-native/src/components/episode/EpisodeModals.tsx
@@ -132,9 +132,10 @@ export const EpisodeModals: React.FC<EpisodeModalsProps> = ({
               value={customEndTime && customEndTime > 0 ? new Date(customEndTime) : new Date()}
               mode="datetime"
               display="spinner"
-              onChange={(_event, selectedDate) => {
-                if (selectedDate) {
-                  onCustomTimeChange(selectedDate.getTime());
+              onChange={(event, selectedDate) => {
+                const timestamp = selectedDate?.getTime() ?? event.nativeEvent?.timestamp;
+                if (timestamp && !isNaN(timestamp)) {
+                  onCustomTimeChange(timestamp);
                 }
               }}
               maximumDate={new Date()}

--- a/mobile-apps/react-native/src/screens/episode/EpisodeDetailScreen.tsx
+++ b/mobile-apps/react-native/src/screens/episode/EpisodeDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { logger } from '../../utils/logger';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Alert, Platform, ActionSheetIOS, useWindowDimensions } from 'react-native';
 
@@ -127,7 +127,12 @@ export default function EpisodeDetailScreen({ route, navigation }: Props) {
   const [locationAddress, setLocationAddress] = useState<string | null>(null);
   const [showMapModal, setShowMapModal] = useState(false);
   const [showEndTimePicker, setShowEndTimePicker] = useState(false);
-  const [customEndTime, setCustomEndTime] = useState<number>(Date.now());
+  const [customEndTime, _setCustomEndTime] = useState<number>(Date.now());
+  const customEndTimeRef = useRef<number>(Date.now());
+  const setCustomEndTime = (time: number) => {
+    customEndTimeRef.current = time;
+    _setCustomEndTime(time);
+  };
 
   useFocusEffect(
     React.useCallback(() => {
@@ -199,17 +204,26 @@ export default function EpisodeDetailScreen({ route, navigation }: Props) {
   const editEpisodeEndTime = async () => {
     if (!episode) return;
 
+    // Use ref value to avoid stale closure issues with DateTimePicker onChange timing
+    const endTimeToSave = customEndTimeRef.current;
+
     // Validate that end time is not before episode start
-    const validation = validateEpisodeEndTime(episode.startTime, customEndTime);
+    const validation = validateEpisodeEndTime(episode.startTime, endTimeToSave);
     if (!validation.isValid) {
       Alert.alert('Invalid Time', validation.error!);
       return;
     }
 
-    // Edit the end time of completed episode
-    await updateEpisode(episode.id, { endTime: customEndTime });
-    await loadEpisodeData(); // Reload to reflect changes
-    setShowEndTimePicker(false);
+    try {
+      // Edit the end time of completed episode
+      await updateEpisode(episode.id, { endTime: endTimeToSave });
+      await loadEpisodeData(); // Reload to reflect changes
+    } catch (error) {
+      logger.error('Failed to edit episode end time:', error);
+      Alert.alert('Error', 'Failed to save the end time. Please try again.');
+    } finally {
+      setShowEndTimePicker(false);
+    }
   };
 
   const handleCustomTimeAction = async () => {
@@ -248,7 +262,7 @@ export default function EpisodeDetailScreen({ route, navigation }: Props) {
 
   const endEpisodeWithCustomTime = async () => {
     if (episode) {
-      await endEpisode(episode.id, customEndTime);
+      await endEpisode(episode.id, customEndTimeRef.current);
       navigation.goBack();
     }
   };

--- a/mobile-apps/react-native/src/screens/episode/NewEpisodeScreen.tsx
+++ b/mobile-apps/react-native/src/screens/episode/NewEpisodeScreen.tsx
@@ -567,8 +567,10 @@ export default function NewEpisodeScreen({ navigation, route }: Props) {
               display={Platform.OS === 'ios' ? 'spinner' : 'default'}
               onChange={(event, date) => {
                 setShowDatePicker(Platform.OS === 'ios');
-                if (date) setStartTime(date);
+                const selectedDate = date ?? (event.nativeEvent?.timestamp ? new Date(event.nativeEvent.timestamp) : undefined);
+                if (selectedDate) setStartTime(selectedDate);
               }}
+              maximumDate={endTime || new Date()}
             />
           )}
         </View>
@@ -628,7 +630,8 @@ export default function NewEpisodeScreen({ navigation, route }: Props) {
                 display={Platform.OS === 'ios' ? 'spinner' : 'default'}
                 onChange={(event, date) => {
                   setShowEndDatePicker(Platform.OS === 'ios');
-                  if (date) setEndTime(date);
+                  const selectedDate = date ?? (event.nativeEvent?.timestamp ? new Date(event.nativeEvent.timestamp) : undefined);
+                  if (selectedDate) setEndTime(selectedDate);
                 }}
                 minimumDate={startTime}
                 maximumDate={new Date()}


### PR DESCRIPTION
## Summary
- **#389**: Fix timeline end time edit not saving — uses ref alongside state to avoid stale closure issues with DateTimePicker onChange timing on Fabric/new architecture
- **#390**: Add `maximumDate` constraint to start time picker preventing selection after end time, plus nativeEvent.timestamp fallback for Fabric compatibility  
- **Sentry MIGRALOG-17**: Add `@MainActor` to async ViewModel methods that modify `@Observable` state, preventing `NSInternalInconsistencyException` during UIKit state restoration

## Test plan
- [x] React Native: 125 test suites, 3296 tests pass
- [x] React Native: TypeScript compiles clean, ESLint clean
- [x] iOS Swift: Build succeeds, 678 tests pass
- [ ] Manual: Long-press episode end on timeline → edit time → tap Done → verify time saved
- [ ] Manual: Edit episode form → change start/end times → verify constraints and save
- [ ] Manual: Background/foreground iOS app during async operations → no crash

Closes #389, Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)