### PR TITLE
feat(ios): dashboard prompt hiding + medication cooldown warnings

### DIFF
--- a/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		055AF4F8C351C8DB9461AE70 /* OnboardingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232D17AEE0F9291C479CD1C7 /* OnboardingUITests.swift */; };
 		05AA044EA783D666E98E81D9 /* EpisodeActionButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5324283BE5DD60BF140715F /* EpisodeActionButtons.swift */; };
 		093B4FE1027E57E1CEBD643B /* DailyStatusUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E3036FF5E4C4872E57D3C1 /* DailyStatusUITests.swift */; };
+		116097B18DA82FE412F3C5BA /* MedicationCooldownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EEA84A71D637DF8F280A3FF /* MedicationCooldownTests.swift */; };
 		12878F9A2A0A6F26B3985759 /* DatabaseManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDDD638C20D39DA42D77E37 /* DatabaseManagerTests.swift */; };
 		1436CCBB593CDEDE4CB17E77 /* PresetMedications.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FDFB70D7FBD2F40C33EEA2 /* PresetMedications.swift */; };
 		1703836554ADC64931DE549C /* NotificationSlotCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB34D740EEB031392E3A8144 /* NotificationSlotCalculatorTests.swift */; };
@@ -125,6 +126,7 @@
 		D05D7F0D0E233BC7B738A540 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B033CF962A0DDA5B74596C49 /* Assets.xcassets */; };
 		D09928A9BF4CFA313D09DA09 /* EpisodeDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E20F8C4F2821974E317505 /* EpisodeDetailViewModelTests.swift */; };
 		D6085DBDEE6689987FC5518D /* LocationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2AD1D8121EECFDA46211D60 /* LocationServiceTests.swift */; };
+		D6173D2C08ED96EB11691B30 /* MedicationCooldown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68F365D4D845E349BD354A39 /* MedicationCooldown.swift */; };
 		D683756FE92F809F3DF37B5D /* NotificationSlotCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E772101710689E022AD7303 /* NotificationSlotCalculator.swift */; };
 		DA97D06996DDCFA919153A49 /* AdaptiveNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFC54BF563A2D05F70E109E /* AdaptiveNavigation.swift */; };
 		E189FA6D7C1661287B5A268A /* MedicationsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9A1C95DF45ECBD6088584F /* MedicationsScreen.swift */; };
@@ -218,11 +220,13 @@
 		58985A1BF0AB1327A2C77292 /* EpisodesListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodesListViewModel.swift; sourceTree = "<group>"; };
 		5A2E67E4C892295C79FB921A /* DashboardScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardScreen.swift; sourceTree = "<group>"; };
 		5ADC08BE6A41699C6F17044C /* MedicationDoseUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationDoseUITests.swift; sourceTree = "<group>"; };
+		5EEA84A71D637DF8F280A3FF /* MedicationCooldownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationCooldownTests.swift; sourceTree = "<group>"; };
 		607D34D4F6637214F7B05DD8 /* MedicationTypeColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationTypeColors.swift; sourceTree = "<group>"; };
 		615C6E4CE39CB6D882770C7F /* DailyStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyStatusViewModel.swift; sourceTree = "<group>"; };
 		64F3FA23BCF098BBE0B8CBB5 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
 		67A30B1978FA36B8ECAC71F5 /* NotificationSettingsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsUITests.swift; sourceTree = "<group>"; };
 		68E2B05FCEFB6493EF0C2FE1 /* DailyCheckinSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCheckinSettingsViewModel.swift; sourceTree = "<group>"; };
+		68F365D4D845E349BD354A39 /* MedicationCooldown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationCooldown.swift; sourceTree = "<group>"; };
 		69B8D2570A843C4069DD91CA /* MigraLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigraLogTests.swift; sourceTree = "<group>"; };
 		6B437D8468CA5BAD36F5009D /* NewEpisodeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewEpisodeViewModel.swift; sourceTree = "<group>"; };
 		6C655C4327B2A2443B6CB590 /* SelectableChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableChip.swift; sourceTree = "<group>"; };
@@ -564,6 +568,7 @@
 				78012231B52727F745C4D9F9 /* ErrorLogger.swift */,
 				FD92CE0E5A2F8B92AF7000C7 /* ExportService.swift */,
 				90E6D59A95E669BF94630D8F /* LocationService.swift */,
+				68F365D4D845E349BD354A39 /* MedicationCooldown.swift */,
 				8FE8ECC3DA7FE72FE8D60A39 /* MedicationNotificationService.swift */,
 				B6ACA4C8E92F6B53F4F7B743 /* NotificationDismissalService.swift */,
 				10A99C28CDBEEE4B30A7A108 /* NotificationIntegrityService.swift */,
@@ -587,6 +592,7 @@
 				02485161F9226C6D742EC36C /* ErrorLoggerTests.swift */,
 				8085FE18D6FA8E5EE15EEF8B /* ExportServiceTests.swift */,
 				E2AD1D8121EECFDA46211D60 /* LocationServiceTests.swift */,
+				5EEA84A71D637DF8F280A3FF /* MedicationCooldownTests.swift */,
 				8750E37C42400B8607707EB7 /* MedicationNotificationServiceTests.swift */,
 				27D3A271598E0C2FBD9B61A2 /* NotificationDismissalServiceTests.swift */,
 				15FD7B9C41B2CEBE275DFBCF /* NotificationIntegrationTests.swift */,
@@ -858,6 +864,7 @@
 				8412219386D826F79CA5DBC8 /* FormattingTests.swift in Sources */,
 				D6085DBDEE6689987FC5518D /* LocationServiceTests.swift in Sources */,
 				27A0391303646CF5E48C1247 /* LogMedicationViewModelTests.swift in Sources */,
+				116097B18DA82FE412F3C5BA /* MedicationCooldownTests.swift in Sources */,
 				62050772CC4D955CEB7AB14F /* MedicationDetailViewModelTests.swift in Sources */,
 				5526658ACE024ED2751F7B58 /* MedicationNotificationServiceTests.swift in Sources */,
 				C17D7AFF287E53975932CED3 /* MedicationRepositoryTests.swift in Sources */,
@@ -935,6 +942,7 @@
 				540E206542F9813929D8AB75 /* LogMedicationViewModel.swift in Sources */,
 				2A1B4DD1A4D7094B0FF06414 /* LogUpdateScreen.swift in Sources */,
 				796AFB13119C6E3D86504CA8 /* Logger.swift in Sources */,
+				D6173D2C08ED96EB11691B30 /* MedicationCooldown.swift in Sources */,
 				42F105DE5B8A28F59DED8D65 /* MedicationDetailScreen.swift in Sources */,
 				2247422882867F75EF1E622A /* MedicationDetailViewModel.swift in Sources */,
 				7F1E89BCE3CA857B918126AE /* MedicationNotificationService.swift in Sources */,

--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -4,7 +4,7 @@ import GRDB
 /// Central database manager. Owns the DatabaseQueue and handles schema creation/migration.
 final class DatabaseManager: Sendable {
     /// The current schema version
-    static let schemaVersion = 25
+    static let schemaVersion = 26
 
     /// Shared singleton for the app's main database
     static let shared = DatabaseManager()
@@ -99,6 +99,19 @@ final class DatabaseManager: Sendable {
             try DatabaseManager.createSchema(in: db)
         }
 
+        // v26: Add medication cooldown (minimum interval between doses).
+        // Fresh installs already create the column in v25's CREATE TABLE, so only
+        // add it when missing to support both upgrade and fresh-install paths.
+        migrator.registerMigration("v26") { db in
+            let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(medications)")
+            let hasColumn = columns.contains { (row: Row) in
+                (row["name"] as String?) == "min_interval_hours"
+            }
+            if !hasColumn {
+                try db.execute(sql: "ALTER TABLE medications ADD COLUMN min_interval_hours REAL")
+            }
+        }
+
         return migrator
     }
 
@@ -191,7 +204,8 @@ final class DatabaseManager: Sendable {
                 notes TEXT CHECK(notes IS NULL OR length(notes) <= 5000),
                 category TEXT CHECK(category IS NULL OR category IN ('otc', 'nsaid', 'triptan', 'cgrp', 'preventive', 'supplement', 'other')),
                 created_at INTEGER NOT NULL CHECK(created_at > 0),
-                updated_at INTEGER NOT NULL CHECK(updated_at > 0)
+                updated_at INTEGER NOT NULL CHECK(updated_at > 0),
+                min_interval_hours REAL CHECK(min_interval_hours IS NULL OR min_interval_hours > 0)
             )
             """)
 

--- a/mobile-apps/ios/MigraLog/Models/DomainModels.swift
+++ b/mobile-apps/ios/MigraLog/Models/DomainModels.swift
@@ -100,6 +100,7 @@ struct Medication: Identifiable, Equatable, Sendable {
     var active: Bool
     var notes: String?
     var category: MedicationCategory?
+    var minIntervalHours: Double?
     let createdAt: Int64
     var updatedAt: Int64
 }

--- a/mobile-apps/ios/MigraLog/Repositories/MedicationRepository.swift
+++ b/mobile-apps/ios/MigraLog/Repositories/MedicationRepository.swift
@@ -17,8 +17,9 @@ final class MedicationRepository: MedicationRepositoryProtocol {
             try db.execute(
                 sql: """
                     INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, default_quantity,
-                        schedule_frequency, photo_uri, active, notes, category, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        schedule_frequency, photo_uri, active, notes, category, created_at, updated_at,
+                        min_interval_hours)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                 arguments: [
                     medication.id,
@@ -33,7 +34,8 @@ final class MedicationRepository: MedicationRepositoryProtocol {
                     medication.notes,
                     medication.category?.rawValue,
                     medication.createdAt,
-                    medication.updatedAt
+                    medication.updatedAt,
+                    medication.minIntervalHours
                 ]
             )
         }
@@ -84,7 +86,8 @@ final class MedicationRepository: MedicationRepositoryProtocol {
                     UPDATE medications SET
                         name = ?, type = ?, dosage_amount = ?, dosage_unit = ?,
                         default_quantity = ?, schedule_frequency = ?, photo_uri = ?,
-                        active = ?, notes = ?, category = ?, updated_at = ?
+                        active = ?, notes = ?, category = ?, updated_at = ?,
+                        min_interval_hours = ?
                     WHERE id = ?
                     """,
                 arguments: [
@@ -99,6 +102,7 @@ final class MedicationRepository: MedicationRepositoryProtocol {
                     updated.notes,
                     updated.category?.rawValue,
                     updated.updatedAt,
+                    updated.minIntervalHours,
                     updated.id
                 ]
             )
@@ -160,6 +164,17 @@ final class MedicationRepository: MedicationRepositoryProtocol {
             )
         }
         return dose
+    }
+
+    func getLastDose(medicationId: String) throws -> MedicationDose? {
+        try dbManager.dbQueue.read { db in
+            let row = try Row.fetchOne(
+                db,
+                sql: "SELECT * FROM medication_doses WHERE medication_id = ? AND status = 'taken' ORDER BY timestamp DESC LIMIT 1",
+                arguments: [medicationId]
+            )
+            return row.map { Self.doseFromRow($0) }
+        }
     }
 
     func getDosesByMedicationId(_ medicationId: String) throws -> [MedicationDose] {
@@ -415,6 +430,7 @@ final class MedicationRepository: MedicationRepositoryProtocol {
             active: (row["active"] as Int) != 0,
             notes: row["notes"],
             category: (row["category"] as String?).flatMap { MedicationCategory(rawValue: $0) },
+            minIntervalHours: row["min_interval_hours"],
             createdAt: row["created_at"],
             updatedAt: row["updated_at"]
         )

--- a/mobile-apps/ios/MigraLog/Repositories/Protocols.swift
+++ b/mobile-apps/ios/MigraLog/Repositories/Protocols.swift
@@ -59,6 +59,7 @@ protocol MedicationRepositoryProtocol: Sendable {
 
     // Doses
     func createDose(_ dose: MedicationDose) throws -> MedicationDose
+    func getLastDose(medicationId: String) throws -> MedicationDose?
     func getDosesByMedicationId(_ medicationId: String) throws -> [MedicationDose]
     func getDosesByEpisodeId(_ episodeId: String) throws -> [MedicationDose]
     func getDosesByDateRange(start: Int64, end: Int64) throws -> [MedicationDose]

--- a/mobile-apps/ios/MigraLog/Services/MedicationCooldown.swift
+++ b/mobile-apps/ios/MigraLog/Services/MedicationCooldown.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Pure functions for evaluating medication dose cooldown state.
+enum MedicationCooldown {
+    struct Status: Equatable {
+        let isOnCooldown: Bool
+        let hoursSinceLastDose: Double?  // nil if no prior dose
+        let hoursUntilNextDose: Double   // 0 if not on cooldown
+        let minIntervalHours: Double?
+    }
+
+    static func evaluate(
+        medication: Medication,
+        lastDose: MedicationDose?,
+        now: Date = Date()
+    ) -> Status {
+        guard let interval = medication.minIntervalHours, interval > 0 else {
+            return Status(
+                isOnCooldown: false,
+                hoursSinceLastDose: nil,
+                hoursUntilNextDose: 0,
+                minIntervalHours: nil
+            )
+        }
+        guard let last = lastDose else {
+            return Status(
+                isOnCooldown: false,
+                hoursSinceLastDose: nil,
+                hoursUntilNextDose: 0,
+                minIntervalHours: interval
+            )
+        }
+        let elapsed = now.timeIntervalSince(last.date) / 3600.0
+        let remaining = max(0, interval - elapsed)
+        return Status(
+            isOnCooldown: remaining > 0,
+            hoursSinceLastDose: elapsed,
+            hoursUntilNextDose: remaining,
+            minIntervalHours: interval
+        )
+    }
+
+    /// Short human-friendly summary: "Last dose 3h ago — wait 21h"
+    static func summary(_ status: Status) -> String? {
+        guard let elapsed = status.hoursSinceLastDose else { return nil }
+        let elapsedStr = formatHours(elapsed)
+        if status.isOnCooldown {
+            let waitStr = formatHours(status.hoursUntilNextDose)
+            return "Last dose \(elapsedStr) ago — wait \(waitStr)"
+        } else {
+            return "Last dose \(elapsedStr) ago"
+        }
+    }
+
+    private static func formatHours(_ hours: Double) -> String {
+        if hours < 1 {
+            let minutes = Int((hours * 60).rounded())
+            return "\(minutes)m"
+        } else if hours < 24 {
+            return String(format: "%.1fh", hours)
+        } else {
+            return String(format: "%.1fd", hours / 24)
+        }
+    }
+}

--- a/mobile-apps/ios/MigraLog/ViewModels/AddMedicationViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/AddMedicationViewModel.swift
@@ -12,6 +12,7 @@ final class AddMedicationViewModel {
     var category: MedicationCategory?
     var scheduleFrequency: ScheduleFrequency?
     var notes: String = ""
+    var minIntervalHours: Double?
     var searchResults: [PresetMedication] = []
     var isSaving = false
     var error: String?
@@ -36,6 +37,7 @@ final class AddMedicationViewModel {
             category = med.category
             scheduleFrequency = med.scheduleFrequency
             notes = med.notes ?? ""
+            minIntervalHours = med.minIntervalHours
         }
     }
 
@@ -85,6 +87,7 @@ final class AddMedicationViewModel {
                 active: true,
                 notes: notes.isEmpty ? nil : notes,
                 category: category,
+                minIntervalHours: minIntervalHours,
                 createdAt: now, // will be ignored on update
                 updatedAt: now
             )
@@ -112,6 +115,7 @@ final class AddMedicationViewModel {
                 active: true,
                 notes: notes.isEmpty ? nil : notes,
                 category: category,
+                minIntervalHours: minIntervalHours,
                 createdAt: now,
                 updatedAt: now
             )

--- a/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
@@ -21,7 +21,10 @@ final class DashboardViewModel {
     var recentEpisodes: [Episode] = []
     var recentReadings: [String: [IntensityReading]] = [:]
     var todaysMedications: [MedicationScheduleItem] = []
+    /// Most recent taken dose per medication id (across all time). Used for cooldown warnings.
+    var lastDoseByMedication: [String: MedicationDose] = [:]
     var yesterdayStatus: DailyStatusLog?
+    var shouldShowYesterdayPrompt: Bool = false
     var showNewEpisode = false
     var showLogMedication = false
     var isLoading = false
@@ -64,11 +67,14 @@ final class DashboardViewModel {
             async let recentTask = loadRecentEpisodes()
             async let medsTask = loadTodaysMedications()
             async let statusTask = loadYesterdayStatus()
+            async let yesterdayHasEpisodeTask = yesterdayHasEpisode()
 
             currentEpisode = try await episodeTask
             recentEpisodes = try await recentTask
             todaysMedications = try await medsTask
             yesterdayStatus = try await statusTask
+            let hasEpisodeYesterday = try await yesterdayHasEpisodeTask
+            shouldShowYesterdayPrompt = yesterdayStatus == nil && !hasEpisodeYesterday
 
             // Load active episode readings for dashboard sparkline
             if let active = currentEpisode,
@@ -107,6 +113,7 @@ final class DashboardViewModel {
             if let index = todaysMedications.firstIndex(where: { $0.id == scheduleItem.id }) {
                 todaysMedications[index].dose = savedDose
             }
+            lastDoseByMedication[scheduleItem.medication.id] = savedDose
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "DashboardViewModel", "action": "logDose"])
             self.error = error.localizedDescription
@@ -175,6 +182,7 @@ final class DashboardViewModel {
         do {
             let saved = try await dailyStatusRepository.createStatus(statusLog)
             yesterdayStatus = saved
+            shouldShowYesterdayPrompt = false
             // Cancel daily check-in for this date and top up
             await dailyCheckinService.cancelForDate(dateString)
             await dailyCheckinService.topUp()
@@ -190,6 +198,9 @@ final class DashboardViewModel {
         do {
             try await dailyStatusRepository.deleteStatus(status.id)
             yesterdayStatus = nil
+            // Re-evaluate prompt visibility: if yesterday has an episode, keep hidden.
+            let hasEpisodeYesterday = (try? await yesterdayHasEpisode()) ?? false
+            shouldShowYesterdayPrompt = !hasEpisodeYesterday
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "DashboardViewModel", "action": "undoYesterdayStatus"])
             self.error = error.localizedDescription
@@ -218,8 +229,12 @@ final class DashboardViewModel {
         let todayDoses = try await medicationRepository.getDosesWithMedications(date: today)
 
         var items: [MedicationScheduleItem] = []
+        var lastDoses: [String: MedicationDose] = [:]
         for med in activeMeds {
             let schedules = try await medicationRepository.getSchedules(medicationId: med.id)
+            if let last = try? medicationRepository.getLastDose(medicationId: med.id) {
+                lastDoses[med.id] = last
+            }
             for schedule in schedules where schedule.enabled {
                 let matchingDose = todayDoses.first { doseWithMed in
                     doseWithMed.medication.id == med.id
@@ -231,6 +246,7 @@ final class DashboardViewModel {
                 ))
             }
         }
+        await MainActor.run { lastDoseByMedication = lastDoses }
         return items
     }
 
@@ -238,5 +254,23 @@ final class DashboardViewModel {
         let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
         let dateString = TimestampHelper.dateString(from: yesterday)
         return try await dailyStatusRepository.getStatusByDate(dateString)
+    }
+
+    /// Returns true if any episode overlaps yesterday (midnight-to-midnight).
+    private func yesterdayHasEpisode() async throws -> Bool {
+        let calendar = Calendar.current
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: Date())!
+        let dayStart = calendar.startOfDay(for: yesterday)
+        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart)!
+        let dayStartMs = TimestampHelper.fromDate(dayStart)
+        let dayEndMs = TimestampHelper.fromDate(dayEnd)
+
+        // Pull a wider range by start-time to catch episodes that began before yesterday
+        // but are still active or ended yesterday. Use all episodes and filter locally,
+        // since getEpisodesByDateRange filters on startTime only.
+        let all = try episodeRepository.getAllEpisodes()
+        return all.contains { ep in
+            ep.startTime < dayEndMs && (ep.endTime ?? Int64.max) > dayStartMs
+        }
     }
 }

--- a/mobile-apps/ios/MigraLog/ViewModels/LogMedicationViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/LogMedicationViewModel.swift
@@ -4,6 +4,8 @@ import Observation
 @Observable
 final class LogMedicationViewModel {
     var medications: [Medication] = []
+    /// Most recent taken dose per medication id. Used for cooldown warnings.
+    var lastDoseByMedication: [String: MedicationDose] = [:]
     var isLoading = false
 
     private let medicationRepository: MedicationRepositoryProtocol
@@ -23,6 +25,13 @@ final class LogMedicationViewModel {
         do {
             let results = try await medicationRepository.getActiveMedicationsWithUsageCounts()
             medications = results.sorted { $0.usageCount > $1.usageCount }.map(\.medication)
+            var lastDoses: [String: MedicationDose] = [:]
+            for med in medications {
+                if let last = try? medicationRepository.getLastDose(medicationId: med.id) {
+                    lastDoses[med.id] = last
+                }
+            }
+            lastDoseByMedication = lastDoses
             isLoading = false
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "LogMedicationViewModel"])

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -139,58 +139,60 @@ struct DailyStatusWidgetView: View {
     @Bindable var viewModel: DashboardViewModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            if let yesterdayStatus = viewModel.yesterdayStatus {
-                HStack {
-                    Text("Yesterday logged as \(yesterdayStatus.status.displayName) day")
-                        .font(.subheadline)
-                    Spacer()
-                    Button("Undo") {
-                        Task { await viewModel.undoYesterdayStatus() }
-                    }
-                    .accessibilityIdentifier("undo-status-button")
-                }
-                .accessibilityIdentifier("daily-status-widget-logged")
-            } else {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("How was yesterday?")
-                        .font(.headline)
-
-                    HStack(spacing: 12) {
-                        Button {
-                            Task { await viewModel.logYesterdayStatus(.green) }
-                        } label: {
-                            Text("Clear")
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 10)
-                                .background(Color.green.opacity(0.2))
-                                .foregroundStyle(.green)
-                                .clipShape(RoundedRectangle(cornerRadius: 12))
+        if viewModel.yesterdayStatus != nil || viewModel.shouldShowYesterdayPrompt {
+            VStack(alignment: .leading, spacing: 8) {
+                if let yesterdayStatus = viewModel.yesterdayStatus {
+                    HStack {
+                        Text("Yesterday logged as \(yesterdayStatus.status.displayName) day")
+                            .font(.subheadline)
+                        Spacer()
+                        Button("Undo") {
+                            Task { await viewModel.undoYesterdayStatus() }
                         }
-                        .accessibilityLabel("Clear day")
-                        .accessibilityIdentifier("green-day-button")
-
-                        Button {
-                            Task { await viewModel.logYesterdayStatus(.yellow) }
-                        } label: {
-                            Text("Not Clear")
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 10)
-                                .background(Color.yellow.opacity(0.2))
-                                .foregroundStyle(.orange)
-                                .clipShape(RoundedRectangle(cornerRadius: 12))
-                        }
-                        .accessibilityLabel("Not clear day")
-                        .accessibilityIdentifier("yellow-day-button")
+                        .accessibilityIdentifier("undo-status-button")
                     }
+                    .accessibilityIdentifier("daily-status-widget-logged")
+                } else {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("How was yesterday?")
+                            .font(.headline)
+
+                        HStack(spacing: 12) {
+                            Button {
+                                Task { await viewModel.logYesterdayStatus(.green) }
+                            } label: {
+                                Text("Clear")
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 10)
+                                    .background(Color.green.opacity(0.2))
+                                    .foregroundStyle(.green)
+                                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                            }
+                            .accessibilityLabel("Clear day")
+                            .accessibilityIdentifier("green-day-button")
+
+                            Button {
+                                Task { await viewModel.logYesterdayStatus(.yellow) }
+                            } label: {
+                                Text("Not Clear")
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 10)
+                                    .background(Color.yellow.opacity(0.2))
+                                    .foregroundStyle(.orange)
+                                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                            }
+                            .accessibilityLabel("Not clear day")
+                            .accessibilityIdentifier("yellow-day-button")
+                        }
+                    }
+                    .accessibilityIdentifier("daily-status-widget")
                 }
-                .accessibilityIdentifier("daily-status-widget")
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding()
-        .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 }
 
@@ -224,6 +226,7 @@ struct TodaysMedicationsCard: View {
 struct MedicationScheduleRow: View {
     let item: MedicationScheduleItem
     @Bindable var viewModel: DashboardViewModel
+    @Environment(\.horizontalSizeClass) private var sizeClass
 
     private var doseLabel: String {
         MedicationFormatting.formatDose(
@@ -233,50 +236,76 @@ struct MedicationScheduleRow: View {
         )
     }
 
+    private var cooldownStatus: MedicationCooldown.Status {
+        MedicationCooldown.evaluate(
+            medication: item.medication,
+            lastDose: viewModel.lastDoseByMedication[item.medication.id]
+        )
+    }
+
     var body: some View {
-        HStack {
-            Text(item.medication.name)
-                .font(.subheadline.weight(.medium))
+        let status = cooldownStatus
+        let showCooldownBanner = sizeClass == .regular && status.isOnCooldown && item.dose == nil
 
-            Spacer()
+        VStack(alignment: .leading, spacing: 4) {
+            if showCooldownBanner, let summary = MedicationCooldown.summary(status) {
+                Label(summary, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .accessibilityIdentifier("cooldown-warning-\(item.medication.id)")
+            }
 
-            if let dose = item.dose {
-                if dose.status == .taken {
-                    Label("Taken at \(DateFormatting.displayTime(dose.date))", systemImage: "checkmark.circle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.green)
+            HStack {
+                Text(item.medication.name)
+                    .font(.subheadline.weight(.medium))
+
+                Spacer()
+
+                if let dose = item.dose {
+                    if dose.status == .taken {
+                        Label("Taken at \(DateFormatting.displayTime(dose.date))", systemImage: "checkmark.circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.green)
+                    } else {
+                        Label("Skipped", systemImage: "xmark.circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                    Button("Undo") {
+                        Task { await viewModel.undoDose(scheduleItem: item) }
+                    }
+                    .font(.caption)
                 } else {
-                    Label("Skipped", systemImage: "xmark.circle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                }
-                Button("Undo") {
-                    Task { await viewModel.undoDose(scheduleItem: item) }
-                }
-                .font(.caption)
-            } else {
-                Button {
-                    Task { await viewModel.logDose(scheduleItem: item) }
-                } label: {
-                    Text("Log \(doseLabel)")
+                    Button {
+                        Task { await viewModel.logDose(scheduleItem: item) }
+                    } label: {
+                        HStack(spacing: 4) {
+                            if status.isOnCooldown {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundStyle(.orange)
+                                    .accessibilityIdentifier("cooldown-icon-\(item.medication.id)")
+                            }
+                            Text("Log \(doseLabel)")
+                        }
                         .font(.caption.weight(.medium))
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
                         .background(Color.accentColor)
                         .foregroundStyle(.white)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
-                }
+                    }
 
-                Button {
-                    Task { await viewModel.skipDose(scheduleItem: item) }
-                } label: {
-                    Text("Skip")
-                        .font(.caption.weight(.medium))
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                        .background(Color.red.opacity(0.15))
-                        .foregroundStyle(.red)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                    Button {
+                        Task { await viewModel.skipDose(scheduleItem: item) }
+                    } label: {
+                        Text("Skip")
+                            .font(.caption.weight(.medium))
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Color.red.opacity(0.15))
+                            .foregroundStyle(.red)
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
                 }
             }
         }

--- a/mobile-apps/ios/MigraLog/Views/Medications/AddMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/AddMedicationScreen.swift
@@ -15,6 +15,7 @@ struct AddMedicationScreen: View {
     @State private var isSaving = false
     @State private var reminderTime = AddMedicationScreen.defaultMorningTime()
     @State private var reminderEnabled = true
+    @State private var minIntervalHoursText: String = ""
 
     var body: some View {
         Form {
@@ -110,6 +111,16 @@ struct AddMedicationScreen: View {
                 }
             }
 
+            Section {
+                TextField("Hours (e.g. 24)", text: $minIntervalHoursText)
+                    .keyboardType(.decimalPad)
+                    .accessibilityIdentifier("add-med-min-interval-hours")
+            } header: {
+                Text("Minimum Time Between Doses")
+            } footer: {
+                Text("Leave blank if there's no minimum interval")
+            }
+
             Section("Notes") {
                 TextEditor(text: $notes)
                     .frame(minHeight: 60)
@@ -165,6 +176,7 @@ struct AddMedicationScreen: View {
             active: true,
             notes: notes.isEmpty ? nil : notes,
             category: category,
+            minIntervalHours: Double(minIntervalHoursText).flatMap { $0 > 0 ? $0 : nil },
             createdAt: now,
             updatedAt: now
         )

--- a/mobile-apps/ios/MigraLog/Views/Medications/EditMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/EditMedicationScreen.swift
@@ -11,6 +11,7 @@ struct EditMedicationScreen: View {
     @State private var defaultQuantity: String
     @State private var notes: String
     @State private var category: MedicationCategory?
+    @State private var minIntervalHoursText: String
     @State private var isSaving = false
 
     init(medication: Medication, viewModel: MedicationDetailViewModel) {
@@ -24,6 +25,9 @@ struct EditMedicationScreen: View {
         } ?? "1")
         _notes = State(initialValue: medication.notes ?? "")
         _category = State(initialValue: medication.category)
+        _minIntervalHoursText = State(initialValue: medication.minIntervalHours.map {
+            $0.truncatingRemainder(dividingBy: 1) == 0 ? String(Int($0)) : String($0)
+        } ?? "")
     }
 
     var body: some View {
@@ -63,6 +67,15 @@ struct EditMedicationScreen: View {
                     }
                 }
             }
+            Section {
+                TextField("Hours (e.g. 24)", text: $minIntervalHoursText)
+                    .keyboardType(.decimalPad)
+                    .accessibilityIdentifier("edit-med-min-interval-hours")
+            } header: {
+                Text("Minimum Time Between Doses")
+            } footer: {
+                Text("Leave blank if there's no minimum interval")
+            }
             Section("Notes") {
                 TextEditor(text: $notes)
                     .frame(minHeight: 60)
@@ -95,6 +108,7 @@ struct EditMedicationScreen: View {
         updated.defaultQuantity = Double(defaultQuantity).flatMap { $0 > 0 ? $0 : nil }
         updated.notes = notes.isEmpty ? nil : notes
         updated.category = category
+        updated.minIntervalHours = Double(minIntervalHoursText).flatMap { $0 > 0 ? $0 : nil }
         updated.updatedAt = TimestampHelper.now
 
         await viewModel.updateMedication(updated)

--- a/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
@@ -23,6 +23,7 @@ struct LogMedicationScreen: View {
                     ForEach(allMeds) { med in
                         LogMedicationCard(
                             medication: med,
+                            lastDose: viewModel.lastDoseByMedication[med.id],
                             onQuickLog: {
                                 Task {
                                     await quickLog(med)
@@ -71,10 +72,17 @@ struct LogMedicationScreen: View {
 
 struct LogMedicationCard: View {
     let medication: Medication
+    var lastDose: MedicationDose? = nil
     let onQuickLog: () -> Void
     let onDetails: () -> Void
+    @Environment(\.horizontalSizeClass) private var sizeClass
+
+    private var cooldownStatus: MedicationCooldown.Status {
+        MedicationCooldown.evaluate(medication: medication, lastDose: lastDose)
+    }
 
     var body: some View {
+        let status = cooldownStatus
         VStack(alignment: .leading, spacing: 12) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(medication.name)
@@ -84,14 +92,28 @@ struct LogMedicationCard: View {
                     .foregroundStyle(.secondary)
             }
 
+            if sizeClass == .regular, status.isOnCooldown, let summary = MedicationCooldown.summary(status) {
+                Label(summary, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .accessibilityIdentifier("cooldown-warning-\(medication.id)")
+            }
+
             HStack(spacing: 8) {
                 Button(action: onQuickLog) {
-                    Text("Log \(MedicationFormatting.formatDose(quantity: medication.defaultQuantity ?? 1, amount: medication.dosageAmount, unit: medication.dosageUnit))")
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 12)
-                        .background(Color.accentColor)
-                        .foregroundStyle(.white)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                    HStack(spacing: 6) {
+                        if status.isOnCooldown {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                                .accessibilityIdentifier("cooldown-icon-\(medication.id)")
+                        }
+                        Text("Log \(MedicationFormatting.formatDose(quantity: medication.defaultQuantity ?? 1, amount: medication.dosageAmount, unit: medication.dosageUnit))")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(Color.accentColor)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
 
                 Button(action: onDetails) {

--- a/mobile-apps/ios/MigraLog/Views/Medications/MedicationDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/MedicationDetailScreen.swift
@@ -12,6 +12,12 @@ struct MedicationDetailScreen: View {
     @State private var showAddSchedule = false
     @State private var showEditSchedule: MedicationSchedule? = nil
     @State private var showLogDoseDetails = false
+    @Environment(\.horizontalSizeClass) private var sizeClass
+
+    private func cooldownStatus(_ medication: Medication) -> MedicationCooldown.Status {
+        let lastTakenDose = viewModel.recentDoses.first(where: { $0.status == .taken })
+        return MedicationCooldown.evaluate(medication: medication, lastDose: lastTakenDose)
+    }
 
     var body: some View {
         Group {
@@ -24,16 +30,36 @@ struct MedicationDetailScreen: View {
                         // Schedules
                         schedulesSection(medication)
 
+                        // Cooldown warning banner (iPad / regular size class)
+                        let status = cooldownStatus(medication)
+                        if sizeClass == .regular, status.isOnCooldown, let summary = MedicationCooldown.summary(status) {
+                            Label(summary, systemImage: "exclamationmark.triangle.fill")
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(.orange)
+                                .padding()
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Color.orange.opacity(0.1))
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                                .accessibilityIdentifier("cooldown-banner")
+                        }
+
                         // Log dose button — opens details sheet pre-filled to now
                         Button {
                             showLogDoseDetails = true
                         } label: {
-                            Label("Log Dose", systemImage: "plus.circle.fill")
-                                .frame(maxWidth: .infinity)
-                                .padding()
-                                .background(Color.accentColor)
-                                .foregroundStyle(.white)
-                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                            HStack {
+                                if status.isOnCooldown {
+                                    Image(systemName: "exclamationmark.triangle.fill")
+                                        .foregroundStyle(.orange)
+                                        .accessibilityIdentifier("cooldown-icon")
+                                }
+                                Label("Log Dose", systemImage: "plus.circle.fill")
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.accentColor)
+                            .foregroundStyle(.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
                         }
                         .accessibilityIdentifier("log-dose-button")
 

--- a/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
@@ -182,7 +182,7 @@ final class DatabaseManagerTests: XCTestCase {
     // MARK: - Schema Version
 
     func testSchemaVersionIsTracked() throws {
-        XCTAssertEqual(DatabaseManager.schemaVersion, 25)
+        XCTAssertEqual(DatabaseManager.schemaVersion, 26)
     }
 
     func testMigrationIsRecordedInGRDB() throws {

--- a/mobile-apps/ios/MigraLogTests/MockRepositories.swift
+++ b/mobile-apps/ios/MigraLogTests/MockRepositories.swift
@@ -353,6 +353,14 @@ final class MockMedicationRepository: MedicationRepositoryProtocol, @unchecked S
         return doses.filter { $0.medicationId == medicationId }.sorted { $0.timestamp > $1.timestamp }
     }
 
+    func getLastDose(medicationId: String) throws -> MedicationDose? {
+        try throwIfNeeded()
+        return doses
+            .filter { $0.medicationId == medicationId && $0.status == .taken }
+            .sorted { $0.timestamp > $1.timestamp }
+            .first
+    }
+
     func getDosesByEpisodeId(_ episodeId: String) throws -> [MedicationDose] {
         try throwIfNeeded()
         return doses.filter { $0.episodeId == episodeId }
@@ -733,7 +741,8 @@ enum TestFixtures {
         dosageUnit: String = "mg",
         active: Bool = true,
         category: MedicationCategory? = .nsaid,
-        scheduleFrequency: ScheduleFrequency? = nil
+        scheduleFrequency: ScheduleFrequency? = nil,
+        minIntervalHours: Double? = nil
     ) -> Medication {
         Medication(
             id: id,
@@ -747,6 +756,7 @@ enum TestFixtures {
             active: active,
             notes: nil,
             category: category,
+            minIntervalHours: minIntervalHours,
             createdAt: now,
             updatedAt: now
         )

--- a/mobile-apps/ios/MigraLogTests/Services/MedicationCooldownTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/MedicationCooldownTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import MigraLog
+
+final class MedicationCooldownTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - No interval configured
+
+    func testEvaluate_noIntervalConfigured_returnsNotOnCooldown() {
+        let medication = TestFixtures.makeMedication(minIntervalHours: nil)
+        let dose = TestFixtures.makeDose(medicationId: medication.id, timestamp: TimestampHelper.fromDate(now))
+
+        let status = MedicationCooldown.evaluate(medication: medication, lastDose: dose, now: now)
+
+        XCTAssertFalse(status.isOnCooldown)
+        XCTAssertNil(status.hoursSinceLastDose)
+        XCTAssertEqual(status.hoursUntilNextDose, 0)
+        XCTAssertNil(status.minIntervalHours)
+    }
+
+    func testEvaluate_zeroInterval_treatedAsNoCooldown() {
+        let medication = TestFixtures.makeMedication(minIntervalHours: 0)
+
+        let status = MedicationCooldown.evaluate(medication: medication, lastDose: nil, now: now)
+
+        XCTAssertFalse(status.isOnCooldown)
+        XCTAssertNil(status.minIntervalHours)
+    }
+
+    // MARK: - No prior dose
+
+    func testEvaluate_noLastDose_returnsNotOnCooldown() {
+        let medication = TestFixtures.makeMedication(minIntervalHours: 24)
+
+        let status = MedicationCooldown.evaluate(medication: medication, lastDose: nil, now: now)
+
+        XCTAssertFalse(status.isOnCooldown)
+        XCTAssertNil(status.hoursSinceLastDose)
+        XCTAssertEqual(status.hoursUntilNextDose, 0)
+        XCTAssertEqual(status.minIntervalHours, 24)
+    }
+
+    // MARK: - On cooldown
+
+    func testEvaluate_onCooldown_returnsPositiveRemaining() {
+        let medication = TestFixtures.makeMedication(minIntervalHours: 24)
+        // last dose 3 hours ago
+        let lastDate = now.addingTimeInterval(-3 * 3600)
+        let dose = TestFixtures.makeDose(
+            medicationId: medication.id,
+            timestamp: TimestampHelper.fromDate(lastDate)
+        )
+
+        let status = MedicationCooldown.evaluate(medication: medication, lastDose: dose, now: now)
+
+        XCTAssertTrue(status.isOnCooldown)
+        XCTAssertEqual(status.hoursSinceLastDose ?? 0, 3.0, accuracy: 0.001)
+        XCTAssertEqual(status.hoursUntilNextDose, 21.0, accuracy: 0.001)
+        XCTAssertEqual(status.minIntervalHours, 24)
+    }
+
+    // MARK: - Off cooldown
+
+    func testEvaluate_offCooldown_returnsZeroRemaining() {
+        let medication = TestFixtures.makeMedication(minIntervalHours: 6)
+        // last dose 10 hours ago
+        let lastDate = now.addingTimeInterval(-10 * 3600)
+        let dose = TestFixtures.makeDose(
+            medicationId: medication.id,
+            timestamp: TimestampHelper.fromDate(lastDate)
+        )
+
+        let status = MedicationCooldown.evaluate(medication: medication, lastDose: dose, now: now)
+
+        XCTAssertFalse(status.isOnCooldown)
+        XCTAssertEqual(status.hoursSinceLastDose ?? 0, 10.0, accuracy: 0.001)
+        XCTAssertEqual(status.hoursUntilNextDose, 0)
+    }
+
+    // MARK: - Boundary
+
+    func testEvaluate_exactlyAtIntervalBoundary_isNotOnCooldown() {
+        let medication = TestFixtures.makeMedication(minIntervalHours: 6)
+        // last dose exactly 6 hours ago
+        let lastDate = now.addingTimeInterval(-6 * 3600)
+        let dose = TestFixtures.makeDose(
+            medicationId: medication.id,
+            timestamp: TimestampHelper.fromDate(lastDate)
+        )
+
+        let status = MedicationCooldown.evaluate(medication: medication, lastDose: dose, now: now)
+
+        XCTAssertFalse(status.isOnCooldown)
+        XCTAssertEqual(status.hoursUntilNextDose, 0, accuracy: 0.001)
+    }
+
+    func testEvaluate_justBeforeBoundary_isOnCooldown() {
+        let medication = TestFixtures.makeMedication(minIntervalHours: 6)
+        // last dose 5h 59m ago
+        let lastDate = now.addingTimeInterval(-((6 * 3600) - 60))
+        let dose = TestFixtures.makeDose(
+            medicationId: medication.id,
+            timestamp: TimestampHelper.fromDate(lastDate)
+        )
+
+        let status = MedicationCooldown.evaluate(medication: medication, lastDose: dose, now: now)
+
+        XCTAssertTrue(status.isOnCooldown)
+        XCTAssertGreaterThan(status.hoursUntilNextDose, 0)
+    }
+
+    // MARK: - summary formatting
+
+    func testSummary_onCooldown_includesWait() {
+        let medication = TestFixtures.makeMedication(minIntervalHours: 24)
+        let lastDate = now.addingTimeInterval(-3 * 3600)
+        let dose = TestFixtures.makeDose(
+            medicationId: medication.id,
+            timestamp: TimestampHelper.fromDate(lastDate)
+        )
+        let status = MedicationCooldown.evaluate(medication: medication, lastDose: dose, now: now)
+
+        let summary = MedicationCooldown.summary(status)
+
+        XCTAssertNotNil(summary)
+        XCTAssertTrue(summary?.contains("wait") ?? false, "Expected summary to contain 'wait', got \(summary ?? "nil")")
+        XCTAssertTrue(summary?.contains("ago") ?? false)
+    }
+
+    func testSummary_offCooldownWithPriorDose_agoOnly() {
+        let medication = TestFixtures.makeMedication(minIntervalHours: 6)
+        let lastDate = now.addingTimeInterval(-10 * 3600)
+        let dose = TestFixtures.makeDose(
+            medicationId: medication.id,
+            timestamp: TimestampHelper.fromDate(lastDate)
+        )
+        let status = MedicationCooldown.evaluate(medication: medication, lastDose: dose, now: now)
+
+        let summary = MedicationCooldown.summary(status)
+
+        XCTAssertNotNil(summary)
+        XCTAssertTrue(summary?.contains("ago") ?? false)
+        XCTAssertFalse(summary?.contains("wait") ?? true)
+    }
+
+    func testSummary_noPriorDose_returnsNil() {
+        let medication = TestFixtures.makeMedication(minIntervalHours: 24)
+        let status = MedicationCooldown.evaluate(medication: medication, lastDose: nil, now: now)
+
+        XCTAssertNil(MedicationCooldown.summary(status))
+    }
+
+    func testSummary_minutesFormatting_whenUnderOneHour() {
+        let medication = TestFixtures.makeMedication(minIntervalHours: 6)
+        // last dose 30 minutes ago
+        let lastDate = now.addingTimeInterval(-30 * 60)
+        let dose = TestFixtures.makeDose(
+            medicationId: medication.id,
+            timestamp: TimestampHelper.fromDate(lastDate)
+        )
+        let status = MedicationCooldown.evaluate(medication: medication, lastDose: dose, now: now)
+
+        let summary = MedicationCooldown.summary(status)
+
+        XCTAssertNotNil(summary)
+        XCTAssertTrue(summary?.contains("30m") ?? false, "Expected '30m' in summary, got \(summary ?? "nil")")
+    }
+
+    func testSummary_daysFormatting_whenOver24Hours() {
+        let medication = TestFixtures.makeMedication(minIntervalHours: 72)
+        // last dose 48 hours ago
+        let lastDate = now.addingTimeInterval(-48 * 3600)
+        let dose = TestFixtures.makeDose(
+            medicationId: medication.id,
+            timestamp: TimestampHelper.fromDate(lastDate)
+        )
+        let status = MedicationCooldown.evaluate(medication: medication, lastDose: dose, now: now)
+
+        let summary = MedicationCooldown.summary(status)
+
+        XCTAssertNotNil(summary)
+        XCTAssertTrue(summary?.contains("d") ?? false, "Expected days formatting in summary, got \(summary ?? "nil")")
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/ViewModels/DashboardViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/DashboardViewModelTests.swift
@@ -74,6 +74,54 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertNil(sut.yesterdayStatus)
     }
 
+    // MARK: - Yesterday Prompt Visibility
+
+    func testLoadData_noStatusNoEpisode_showsPrompt() async throws {
+        await sut.loadData()
+
+        XCTAssertNil(sut.yesterdayStatus)
+        XCTAssertTrue(sut.shouldShowYesterdayPrompt)
+    }
+
+    func testLoadData_yesterdayHasEpisode_hidesPrompt() async throws {
+        let calendar = Calendar.current
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: Date())!
+        let dayStart = calendar.startOfDay(for: yesterday)
+        let startMs = TimestampHelper.fromDate(dayStart)
+        let endMs = startMs + 3_600_000 // +1 hour, squarely within yesterday
+        let episode = TestFixtures.makeEpisode(id: "ep-y", startTime: startMs, endTime: endMs)
+        mockEpisodeRepo.episodes = [episode]
+
+        await sut.loadData()
+
+        XCTAssertNil(sut.yesterdayStatus)
+        XCTAssertFalse(sut.shouldShowYesterdayPrompt)
+    }
+
+    func testLoadData_yesterdayStatusLogged_hidesPrompt() async throws {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let dateString = TimestampHelper.dateString(from: yesterday)
+        mockStatusRepo.statuses = [TestFixtures.makeDailyStatus(id: "ds-1", date: dateString, status: .green)]
+
+        await sut.loadData()
+
+        XCTAssertNotNil(sut.yesterdayStatus)
+        XCTAssertFalse(sut.shouldShowYesterdayPrompt)
+    }
+
+    func testLoadData_episodeSpansOvernightIntoYesterday_hidesPrompt() async throws {
+        // Episode started two days ago, still ongoing — overlaps yesterday.
+        let calendar = Calendar.current
+        let twoDaysAgo = calendar.date(byAdding: .day, value: -2, to: Date())!
+        let startMs = TimestampHelper.fromDate(calendar.startOfDay(for: twoDaysAgo))
+        let episode = TestFixtures.makeEpisode(id: "ep-long", startTime: startMs, endTime: nil)
+        mockEpisodeRepo.episodes = [episode]
+
+        await sut.loadData()
+
+        XCTAssertFalse(sut.shouldShowYesterdayPrompt)
+    }
+
     func testLoadData_error_setsError() async throws {
         mockEpisodeRepo.errorToThrow = TestError.mockError("DB error")
 


### PR DESCRIPTION
## Summary
- Hide "How was yesterday?" dashboard prompt when yesterday already has a day entry
- Add medication cooldown warnings to prevent logging doses too soon (new MedicationCooldown service, cooldown metadata on medications, surfaced in dashboard quick-log, Add/Edit medication, log dose flow, and medication detail)

## Test plan
- [x] Unit tests: 700 passed, 0 failures
- [x] UI tests: 41 passed, 0 failures

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>