### PR TITLE
feat(ios): sparkline on active episode card + medication default quantity

### DIFF
--- a/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
@@ -69,6 +69,12 @@ final class DashboardViewModel {
             recentEpisodes = try await recentTask
             todaysMedications = try await medsTask
             yesterdayStatus = try await statusTask
+
+            // Load active episode readings for dashboard sparkline
+            if let active = currentEpisode,
+               let details = try episodeRepository.getEpisodeWithDetails(active.id) {
+                recentReadings[active.id] = details.intensityReadings
+            }
             isLoading = false
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "DashboardViewModel", "action": "loadData"])

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -159,47 +159,6 @@ struct DailyStatusWidgetView: View {
     }
 }
 
-// MARK: - Active Episode Card
-
-struct ActiveEpisodeCard: View {
-    let episode: Episode
-
-    var body: some View {
-        NavigationLink {
-            EpisodeDetailScreen(episodeId: episode.id)
-        } label: {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Text("Active Episode")
-                        .font(.headline)
-                    Spacer()
-                    Text("Ongoing")
-                        .font(.caption)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(Color.red.opacity(0.2))
-                        .foregroundStyle(.red)
-                        .clipShape(Capsule())
-                }
-
-                Text("Started \(DateFormatting.displayTime(episode.startDate))")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-
-                Text(DateFormatting.formatDuration(from: episode.startTime, to: nil))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding()
-            .background(Color(.secondarySystemBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-        }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("active-episode-card")
-    }
-}
-
 // MARK: - Today's Medications Card
 
 struct TodaysMedicationsCard: View {
@@ -310,9 +269,13 @@ struct RecentEpisodesCard: View {
                     NavigationLink {
                         EpisodeDetailScreen(episodeId: episode.id)
                     } label: {
-                        ActiveEpisodeCard(episode: episode)
+                        EpisodeCardView(
+                            episode: episode,
+                            readings: viewModel.recentReadings[episode.id] ?? []
+                        )
                     }
                     .buttonStyle(.plain)
+                    .accessibilityIdentifier("active-episode-card")
                 }
 
                 // Recent closed episodes

--- a/mobile-apps/ios/MigraLog/Views/Medications/AddMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/AddMedicationScreen.swift
@@ -8,6 +8,7 @@ struct AddMedicationScreen: View {
     @State private var dosageUnit: String = "mg"
     @State private var category: MedicationCategory?
     @State private var scheduleFrequency: ScheduleFrequency?
+    @State private var defaultQuantity: String = "1"
     @State private var notes: String = ""
     @State private var searchResults: [PresetMedication] = []
     @State private var showAutocomplete = false
@@ -64,6 +65,15 @@ struct AddMedicationScreen: View {
                 TextField("Amount", text: $dosageAmount)
                     .keyboardType(.decimalPad)
                 TextField("Unit (mg, ml, tablets...)", text: $dosageUnit)
+            }
+
+            Section {
+                TextField("Number of doses", text: $defaultQuantity)
+                    .keyboardType(.decimalPad)
+            } header: {
+                Text("Default Quantity")
+            } footer: {
+                Text("Number of doses typically taken at once. For example, if you take 3 tablets of 200mg Advil, enter 3.")
             }
 
             Section("Category") {
@@ -149,7 +159,7 @@ struct AddMedicationScreen: View {
             type: type,
             dosageAmount: amount,
             dosageUnit: dosageUnit,
-            defaultQuantity: nil,
+            defaultQuantity: Double(defaultQuantity).flatMap { $0 > 0 ? $0 : nil },
             scheduleFrequency: scheduleFrequency,
             photoUri: nil,
             active: true,

--- a/mobile-apps/ios/MigraLog/Views/Medications/EditMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/EditMedicationScreen.swift
@@ -8,6 +8,7 @@ struct EditMedicationScreen: View {
     @State private var name: String
     @State private var dosageAmount: String
     @State private var dosageUnit: String
+    @State private var defaultQuantity: String
     @State private var notes: String
     @State private var category: MedicationCategory?
     @State private var isSaving = false
@@ -18,6 +19,9 @@ struct EditMedicationScreen: View {
         _name = State(initialValue: medication.name)
         _dosageAmount = State(initialValue: String(medication.dosageAmount))
         _dosageUnit = State(initialValue: medication.dosageUnit)
+        _defaultQuantity = State(initialValue: medication.defaultQuantity.map {
+            $0.truncatingRemainder(dividingBy: 1) == 0 ? String(Int($0)) : String($0)
+        } ?? "1")
         _notes = State(initialValue: medication.notes ?? "")
         _category = State(initialValue: medication.category)
     }
@@ -42,6 +46,14 @@ struct EditMedicationScreen: View {
                 TextField("Amount", text: $dosageAmount)
                     .keyboardType(.decimalPad)
                 TextField("Unit", text: $dosageUnit)
+            }
+            Section {
+                TextField("Number of doses", text: $defaultQuantity)
+                    .keyboardType(.decimalPad)
+            } header: {
+                Text("Default Quantity")
+            } footer: {
+                Text("Number of doses typically taken at once. For example, if you take 3 tablets of 200mg Advil, enter 3.")
             }
             Section("Category") {
                 Picker("Category", selection: $category) {
@@ -80,6 +92,7 @@ struct EditMedicationScreen: View {
         updated.name = name
         updated.dosageAmount = amount
         updated.dosageUnit = dosageUnit
+        updated.defaultQuantity = Double(defaultQuantity).flatMap { $0 > 0 ? $0 : nil }
         updated.notes = notes.isEmpty ? nil : notes
         updated.category = category
         updated.updatedAt = TimestampHelper.now


### PR DESCRIPTION
## Summary
- **#393**: Replace `ActiveEpisodeCard` with unified `EpisodeCardView` on dashboard — ongoing episodes now show sparkline with intensity history, matching recent episode cards
- **#394**: Add "Default Quantity" field to Add/Edit Medication forms with helper text, validation (> 0), and fractional value preservation

## Test plan
- [x] iOS build succeeds
- [x] 684 unit tests pass
- [ ] Manual: Start episode, log intensity readings, check dashboard shows sparkline on active card
- [ ] Manual: Add medication with default quantity of 3, verify it appears when logging
- [ ] Manual: Edit existing medication, verify default quantity is editable and saves

Closes #393, Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)