### PR TITLE
feat(ios): add graceful database error recovery

### DIFF
--- a/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		5339F16DC70F87218207B58D /* EpisodeValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32374D27529ACFAE6B94FC8B /* EpisodeValidation.swift */; };
 		542422BA21D92779421169E3 /* AddMedicationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158207F7E5E35F65C5CC154B /* AddMedicationScreen.swift */; };
 		545F02A7E17730DADEF9269F /* LocationSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96ADD663FB891445B7511E5 /* LocationSettingsScreen.swift */; };
+		DA7E0B21C8F34A5E9B1D6F03 /* DatabaseErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7E0B21C8F34A5E9B1D6F04 /* DatabaseErrorView.swift */; };
 		54A8ABCB153D69F200FE93A3 /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E6D59A95E669BF94630D8F /* LocationService.swift */; };
 		5526658ACE024ED2751F7B58 /* MedicationNotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8750E37C42400B8607707EB7 /* MedicationNotificationServiceTests.swift */; };
 		AA11BB22CC33DD44EE55FF01 /* NotificationSlotCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE55FF11 /* NotificationSlotCalculatorTests.swift */; };
@@ -282,6 +283,7 @@
 		D1BF06D4B0AF537BEAF4698D /* WelcomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeScreen.swift; sourceTree = "<group>"; };
 		D1F340F63DF6C366F048A48B /* DatabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseManager.swift; sourceTree = "<group>"; };
 		D2905118EC1EC29D6FAFC7F3 /* DataSettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSettingsScreen.swift; sourceTree = "<group>"; };
+		DA7E0B21C8F34A5E9B1D6F04 /* DatabaseErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseErrorView.swift; sourceTree = "<group>"; };
 		D5C72860862DA711BCBEAFCE /* DailyStatusViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyStatusViewModelTests.swift; sourceTree = "<group>"; };
 		D5FDFB70D7FBD2F40C33EEA2 /* PresetMedications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetMedications.swift; sourceTree = "<group>"; };
 		D63D77F78450B572B22BACE5 /* MigraLogTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MigraLogTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -542,6 +544,7 @@
 		84D341D07CE116E5E19B7A9A /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				DA7E0B21C8F34A5E9B1D6F04 /* DatabaseErrorView.swift */,
 				D2905118EC1EC29D6FAFC7F3 /* DataSettingsScreen.swift */,
 				F5BF70F8D6B06F72BB0220C8 /* DeveloperToolsScreen.swift */,
 				F96ADD663FB891445B7511E5 /* LocationSettingsScreen.swift */,
@@ -889,6 +892,7 @@
 				02755879A237973FD67FE2B5 /* DailyStatusViewModel.swift in Sources */,
 				18C6ED3634A20309D3DD8261 /* DashboardScreen.swift in Sources */,
 				4791955D828CAA808F2E1B71 /* DashboardViewModel.swift in Sources */,
+				DA7E0B21C8F34A5E9B1D6F03 /* DatabaseErrorView.swift in Sources */,
 				C2D3CA453CD9096E0FE76A93 /* DataSettingsScreen.swift in Sources */,
 				E919E2044D68ED0932A9D71D /* DatabaseManager.swift in Sources */,
 				B198B47C0F880F123164B743 /* DateFormatting.swift in Sources */,

--- a/mobile-apps/ios/MigraLog/App/ContentView.swift
+++ b/mobile-apps/ios/MigraLog/App/ContentView.swift
@@ -5,7 +5,9 @@ struct ContentView: View {
 
     var body: some View {
         Group {
-            if appState.isLoading {
+            if DatabaseManager.initializationError != nil {
+                DatabaseErrorView()
+            } else if appState.isLoading {
                 ProgressView("Loading...")
             } else if !appState.isOnboardingComplete {
                 WelcomeScreen()

--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -9,12 +9,30 @@ final class DatabaseManager: Sendable {
     /// Shared singleton for the app's main database
     static let shared = DatabaseManager()
 
+    /// If database initialization failed, this holds the error.
+    /// Check this at app launch to show a recovery UI instead of the normal app.
+    /// Written once during singleton init, read-only thereafter.
+    nonisolated(unsafe) static private(set) var initializationError: Error?
+
+    /// The file URL of the database, available even when initialization failed
+    /// so the user can export the file for recovery.
+    /// Written once during singleton init, read-only thereafter.
+    nonisolated(unsafe) static private(set) var databaseFileURL: URL?
+
     let dbQueue: DatabaseQueue
 
-    /// Initialize with a file-based database at the default app location
+    /// Initialize with a file-based database at the default app location.
+    /// On failure, falls back to an in-memory database so the app can launch
+    /// and present recovery UI (e.g. exporting the corrupt database file).
     private init() {
+        dbQueue = DatabaseManager.createDatabaseQueue()
+    }
+
+    /// Creates the database queue, falling back to in-memory on failure.
+    /// Sets static properties for error state and file URL as side effects.
+    private static func createDatabaseQueue() -> DatabaseQueue {
+        let fileManager = FileManager.default
         do {
-            let fileManager = FileManager.default
             let appSupport = try fileManager.url(
                 for: .applicationSupportDirectory,
                 in: .userDomainMask,
@@ -22,6 +40,7 @@ final class DatabaseManager: Sendable {
                 create: true
             )
             let dbURL = appSupport.appendingPathComponent("migralog.db")
+            databaseFileURL = dbURL
             var config = Configuration()
             config.foreignKeysEnabled = true
             #if DEBUG
@@ -29,10 +48,21 @@ final class DatabaseManager: Sendable {
                 db.trace { print("SQL: \($0)") }
             }
             #endif
-            dbQueue = try DatabaseQueue(path: dbURL.path, configuration: config)
-            try migrator.migrate(dbQueue)
+            let queue = try DatabaseQueue(path: dbURL.path, configuration: config)
+            let mgr = DatabaseManager.buildMigrator()
+            try mgr.migrate(queue)
+            return queue
         } catch {
-            fatalError("Database initialization failed: \(error)")
+            initializationError = error
+            // Fall back to an in-memory database so the app can launch
+            // and present recovery UI to the user
+            var fallbackConfig = Configuration()
+            fallbackConfig.foreignKeysEnabled = true
+            // swiftlint:disable:next force_try
+            let queue = try! DatabaseQueue(configuration: fallbackConfig)
+            let mgr = DatabaseManager.buildMigrator()
+            try? mgr.migrate(queue)
+            return queue
         }
     }
 
@@ -58,6 +88,10 @@ final class DatabaseManager: Sendable {
     }
 
     private var migrator: DatabaseMigrator {
+        DatabaseManager.buildMigrator()
+    }
+
+    private static func buildMigrator() -> DatabaseMigrator {
         var migrator = DatabaseMigrator()
 
         // v25: Full schema creation

--- a/mobile-apps/ios/MigraLog/Views/Settings/DatabaseErrorView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DatabaseErrorView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// Shown when the database fails to initialize, giving the user a chance
+/// to export their database file for recovery before the data is lost.
+struct DatabaseErrorView: View {
+    @State private var showShareSheet = false
+
+    private var error: Error? {
+        DatabaseManager.initializationError
+    }
+
+    private var databaseFileExists: Bool {
+        guard let url = DatabaseManager.databaseFileURL else { return false }
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 56))
+                .foregroundStyle(.orange)
+
+            Text("Database Error")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text("MigraLog was unable to open its database. Your data may still be on this device.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            if let error {
+                Text(error.localizedDescription)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
+            if databaseFileExists {
+                VStack(spacing: 12) {
+                    Text("You can export the database file so it can be recovered or sent to support.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 32)
+
+                    Button {
+                        showShareSheet = true
+                    } label: {
+                        Label("Export Database File", systemImage: "square.and.arrow.up")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .padding(.horizontal, 32)
+                }
+            } else {
+                Text("No database file was found on this device.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
+            Spacer()
+        }
+        .sheet(isPresented: $showShareSheet) {
+            if let url = DatabaseManager.databaseFileURL {
+                ShareSheet(items: [url])
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `fatalError` on database initialization failure with in-memory fallback
- Add `DatabaseErrorView` recovery UI shown when database corruption is detected
- Expose `initializationError` and `databaseFileURL` on `DatabaseManager` for recovery

## Test plan
- [x] 684 unit tests pass
- [x] 41 UI tests pass