### PR TITLE
feat(ios): switch iPad to tab bar + two-column splits

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/AdaptiveNavigation.swift
+++ b/mobile-apps/ios/MigraLog/Views/AdaptiveNavigation.swift
@@ -1,210 +1,149 @@
 import SwiftUI
 
-/// Top-level navigation container that adapts between iPad (sidebar) and iPhone (tab bar).
+/// Top-level navigation using a tab bar on all devices.
+/// On iPad, list-detail tabs use NavigationSplitView internally for two-column layout.
 struct AdaptiveNavigation: View {
-    @Environment(\.horizontalSizeClass) private var sizeClass
-    @State private var selectedSection: NavigationSection = .dashboard
-    @State private var selectedEpisodeId: String?
-    @State private var selectedMedicationId: String?
-    @State private var analyticsViewModel = AnalyticsViewModel()
-    @State private var showAddOverlay = false
-    @State private var editingOverlay: CalendarOverlay?
-
-    /// Whether the selected section uses a three-column layout (sidebar + list + detail)
-    private var usesThreeColumnLayout: Bool {
-        switch selectedSection {
-        case .episodes, .medications, .trends:
-            return true
-        case .dashboard, .settings:
-            return false
-        }
-    }
+    @State private var selectedTab: TabSection = .dashboard
 
     var body: some View {
-        if sizeClass == .regular {
-            iPadNavigation
-        } else {
-            iPhoneNavigation
-        }
-    }
-
-    // MARK: - iPad Navigation
-
-    private var iPadNavigation: some View {
-        Group {
-            if usesThreeColumnLayout {
-                iPadThreeColumnNavigation
-            } else {
-                iPadTwoColumnNavigation
-            }
-        }
-        .sheet(isPresented: $showAddOverlay, onDismiss: { Task { await analyticsViewModel.loadCalendarData(for: Date()) } }) {
-            NavigationStack {
-                OverlayFormSheet { overlay in
-                    Task { await analyticsViewModel.saveOverlay(overlay) }
-                }
-            }
-        }
-        .sheet(item: $editingOverlay, onDismiss: { Task { await analyticsViewModel.loadCalendarData(for: Date()) } }) { overlay in
-            NavigationStack {
-                OverlayFormSheet(overlay: overlay, onSave: { updated in
-                    Task { await analyticsViewModel.saveOverlay(updated) }
-                }, onDelete: { id in
-                    Task { await analyticsViewModel.deleteOverlay(id) }
-                })
-            }
-        }
-    }
-
-    // MARK: - Two-Column: Sidebar + Detail (Dashboard, Settings)
-
-    private var iPadTwoColumnNavigation: some View {
-        NavigationSplitView {
-            SidebarView(selection: $selectedSection)
-        } detail: {
-            NavigationStack {
-                switch selectedSection {
-                case .dashboard:
-                    DashboardScreen()
-                case .settings:
-                    SettingsScreen()
-                default:
-                    EmptyView()
-                }
-            }
-        }
-    }
-
-    // MARK: - Three-Column: Sidebar + List + Detail (Episodes, Medications, Trends)
-
-    private var iPadThreeColumnNavigation: some View {
-        NavigationSplitView {
-            SidebarView(selection: $selectedSection)
-        } content: {
-            switch selectedSection {
-            case .episodes:
-                EpisodesListColumn(selectedEpisodeId: $selectedEpisodeId)
-            case .medications:
-                MedicationsListColumn(selectedMedicationId: $selectedMedicationId)
-            case .trends:
-                AnalyticsControlsColumn(
-                    viewModel: analyticsViewModel,
-                    onAddOverlay: { showAddOverlay = true },
-                    onEditOverlay: { editingOverlay = $0 }
-                )
-            default:
-                EmptyView()
-            }
-        } detail: {
-            NavigationStack {
-                switch selectedSection {
-                case .episodes:
-                    if let episodeId = selectedEpisodeId {
-                        EpisodeDetailScreen(episodeId: episodeId)
-                    } else {
-                        ContentUnavailableView(
-                            "No Episode Selected",
-                            systemImage: "bolt.heart",
-                            description: Text("Select an episode to view details.")
-                        )
-                    }
-                case .medications:
-                    if let medicationId = selectedMedicationId {
-                        MedicationDetailScreen(medicationId: medicationId)
-                    } else {
-                        ContentUnavailableView(
-                            "No Medication Selected",
-                            systemImage: "pills",
-                            description: Text("Select a medication to view details.")
-                        )
-                    }
-                case .trends:
-                    AnalyticsVisualizationPane(viewModel: analyticsViewModel)
-                default:
-                    EmptyView()
-                }
-            }
-        }
-    }
-
-    // MARK: - iPhone: Tab Bar (existing behavior)
-
-    private var iPhoneNavigation: some View {
-        TabView(selection: $selectedSection) {
+        TabView(selection: $selectedTab) {
             NavigationStack {
                 DashboardScreen()
             }
             .tabItem {
                 Label("Dashboard", systemImage: "house")
             }
-            .tag(NavigationSection.dashboard)
+            .tag(TabSection.dashboard)
 
-            NavigationStack {
-                EpisodesScreen()
-            }
-            .tabItem {
-                Label("Episodes", systemImage: "bolt.heart")
-            }
-            .tag(NavigationSection.episodes)
+            EpisodesTab()
+                .tabItem {
+                    Label("Episodes", systemImage: "bolt.heart")
+                }
+                .tag(TabSection.episodes)
 
-            NavigationStack {
-                MedicationsScreen()
-            }
-            .tabItem {
-                Label("Medications", systemImage: "pills")
-            }
-            .tag(NavigationSection.medications)
+            MedicationsTab()
+                .tabItem {
+                    Label("Medications", systemImage: "pills")
+                }
+                .tag(TabSection.medications)
 
-            NavigationStack {
-                AnalyticsScreen()
-            }
-            .tabItem {
-                Label("Trends", systemImage: "chart.bar")
-            }
-            .tag(NavigationSection.trends)
+            TrendsTab()
+                .tabItem {
+                    Label("Trends", systemImage: "chart.bar")
+                }
+                .tag(TabSection.trends)
         }
     }
 }
 
-// MARK: - Navigation Section Enum
+// MARK: - Tab Section Enum
 
-enum NavigationSection: Hashable {
+enum TabSection: Hashable {
     case dashboard
     case episodes
     case medications
     case trends
-    case settings
 }
 
-// MARK: - Sidebar View
+// MARK: - Episodes Tab (two-column on iPad, stack on iPhone)
 
-struct SidebarView: View {
-    @Binding var selection: NavigationSection
+struct EpisodesTab: View {
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    @State private var selectedEpisodeId: String?
 
     var body: some View {
-        List {
-            Section {
-                sidebarButton(.dashboard, label: "Dashboard", icon: "house")
-                sidebarButton(.episodes, label: "Episodes", icon: "bolt.heart")
-                sidebarButton(.medications, label: "Medications", icon: "pills")
-                sidebarButton(.trends, label: "Trends", icon: "chart.bar")
+        if sizeClass == .regular {
+            NavigationSplitView {
+                EpisodesListColumn(selectedEpisodeId: $selectedEpisodeId)
+            } detail: {
+                if let episodeId = selectedEpisodeId {
+                    EpisodeDetailScreen(episodeId: episodeId)
+                } else {
+                    ContentUnavailableView(
+                        "No Episode Selected",
+                        systemImage: "bolt.heart",
+                        description: Text("Select an episode to view details.")
+                    )
+                }
             }
-
-            Section {
-                sidebarButton(.settings, label: "Settings", icon: "gearshape")
+        } else {
+            NavigationStack {
+                EpisodesScreen()
             }
         }
-        .navigationTitle("MigraLog")
-        .listStyle(.sidebar)
     }
+}
 
-    private func sidebarButton(_ section: NavigationSection, label: String, icon: String) -> some View {
-        Button {
-            selection = section
-        } label: {
-            Label(label, systemImage: icon)
+// MARK: - Medications Tab (two-column on iPad, stack on iPhone)
+
+struct MedicationsTab: View {
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    @State private var selectedMedicationId: String?
+
+    var body: some View {
+        if sizeClass == .regular {
+            NavigationSplitView {
+                MedicationsListColumn(selectedMedicationId: $selectedMedicationId)
+            } detail: {
+                if let medicationId = selectedMedicationId {
+                    MedicationDetailScreen(medicationId: medicationId)
+                } else {
+                    ContentUnavailableView(
+                        "No Medication Selected",
+                        systemImage: "pills",
+                        description: Text("Select a medication to view details.")
+                    )
+                }
+            }
+        } else {
+            NavigationStack {
+                MedicationsScreen()
+            }
         }
-        .listRowBackground(selection == section ? Color.accentColor.opacity(0.2) : nil)
-        .foregroundStyle(selection == section ? Color.accentColor : .primary)
+    }
+}
+
+// MARK: - Trends Tab (two-column on iPad, stack on iPhone)
+
+struct TrendsTab: View {
+    @Environment(\.horizontalSizeClass) private var sizeClass
+    @State private var viewModel = AnalyticsViewModel()
+    @State private var showAddOverlay = false
+    @State private var editingOverlay: CalendarOverlay?
+
+    var body: some View {
+        Group {
+            if sizeClass == .regular {
+                NavigationSplitView {
+                    AnalyticsControlsColumn(
+                        viewModel: viewModel,
+                        onAddOverlay: { showAddOverlay = true },
+                        onEditOverlay: { editingOverlay = $0 }
+                    )
+                } detail: {
+                    AnalyticsVisualizationPane(viewModel: viewModel)
+                }
+            } else {
+                NavigationStack {
+                    AnalyticsScreen()
+                }
+            }
+        }
+        .sheet(isPresented: $showAddOverlay, onDismiss: { Task { await viewModel.loadCalendarData(for: Date()) } }) {
+            NavigationStack {
+                OverlayFormSheet { overlay in
+                    Task { await viewModel.saveOverlay(overlay) }
+                }
+            }
+        }
+        .sheet(item: $editingOverlay, onDismiss: { Task { await viewModel.loadCalendarData(for: Date()) } }) { overlay in
+            NavigationStack {
+                OverlayFormSheet(overlay: overlay, onSave: { updated in
+                    Task { await viewModel.saveOverlay(updated) }
+                }, onDelete: { id in
+                    Task { await viewModel.deleteOverlay(id) }
+                })
+            }
+        }
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -18,17 +18,15 @@ struct DashboardScreen: View {
         .navigationTitle("MigraLog")
         .accessibilityIdentifier("dashboard-title")
         .toolbar {
-            if sizeClass != .regular {
-                ToolbarItem(placement: .topBarTrailing) {
-                    NavigationLink {
-                        SettingsScreen()
-                    } label: {
-                        Image(systemName: "gearshape")
-                    }
-                    .accessibilityIdentifier("settings-button")
-                    .accessibilityLabel("Settings")
-                    .accessibilityHint("Open application settings")
+            ToolbarItem(placement: .topBarTrailing) {
+                NavigationLink {
+                    SettingsScreen()
+                } label: {
+                    Image(systemName: "gearshape")
                 }
+                .accessibilityIdentifier("settings-button")
+                .accessibilityLabel("Settings")
+                .accessibilityHint("Open application settings")
             }
         }
         .sheet(isPresented: $viewModel.showNewEpisode, onDismiss: {


### PR DESCRIPTION
## Summary

Replace sidebar navigation with standard tab bar on iPad. Much cleaner navigation UX:
- Tab bar for section switching (same as iPhone)
- Episodes/Medications: two-column split (list | detail)
- Trends: two-column split (controls | visualizations)
- Dashboard: full-width with two-column card grid

## Test plan
- [ ] iPad shows tab bar, not sidebar
- [ ] Episodes tab: list on left, detail on right
- [ ] Medications tab: same pattern
- [ ] Trends tab: controls on left, calendar on right
- [ ] Dashboard: full-width with grid layout
- [ ] iPhone: unchanged behavior