### PR TITLE
feat(ios): medication safety limits redesign + warning banners

### DIFF
--- a/docs/superpowers/plans/2026-04-16-medication-safety-limits-redesign.md
+++ b/docs/superpowers/plans/2026-04-16-medication-safety-limits-redesign.md
@@ -1,0 +1,768 @@
+# Medication Safety Limits Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the all-categories-visible Medication Safety Limits screen with a clean list-of-configured-limits + modal Add/Edit sheet, including preset auto-fill for NSAIDs and Triptans.
+
+**Architecture:** SwiftUI `List` showing only configured limits; toolbar `+` opens a `.sheet` (`CategoryLimitEditorSheet`) for add/edit. Swipe-to-delete removes a row. No schema or repository changes — existing `CategoryUsageLimit`, `CategoryUsageLimitRepository`, and `CategoryLimitsViewModel` are reused, with small additive changes on the view model. Presets live as a static extension on `MedicationCategory`.
+
+**Tech Stack:** Swift 5.9+, SwiftUI (iOS 17 target), `@Observable` view models, XCTest, xcodegen (project generation), GRDB (already wired — no changes).
+
+**Spec:** `docs/superpowers/specs/2026-04-16-medication-safety-limits-redesign-design.md`
+
+---
+
+## File Structure
+
+- **Modified**: `mobile-apps/ios/MigraLog/Models/Enums.swift` — add `mohPreset` computed property to `MedicationCategory`.
+- **Modified**: `mobile-apps/ios/MigraLog/ViewModels/CategoryLimitsViewModel.swift` — add `availableCategoriesForAdd` and `canAddMoreLimits` computed properties.
+- **Created**: `mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift` — add/edit modal sheet.
+- **Rewritten body**: `mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitsScreen.swift` — list of configured limits + empty state + sheet presentation.
+- **Created**: `mobile-apps/ios/MigraLogTests/ViewModels/CategoryLimitsViewModelTests.swift` — tests for the view model (did not exist previously).
+- **Created**: `mobile-apps/ios/MigraLogTests/Models/MedicationCategoryTests.swift` — tests for `mohPreset`.
+
+The xcodeproj is regenerated from `project.yml` via `xcodegen` — sources are picked up automatically from `path: MigraLog` and `path: MigraLogTests`, so no manual `project.pbxproj` edits are needed.
+
+---
+
+## Task 1: Add MOH preset to MedicationCategory
+
+**Files:**
+- Create: `mobile-apps/ios/MigraLogTests/Models/MedicationCategoryTests.swift`
+- Modify: `mobile-apps/ios/MigraLog/Models/Enums.swift` (append at end of file, after the `MedicationCategory` enum)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `mobile-apps/ios/MigraLogTests/Models/MedicationCategoryTests.swift`:
+
+```swift
+import XCTest
+@testable import MigraLog
+
+final class MedicationCategoryTests: XCTestCase {
+    func test_mohPreset_forNSAID_is15DaysIn30Days() {
+        let preset = MedicationCategory.nsaid.mohPreset
+        XCTAssertEqual(preset?.maxDays, 15)
+        XCTAssertEqual(preset?.windowDays, 30)
+    }
+
+    func test_mohPreset_forTriptan_is10DaysIn30Days() {
+        let preset = MedicationCategory.triptan.mohPreset
+        XCTAssertEqual(preset?.maxDays, 10)
+        XCTAssertEqual(preset?.windowDays, 30)
+    }
+
+    func test_mohPreset_forOTC_isNil() {
+        XCTAssertNil(MedicationCategory.otc.mohPreset)
+    }
+
+    func test_mohPreset_forCGRP_isNil() {
+        XCTAssertNil(MedicationCategory.cgrp.mohPreset)
+    }
+
+    func test_mohPreset_forPreventive_isNil() {
+        XCTAssertNil(MedicationCategory.preventive.mohPreset)
+    }
+
+    func test_mohPreset_forSupplement_isNil() {
+        XCTAssertNil(MedicationCategory.supplement.mohPreset)
+    }
+
+    func test_mohPreset_forOther_isNil() {
+        XCTAssertNil(MedicationCategory.other.mohPreset)
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate xcodeproj so the new test file is picked up**
+
+Run (from `mobile-apps/ios`):
+```bash
+cd mobile-apps/ios && xcodegen generate
+```
+Expected: "Loaded project..." then "Created project at ...MigraLog.xcodeproj".
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+```bash
+cd mobile-apps/ios && xcodebuild test -scheme MigraLog -destination 'platform=iOS Simulator,name=iPhone 15' -only-testing:MigraLogTests/MedicationCategoryTests 2>&1 | tail -30
+```
+Expected: Compilation error — `Value of type 'MedicationCategory' has no member 'mohPreset'`.
+
+- [ ] **Step 4: Add the preset extension**
+
+Append to `mobile-apps/ios/MigraLog/Models/Enums.swift` directly after the closing `}` of `enum MedicationCategory` (currently line 152), *before* the `// MARK: - Daily Status Enums` comment:
+
+```swift
+extension MedicationCategory {
+    /// Common MOH (medication overuse headache) guideline defaults used to pre-fill
+    /// the Add Limit sheet. Informational only — not medical advice.
+    var mohPreset: (maxDays: Int, windowDays: Int)? {
+        switch self {
+        case .nsaid:   return (15, 30)
+        case .triptan: return (10, 30)
+        case .otc, .cgrp, .preventive, .supplement, .other:
+            return nil
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+```bash
+cd mobile-apps/ios && xcodebuild test -scheme MigraLog -destination 'platform=iOS Simulator,name=iPhone 15' -only-testing:MigraLogTests/MedicationCategoryTests 2>&1 | tail -20
+```
+Expected: `Test Suite 'MedicationCategoryTests' passed`, 7 tests passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile-apps/ios/MigraLog/Models/Enums.swift mobile-apps/ios/MigraLogTests/Models/MedicationCategoryTests.swift mobile-apps/ios/MigraLog.xcodeproj
+git commit -m "feat(ios): add MOH preset to MedicationCategory"
+```
+
+---
+
+## Task 2: Extend CategoryLimitsViewModel with availableCategoriesForAdd / canAddMoreLimits
+
+**Files:**
+- Create: `mobile-apps/ios/MigraLogTests/ViewModels/CategoryLimitsViewModelTests.swift`
+- Modify: `mobile-apps/ios/MigraLog/ViewModels/CategoryLimitsViewModel.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `mobile-apps/ios/MigraLogTests/ViewModels/CategoryLimitsViewModelTests.swift`:
+
+```swift
+import XCTest
+@testable import MigraLog
+
+@MainActor
+final class CategoryLimitsViewModelTests: XCTestCase {
+    private var mockRepo: MockCategoryUsageLimitRepository!
+    private var sut: CategoryLimitsViewModel!
+
+    override func setUp() {
+        super.setUp()
+        mockRepo = MockCategoryUsageLimitRepository()
+        sut = CategoryLimitsViewModel(repository: mockRepo)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockRepo = nil
+        super.tearDown()
+    }
+
+    // MARK: - loadLimits
+
+    func test_loadLimits_populatesLimitsMapKeyedByCategory() {
+        let nsaid = CategoryUsageLimit(category: .nsaid, maxDays: 15, windowDays: 30)
+        let triptan = CategoryUsageLimit(category: .triptan, maxDays: 10, windowDays: 30)
+        mockRepo.limits = [.nsaid: nsaid, .triptan: triptan]
+
+        sut.loadLimits()
+
+        XCTAssertEqual(sut.limits[.nsaid], nsaid)
+        XCTAssertEqual(sut.limits[.triptan], triptan)
+        XCTAssertNil(sut.limits[.otc])
+    }
+
+    // MARK: - availableCategoriesForAdd
+
+    func test_availableCategoriesForAdd_whenEmpty_returnsAllCategories() {
+        sut.loadLimits()
+
+        XCTAssertEqual(Set(sut.availableCategoriesForAdd), Set(MedicationCategory.allCases))
+    }
+
+    func test_availableCategoriesForAdd_excludesConfiguredCategories() {
+        mockRepo.limits = [
+            .nsaid: CategoryUsageLimit(category: .nsaid, maxDays: 15, windowDays: 30)
+        ]
+        sut.loadLimits()
+
+        XCTAssertFalse(sut.availableCategoriesForAdd.contains(.nsaid))
+        XCTAssertTrue(sut.availableCategoriesForAdd.contains(.triptan))
+        XCTAssertEqual(sut.availableCategoriesForAdd.count, MedicationCategory.allCases.count - 1)
+    }
+
+    func test_availableCategoriesForAdd_preservesAllCasesOrder() {
+        mockRepo.limits = [
+            .triptan: CategoryUsageLimit(category: .triptan, maxDays: 10, windowDays: 30)
+        ]
+        sut.loadLimits()
+
+        let expected = MedicationCategory.allCases.filter { $0 != .triptan }
+        XCTAssertEqual(sut.availableCategoriesForAdd, expected)
+    }
+
+    // MARK: - canAddMoreLimits
+
+    func test_canAddMoreLimits_whenEmpty_isTrue() {
+        sut.loadLimits()
+        XCTAssertTrue(sut.canAddMoreLimits)
+    }
+
+    func test_canAddMoreLimits_whenAllConfigured_isFalse() {
+        var map: [MedicationCategory: CategoryUsageLimit] = [:]
+        for c in MedicationCategory.allCases {
+            map[c] = CategoryUsageLimit(category: c, maxDays: 1, windowDays: 1)
+        }
+        mockRepo.limits = map
+        sut.loadLimits()
+
+        XCTAssertFalse(sut.canAddMoreLimits)
+    }
+
+    // MARK: - saveLimit
+
+    func test_saveLimit_addsToLimitsMap() {
+        let limit = CategoryUsageLimit(category: .nsaid, maxDays: 15, windowDays: 30)
+        sut.saveLimit(limit)
+
+        XCTAssertEqual(sut.limits[.nsaid], limit)
+        XCTAssertTrue(mockRepo.setLimitCalled)
+    }
+
+    // MARK: - clearLimit
+
+    func test_clearLimit_removesFromLimitsMap() {
+        mockRepo.limits = [
+            .nsaid: CategoryUsageLimit(category: .nsaid, maxDays: 15, windowDays: 30)
+        ]
+        sut.loadLimits()
+        XCTAssertNotNil(sut.limits[.nsaid])
+
+        sut.clearLimit(.nsaid)
+
+        XCTAssertNil(sut.limits[.nsaid])
+        XCTAssertTrue(mockRepo.clearLimitCalled)
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate xcodeproj**
+
+Run:
+```bash
+cd mobile-apps/ios && xcodegen generate
+```
+Expected: "Created project at ...MigraLog.xcodeproj".
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+```bash
+cd mobile-apps/ios && xcodebuild test -scheme MigraLog -destination 'platform=iOS Simulator,name=iPhone 15' -only-testing:MigraLogTests/CategoryLimitsViewModelTests 2>&1 | tail -30
+```
+Expected: Compilation error — `Value of type 'CategoryLimitsViewModel' has no member 'availableCategoriesForAdd'` (and `canAddMoreLimits`).
+
+- [ ] **Step 4: Add the computed properties**
+
+Modify `mobile-apps/ios/MigraLog/ViewModels/CategoryLimitsViewModel.swift` — add the following computed properties inside the class, immediately after the `private let repository: CategoryUsageLimitRepositoryProtocol` line and before the `init`:
+
+```swift
+    /// Categories not yet configured — used to populate the Add Limit picker.
+    /// Preserves `MedicationCategory.allCases` order.
+    var availableCategoriesForAdd: [MedicationCategory] {
+        MedicationCategory.allCases.filter { limits[$0] == nil }
+    }
+
+    /// Whether the toolbar "+" should be enabled.
+    var canAddMoreLimits: Bool {
+        !availableCategoriesForAdd.isEmpty
+    }
+
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+```bash
+cd mobile-apps/ios && xcodebuild test -scheme MigraLog -destination 'platform=iOS Simulator,name=iPhone 15' -only-testing:MigraLogTests/CategoryLimitsViewModelTests 2>&1 | tail -20
+```
+Expected: `Test Suite 'CategoryLimitsViewModelTests' passed`, all tests passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile-apps/ios/MigraLog/ViewModels/CategoryLimitsViewModel.swift mobile-apps/ios/MigraLogTests/ViewModels/CategoryLimitsViewModelTests.swift mobile-apps/ios/MigraLog.xcodeproj
+git commit -m "feat(ios): add availableCategoriesForAdd + canAddMoreLimits to CategoryLimitsViewModel"
+```
+
+---
+
+## Task 3: Create CategoryLimitEditorSheet
+
+This task creates the add/edit modal sheet. SwiftUI views in this codebase are not covered by automated tests; correctness is verified by (a) compiling, (b) the view model it drives being covered by tests from Task 2, and (c) manual verification in Task 5.
+
+**Files:**
+- Create: `mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift`
+
+- [ ] **Step 1: Create the sheet file**
+
+Create `mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift` with the full contents below:
+
+```swift
+import SwiftUI
+
+/// Modal sheet for adding or editing a single `CategoryUsageLimit`.
+/// In add mode the user picks a category from the supplied list and the fields
+/// auto-fill with the category's `mohPreset` if one exists. In edit mode the
+/// category is locked and the fields are pre-populated from the existing limit.
+struct CategoryLimitEditorSheet: View {
+    enum Mode: Equatable {
+        case add(available: [MedicationCategory])
+        case edit(existing: CategoryUsageLimit)
+    }
+
+    let mode: Mode
+    let onSave: (CategoryUsageLimit) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedCategory: MedicationCategory?
+    @State private var maxDaysText: String = ""
+    @State private var windowDaysText: String = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                categorySection
+                limitSection
+                guidanceSection
+            }
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .accessibilityIdentifier("limit-editor-cancel")
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        .disabled(!isValid)
+                        .accessibilityIdentifier("limit-editor-save")
+                }
+            }
+            .onAppear(perform: configureInitialState)
+            .presentationDetents([.medium])
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var categorySection: some View {
+        switch mode {
+        case .add(let available):
+            Section("Category") {
+                Picker("Category", selection: $selectedCategory) {
+                    Text("Select a category").tag(MedicationCategory?.none)
+                    ForEach(available) { category in
+                        Text(category.displayName).tag(Optional(category))
+                    }
+                }
+                .accessibilityIdentifier("limit-editor-category-picker")
+                .onChange(of: selectedCategory) { _, newValue in
+                    applyPresetIfAvailable(for: newValue)
+                }
+            }
+        case .edit(let existing):
+            Section("Category") {
+                Text(existing.category.displayName)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var limitSection: some View {
+        Section("Limit") {
+            TextField("Max days", text: $maxDaysText)
+                .keyboardType(.numberPad)
+                .accessibilityIdentifier("limit-editor-max-days")
+
+            TextField("Window (days)", text: $windowDaysText)
+                .keyboardType(.numberPad)
+                .accessibilityIdentifier("limit-editor-window-days")
+
+            if let warning = validationWarning {
+                Text(warning)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var guidanceSection: some View {
+        Section {
+            EmptyView()
+        } footer: {
+            Text("Based on common MOH (medication overuse headache) guidelines — informational only. Talk to your doctor about thresholds appropriate for your situation. This app does not provide medical advice.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - State / actions
+
+    private var navigationTitle: String {
+        switch mode {
+        case .add: return "Add Limit"
+        case .edit(let existing): return existing.category.displayName
+        }
+    }
+
+    private var parsedMaxDays: Int? {
+        guard let v = Int(maxDaysText), v > 0 else { return nil }
+        return v
+    }
+
+    private var parsedWindowDays: Int? {
+        guard let v = Int(windowDaysText), v > 0 else { return nil }
+        return v
+    }
+
+    private var resolvedCategory: MedicationCategory? {
+        switch mode {
+        case .add:                 return selectedCategory
+        case .edit(let existing):  return existing.category
+        }
+    }
+
+    private var isValid: Bool {
+        guard resolvedCategory != nil,
+              let maxDays = parsedMaxDays,
+              let windowDays = parsedWindowDays else {
+            return false
+        }
+        return maxDays <= windowDays
+    }
+
+    private var validationWarning: String? {
+        guard let maxDays = parsedMaxDays, let windowDays = parsedWindowDays else {
+            return nil
+        }
+        return maxDays > windowDays ? "Max days can't exceed the window." : nil
+    }
+
+    private func configureInitialState() {
+        if case .edit(let existing) = mode {
+            maxDaysText = String(existing.maxDays)
+            windowDaysText = String(existing.windowDays)
+        }
+    }
+
+    private func applyPresetIfAvailable(for category: MedicationCategory?) {
+        guard case .add = mode, let category, let preset = category.mohPreset else {
+            return
+        }
+        maxDaysText = String(preset.maxDays)
+        windowDaysText = String(preset.windowDays)
+    }
+
+    private func save() {
+        guard let category = resolvedCategory,
+              let maxDays = parsedMaxDays,
+              let windowDays = parsedWindowDays,
+              maxDays <= windowDays else {
+            return
+        }
+        let limit = CategoryUsageLimit(
+            category: category,
+            maxDays: maxDays,
+            windowDays: windowDays
+        )
+        onSave(limit)
+        dismiss()
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate xcodeproj**
+
+Run:
+```bash
+cd mobile-apps/ios && xcodegen generate
+```
+Expected: "Created project at ...MigraLog.xcodeproj".
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run:
+```bash
+cd mobile-apps/ios && xcodebuild build -scheme MigraLog -destination 'platform=iOS Simulator,name=iPhone 15' 2>&1 | tail -20
+```
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift mobile-apps/ios/MigraLog.xcodeproj
+git commit -m "feat(ios): add CategoryLimitEditorSheet for add/edit of usage limits"
+```
+
+---
+
+## Task 4: Rewrite CategoryLimitsScreen
+
+This task replaces the old all-categories layout with the list-of-configured-limits + empty-state + sheet-presentation design. The view model already has everything needed after Task 2.
+
+**Files:**
+- Modify (full rewrite of body): `mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitsScreen.swift`
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace the entire contents of `mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitsScreen.swift` with:
+
+```swift
+import SwiftUI
+
+/// Settings screen listing the user's configured medication usage limits.
+/// Users add a new limit via the toolbar "+" (or the empty-state button),
+/// tap a row to edit, and swipe to delete. At most one limit per category.
+struct CategoryLimitsScreen: View {
+    @State private var viewModel = CategoryLimitsViewModel()
+    @State private var editorMode: CategoryLimitEditorSheet.Mode?
+
+    var body: some View {
+        Group {
+            if viewModel.limits.isEmpty {
+                emptyState
+            } else {
+                limitsList
+            }
+        }
+        .navigationTitle("Medication Safety Limits")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    presentAddSheet()
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .disabled(!viewModel.canAddMoreLimits)
+                .accessibilityIdentifier("category-limits-add")
+            }
+        }
+        .sheet(item: $editorMode) { mode in
+            CategoryLimitEditorSheet(mode: mode) { limit in
+                viewModel.saveLimit(limit)
+            }
+        }
+        .task {
+            viewModel.loadLimits()
+        }
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("No Limits Configured", systemImage: "shield.lefthalf.filled")
+        } description: {
+            Text("Optional warnings for medication-overuse headache risk. These are informational only — talk to your doctor before relying on them.")
+        } actions: {
+            Button {
+                presentAddSheet()
+            } label: {
+                Text("Add Limit")
+                    .fontWeight(.semibold)
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("category-limits-empty-add")
+        }
+    }
+
+    // MARK: - List
+
+    private var limitsList: some View {
+        List {
+            Section {
+                ForEach(configuredLimitsInOrder) { limit in
+                    Button {
+                        editorMode = .edit(existing: limit)
+                    } label: {
+                        limitRow(limit)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("limit-row-\(limit.category.rawValue)")
+                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                        Button(role: .destructive) {
+                            viewModel.clearLimit(limit.category)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        .accessibilityIdentifier("limit-row-delete-\(limit.category.rawValue)")
+                    }
+                }
+            } footer: {
+                Text("Informational warnings only — not medical advice. The app will not block you from logging doses. Talk to your doctor about appropriate thresholds. Common guidelines: NSAIDs 15/30, Triptans 10/30.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func limitRow(_ limit: CategoryUsageLimit) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(limit.category.displayName)
+                    .font(.body)
+                Text("\(limit.maxDays) days in any \(limit.windowDays) days")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.footnote)
+                .foregroundStyle(.tertiary)
+        }
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Helpers
+
+    private var configuredLimitsInOrder: [CategoryUsageLimit] {
+        MedicationCategory.allCases.compactMap { viewModel.limits[$0] }
+    }
+
+    private func presentAddSheet() {
+        editorMode = .add(available: viewModel.availableCategoriesForAdd)
+    }
+}
+
+// MARK: - Sheet Identifiable
+
+extension CategoryLimitEditorSheet.Mode: Identifiable {
+    var id: String {
+        switch self {
+        case .add:                 return "__add__"
+        case .edit(let existing):  return existing.category.rawValue
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run:
+```bash
+cd mobile-apps/ios && xcodebuild build -scheme MigraLog -destination 'platform=iOS Simulator,name=iPhone 15' 2>&1 | tail -20
+```
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Run the full test suite to catch regressions**
+
+Run:
+```bash
+cd mobile-apps/ios && xcodebuild test -scheme MigraLog -destination 'platform=iOS Simulator,name=iPhone 15' 2>&1 | tail -30
+```
+Expected: All tests pass, including `MedicationCategoryTests` and `CategoryLimitsViewModelTests`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitsScreen.swift
+git commit -m "feat(ios): redesign CategoryLimitsScreen with Add flow and swipe-to-delete"
+```
+
+---
+
+## Task 5: Manual verification in iOS Simulator
+
+SwiftUI views have no snapshot or UI-test coverage in this project, so this task is a manual walkthrough to confirm the design matches the spec. Capture screenshots where indicated.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Launch the app in the Simulator**
+
+Run:
+```bash
+cd mobile-apps/ios && xcodebuild build -scheme MigraLog -destination 'platform=iOS Simulator,name=iPhone 15' 2>&1 | tail -5
+```
+Then open `MigraLog.xcodeproj` in Xcode and run on the iPhone 15 simulator, or use:
+```bash
+xcrun simctl launch booted com.eff3.migralog
+```
+
+- [ ] **Step 2: Verify the empty state**
+
+Navigate: Settings → Medication Safety Limits (on a fresh install with no limits configured).
+
+Expected:
+- Centered icon + "No Limits Configured" heading.
+- Description paragraph mentioning MOH risk and doctor consultation.
+- Prominent "Add Limit" button.
+- Toolbar `+` visible and enabled.
+
+If any configured limits already exist from prior runs, clear them via swipe-to-delete first.
+
+- [ ] **Step 3: Verify the add flow with a preset**
+
+Tap toolbar `+` (or the empty-state "Add Limit" button). Expected: sheet slides up at medium detent with title "Add Limit", Cancel (left) / Save (right, disabled), a category picker reading "Select a category", empty Max days / Window days fields, and the footer guidance text.
+
+Pick **NSAID** from the picker. Expected: fields auto-fill to 15 and 30; Save becomes enabled.
+
+Tap Save. Expected: sheet dismisses; a row appears reading "NSAID" with subtitle "15 days in any 30 days".
+
+- [ ] **Step 4: Verify the add flow without a preset**
+
+Tap the `+` again. Pick **CGRP**. Expected: fields remain empty (no preset); Save stays disabled until valid numbers are entered.
+
+Enter `3` and `30`. Tap Save. Expected: new CGRP row appears.
+
+- [ ] **Step 5: Verify picker filtering**
+
+Tap `+` again. Open the category picker. Expected: NSAID and CGRP do NOT appear in the options. Triptan, OTC, Preventive, Supplement, Other do appear.
+
+Dismiss with Cancel.
+
+- [ ] **Step 6: Verify edit mode**
+
+Tap the NSAID row. Expected: sheet opens with title "NSAID", category section shows "NSAID" as a locked row (no picker), Max days = 15, Window days = 30.
+
+Change Window days to `60`. Tap Save. Expected: row subtitle updates to "15 days in any 60 days".
+
+- [ ] **Step 7: Verify validation**
+
+Tap the NSAID row. Change Max days to `100`, Window days to `30`. Expected: red helper text "Max days can't exceed the window." appears; Save is disabled.
+
+Change Max days back to `15`. Save re-enables. Cancel.
+
+- [ ] **Step 8: Verify swipe-to-delete**
+
+Swipe left on the CGRP row. Tap the red Delete action. Expected: row animates out of the list. Open the `+` picker; CGRP is once again available.
+
+- [ ] **Step 9: Verify "all configured" disables Add**
+
+Add limits for every remaining category (Triptan, OTC, Preventive, Supplement, Other). Expected: after the seventh limit is saved, the toolbar `+` becomes disabled.
+
+Delete one row. Expected: `+` becomes enabled again.
+
+- [ ] **Step 10: Verify footer text is present**
+
+With at least one limit configured, scroll to the bottom of the list. Expected: footer reads "Informational warnings only — not medical advice…" with the common-guidelines examples.
+
+- [ ] **Step 11: Commit any final fixes**
+
+If Steps 2–10 uncover a visual or behavioral issue, fix it in the relevant file and commit with a `fix(ios): …` message. Otherwise this task is complete.
+
+Final sanity:
+```bash
+git status
+```
+Expected: clean working tree.
+
+---
+
+## Self-Review Notes
+
+- All spec requirements mapped to tasks: empty state (Task 4), list row format (Task 4), toolbar `+` (Task 4), swipe-to-delete (Task 4), add sheet with category picker and preset auto-fill (Task 3), edit sheet with locked category (Task 3), validation rule `maxDays <= windowDays` (Task 3), footer warning (Tasks 3 & 4), preset values (Task 1), view model additions (Task 2). No gaps.
+- No placeholders: every step includes the actual code or command.
+- Types and names are consistent across tasks: `CategoryLimitEditorSheet.Mode.add(available:)` / `.edit(existing:)`, `CategoryUsageLimit(category:maxDays:windowDays:)`, `availableCategoriesForAdd`, `canAddMoreLimits`, `mohPreset`. `CategoryLimitsScreen` calls `.sheet(item:)` which requires `Mode: Identifiable` — that conformance is added in Task 4.

--- a/docs/superpowers/specs/2026-04-16-medication-safety-limits-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-16-medication-safety-limits-redesign-design.md
@@ -1,0 +1,120 @@
+# Medication Safety Limits — Redesign
+
+**Date:** 2026-04-16
+**Platform:** iOS (Swift / SwiftUI)
+**Scope:** `mobile-apps/ios` — Settings → Medication Safety Limits
+
+## Problem
+
+The current `CategoryLimitsScreen` renders every `MedicationCategory` (OTC, NSAID, Triptan, CGRP, Preventive, Supplement, Other) as its own form section with "Max days" / "Window (days)" text fields and Save / Clear buttons — regardless of whether the user wants a limit for that category. The result is visually noisy, makes it hard to see which limits are actually configured, and feels amateurish. MOH-risk limits apply to only a couple of categories for most users, so the bulk of the screen is dead weight.
+
+## Goals
+
+- Show only the limits the user has configured.
+- Provide a clean "Add Limit" flow that lets the user pick a category, set a max-days / window, and save.
+- Keep the "one rule per category" constraint (sufficient for current needs; revisit only if a concrete use case emerges).
+- Reduce friction for common cases (NSAIDs, Triptans) by pre-filling well-established ICHD MOH thresholds, without implying medical advice.
+- Preserve the existing doctor-consultation warning; make it more prominent inside the add/edit flow where thresholds are being chosen.
+
+## Non-goals
+
+- Changing the data model or repository layer. The existing `CategoryUsageLimit` and `CategoryUsageLimitRepository` already support everything needed.
+- Multiple rules per category.
+- Changing how limits are evaluated or surfaced in dose logging / dashboard warnings. Only the configuration UI changes.
+- Adding new MOH evaluation logic.
+
+## Design
+
+### Main screen — `CategoryLimitsScreen`
+
+- **Navigation**: title `"Medication Safety Limits"`, inline display mode.
+- **Toolbar**: trailing `+` button. Disabled iff every `MedicationCategory` already has a configured limit.
+- **Empty state** (no limits configured):
+  - Centered `ContentUnavailableView` (or equivalent) with a shield / medical icon, heading "No Limits Configured", and a one-sentence description that these are optional MOH-risk warnings.
+  - Primary button "Add Limit" that opens the add sheet (same action as the toolbar `+`).
+- **Populated state**: a SwiftUI `List` of rows, one per configured limit, sorted by `MedicationCategory.allCases` order.
+  - Row shows the category `displayName` as the primary label and a secondary subtitle of the form `"{maxDays} days in any {windowDays} days"` (e.g., "15 days in any 30 days").
+  - Tapping a row opens the editor sheet in edit mode for that category.
+  - Swipe-from-trailing reveals a red "Delete" action that calls `viewModel.clearLimit(category)`.
+- **Footer** (populated state only): the existing "informational warnings only — not medical advice — talk to your doctor" text, followed by the "Common examples: NSAIDs 15/30, Triptans 10/30" guidance. In the empty state, the empty-state description carries the warning instead.
+
+### Add / Edit sheet — `CategoryLimitEditorSheet`
+
+- **Presentation**: `.sheet` with `.presentationDetents([.medium])`. Drag-to-dismiss is enabled; dismissing without tapping Save discards changes.
+- **Navigation** (inside the sheet):
+  - Title: `"Add Limit"` (add mode) or the locked category's `displayName` (edit mode).
+  - Leading toolbar item: `Cancel` — dismisses without saving.
+  - Trailing toolbar item: `Save` — disabled until the form is valid (both integers > 0 and `maxDays <= windowDays`).
+- **Body** (SwiftUI `Form`):
+  1. **Category section**
+     - *Add mode*: a `Picker` bound to the selected category, whose options are `viewModel.availableCategoriesForAdd` (categories not already configured). No default selection; Save is disabled until a category is chosen.
+     - *Edit mode*: a single disabled row displaying the locked category (or omit the section and rely on the navigation title).
+  2. **Limit section**: two rows — "Max days" and "Window (days)" — each a `TextField` with `.numberPad` keyboard. Validation shown inline (disabled Save is the primary signal; an inline red helper text appears only when the user has entered both values and they violate `maxDays <= windowDays`).
+  3. **Footer**: plain-text section footer: *"Based on common MOH (medication overuse headache) guidelines — informational only. Talk to your doctor about thresholds appropriate for your situation. This app does not provide medical advice."*
+- **Preset auto-fill** (add mode only): when the user selects a category in the picker, if `MedicationCategory.mohPreset` returns a value for that category, populate the Max days and Window fields with those values. The user can edit the prefilled values freely before saving. In edit mode, the fields are populated from the existing limit; presets are never applied.
+
+### Presets
+
+Added as a static extension on `MedicationCategory`:
+
+```
+extension MedicationCategory {
+    /// Common MOH guideline defaults used to pre-fill the Add Limit sheet.
+    /// Presets are informational only and must not be treated as medical advice.
+    var mohPreset: (maxDays: Int, windowDays: Int)? {
+        switch self {
+        case .nsaid:   return (15, 30)
+        case .triptan: return (10, 30)
+        default:       return nil  // OTC, CGRP, Preventive, Supplement, Other have no preset
+        }
+    }
+}
+```
+
+OTC is intentionally excluded because the category is too heterogeneous (acetaminophen, caffeine blends, combined analgesics, etc.) to pick a single defensible default.
+
+### View model — `CategoryLimitsViewModel`
+
+Existing responsibilities (`loadLimits`, `saveLimit`, `clearLimit`, error surfacing) are preserved. Adds:
+
+- `var availableCategoriesForAdd: [MedicationCategory]` — computed: `MedicationCategory.allCases.filter { limits[$0] == nil }`.
+- A helper for the "can add" state the toolbar `+` uses: `var canAddMoreLimits: Bool { !availableCategoriesForAdd.isEmpty }`.
+
+No repository or database changes.
+
+### User flows
+
+1. **First-time user** — opens Settings → Medication Safety Limits → sees empty state → taps "Add Limit" → picks NSAID → fields auto-fill to 15 / 30 → taps Save → sheet dismisses → NSAID row appears in list with subtitle "15 days in any 30 days".
+2. **Editing an existing limit** — taps the NSAID row → sheet opens with title "NSAID", fields populated with current values, category locked → edits Window from 30 to 90 → Save → row subtitle updates.
+3. **Removing a limit** — swipes left on the NSAID row → taps red Delete → row animates out → next time "Add Limit" is opened, NSAID reappears in the picker.
+4. **All categories configured** — after seven limits are added the toolbar `+` becomes disabled (a rare case in practice but handled).
+
+## Files changed
+
+- **`mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitsScreen.swift`** — full rewrite of the body to present the configured list, empty state, toolbar add button, and swipe-to-delete.
+- **`mobile-apps/ios/MigraLog/ViewModels/CategoryLimitsViewModel.swift`** — add `availableCategoriesForAdd` and `canAddMoreLimits`.
+- **New: `mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift`** — add/edit sheet described above.
+- **`mobile-apps/ios/MigraLog/Models/Enums.swift`** — add `mohPreset` extension on `MedicationCategory`.
+- **`mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj`** — register the new source file.
+
+## Testing
+
+- **ViewModel tests** (`CategoryLimitsViewModelTests`, extend existing)
+  - `availableCategoriesForAdd` returns all seven categories when nothing is configured.
+  - After `saveLimit` for NSAID, `availableCategoriesForAdd` omits NSAID.
+  - `canAddMoreLimits` is false when all seven categories have limits and true otherwise.
+- **Preset tests** (new, in `MedicationCategoryTests` or a suitable existing file)
+  - `mohPreset` returns `(15, 30)` for `.nsaid`, `(10, 30)` for `.triptan`, and `nil` for every other case.
+- **Screen / UI tests** — rewrite the existing `CategoryLimitsScreen` tests that assumed the all-categories-always-visible layout:
+  - Empty state renders the "No Limits Configured" view and Add button.
+  - Populated list renders one row per configured limit with the expected subtitle format.
+  - Tapping a row presents the editor sheet in edit mode with the category locked and fields populated.
+  - Tapping toolbar `+` presents the editor sheet in add mode with no category preselected.
+  - Picking NSAID in the add sheet auto-fills 15 / 30; picking CGRP leaves fields empty.
+  - Save is disabled when fields are empty, when values are non-integer or ≤ 0, or when `maxDays > windowDays`; otherwise enabled.
+  - Swipe-to-delete on a row calls the view model's `clearLimit` for the right category and removes the row from the list.
+  - When all seven categories are configured, the toolbar `+` is disabled.
+
+## Open questions
+
+None.

--- a/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		77F1955DB2EE63D1C537E642 /* UITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE19AF6509CF8DC4DB455A7 /* UITestHelpers.swift */; };
 		78618FC7FEA0CC547CDC50FE /* DailyStatusRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B607214AFA5F71F48657C6F1 /* DailyStatusRepositoryTests.swift */; };
 		796AFB13119C6E3D86504CA8 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8B9C30690CBBBD832E0020 /* Logger.swift */; };
+		7A3740B482B2C0A54A943595 /* MedicationSafetyBanners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D878ADD80369542076806E /* MedicationSafetyBanners.swift */; };
 		7A525B8D0D71FF77ADEA45D0 /* EditEpisodeNoteScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342535FA23D1E520269A5F56 /* EditEpisodeNoteScreen.swift */; };
 		7F1E89BCE3CA857B918126AE /* MedicationNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE8ECC3DA7FE72FE8D60A39 /* MedicationNotificationService.swift */; };
 		8104BEC89E7FB49DAC7B9E1B /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A94F406EFF4E5DCB0805C800 /* Sentry */; };
@@ -202,6 +203,7 @@
 		24958A6C17AF95BAC07D7A8E /* EpisodeValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeValidationTests.swift; sourceTree = "<group>"; };
 		27D3A271598E0C2FBD9B61A2 /* NotificationDismissalServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDismissalServiceTests.swift; sourceTree = "<group>"; };
 		2868FBA8AE7DF7D18EE121E7 /* CategoryUsageLimitRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryUsageLimitRepository.swift; sourceTree = "<group>"; };
+		28D878ADD80369542076806E /* MedicationSafetyBanners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationSafetyBanners.swift; sourceTree = "<group>"; };
 		2AFC602F51C0713E7E983A25 /* TimezoneChangeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimezoneChangeService.swift; sourceTree = "<group>"; };
 		2B616E302896B7AB4F10050D /* DailyCheckinNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCheckinNotificationService.swift; sourceTree = "<group>"; };
 		2D3F7165AEE8A6DFA8A24BA3 /* AnalyticsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsViewModelTests.swift; sourceTree = "<group>"; };
@@ -535,6 +537,7 @@
 		63B527C60BA652F4DD0B8D81 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				28D878ADD80369542076806E /* MedicationSafetyBanners.swift */,
 				DEF8B890D3D69DC1E55A96AA /* PainIntensitySlider.swift */,
 				86B0D6C1B51A39DFA4F4BB68 /* PainLocationGrid.swift */,
 				6C655C4327B2A2443B6CB590 /* SelectableChip.swift */,
@@ -991,6 +994,7 @@
 				2247422882867F75EF1E622A /* MedicationDetailViewModel.swift in Sources */,
 				7F1E89BCE3CA857B918126AE /* MedicationNotificationService.swift in Sources */,
 				EF2F89545E73FA4D4AB17CC7 /* MedicationRepository.swift in Sources */,
+				7A3740B482B2C0A54A943595 /* MedicationSafetyBanners.swift in Sources */,
 				87F25A63EC5156E4D0819674 /* MedicationTypeColors.swift in Sources */,
 				40FC7F16B00E4C05E9482C9F /* MedicationsListViewModel.swift in Sources */,
 				E189FA6D7C1661287B5A268A /* MedicationsScreen.swift in Sources */,

--- a/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		F77853584FB6F2293AE0664E /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC45242898147892D6109FC /* Protocols.swift */; };
 		F7885259909E7E8869A0FBF8 /* PainScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E377B93A69A1FB87C4B7AD /* PainScale.swift */; };
 		F8E0741DCAEF1B945C8BB427 /* EpisodesListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDF073B14BA448A9118494E /* EpisodesListViewModelTests.swift */; };
+		FA1B88D89140735D8D0B0540 /* MedicationCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726CBCDA596A725E3A0E7FD8 /* MedicationCategoryTests.swift */; };
 		FF383A8EEB9FE0F86269D329 /* ColorContrast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B55F2C874C905BFB8743D84 /* ColorContrast.swift */; };
 		FF68B224525BC81241D056DB /* NewEpisodeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B437D8468CA5BAD36F5009D /* NewEpisodeViewModel.swift */; };
 /* End PBXBuildFile section */
@@ -241,6 +242,7 @@
 		6C655C4327B2A2443B6CB590 /* SelectableChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableChip.swift; sourceTree = "<group>"; };
 		6E3EB2C7C80B90165E71117D /* AddMedicationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMedicationViewModelTests.swift; sourceTree = "<group>"; };
 		6EE19AF6509CF8DC4DB455A7 /* UITestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestHelpers.swift; sourceTree = "<group>"; };
+		726CBCDA596A725E3A0E7FD8 /* MedicationCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationCategoryTests.swift; sourceTree = "<group>"; };
 		73F297C313657784597A4A5B /* LogUpdateScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogUpdateScreen.swift; sourceTree = "<group>"; };
 		76E303BA2AD06087C298A076 /* ColorContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorContrastTests.swift; sourceTree = "<group>"; };
 		78012231B52727F745C4D9F9 /* ErrorLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorLogger.swift; sourceTree = "<group>"; };
@@ -383,6 +385,7 @@
 				31A3C99C430157F0BB3F9C23 /* MockRepositories.swift */,
 				AC5DEC524950E35C81941E23 /* Database */,
 				D929363C6455385A28A63AE3 /* Integration */,
+				D8851454B9F3755F8A764F21 /* Models */,
 				08AF79C9DBBC75EEF5E3ED4A /* Repositories */,
 				91F1000C3851650C0AC7FCBD /* Services */,
 				E3948A90CD5BC7C9CB260270 /* Utils */,
@@ -693,6 +696,14 @@
 			path = Analytics;
 			sourceTree = "<group>";
 		};
+		D8851454B9F3755F8A764F21 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				726CBCDA596A725E3A0E7FD8 /* MedicationCategoryTests.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		D929363C6455385A28A63AE3 /* Integration */ = {
 			isa = PBXGroup;
 			children = (
@@ -884,6 +895,7 @@
 				8412219386D826F79CA5DBC8 /* FormattingTests.swift in Sources */,
 				D6085DBDEE6689987FC5518D /* LocationServiceTests.swift in Sources */,
 				27A0391303646CF5E48C1247 /* LogMedicationViewModelTests.swift in Sources */,
+				FA1B88D89140735D8D0B0540 /* MedicationCategoryTests.swift in Sources */,
 				116097B18DA82FE412F3C5BA /* MedicationCooldownTests.swift in Sources */,
 				62050772CC4D955CEB7AB14F /* MedicationDetailViewModelTests.swift in Sources */,
 				5526658ACE024ED2751F7B58 /* MedicationNotificationServiceTests.swift in Sources */,

--- a/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		87F25A63EC5156E4D0819674 /* MedicationTypeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607D34D4F6637214F7B05DD8 /* MedicationTypeColors.swift */; };
 		8B0F482B6F32B51DAD53AD0F /* AnalyticsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3F7165AEE8A6DFA8A24BA3 /* AnalyticsViewModelTests.swift */; };
 		96763618847DBF5CF4F697AC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859A5576CD7D5A38E8B31B35 /* ContentView.swift */; };
+		98DB843B84819207C6D78E41 /* CategoryLimitEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8362347A971FD98E28A81361 /* CategoryLimitEditorSheet.swift */; };
 		9E3BE09BF5DB1CA80A42CA6C /* TimezoneChangeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFC602F51C0713E7E983A25 /* TimezoneChangeService.swift */; };
 		9ED614E5CA0DA670062E2BE2 /* CategoryUsageStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135285FDC99350DFF3A19D24 /* CategoryUsageStatus.swift */; };
 		A0AD7D5F9D72936BBA6CBA40 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 972F942EC9953A772E2CB7F6 /* NotificationService.swift */; };
@@ -255,6 +256,7 @@
 		7ED444111958701D34C394EC /* SentrySetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySetup.swift; sourceTree = "<group>"; };
 		7F8B9C30690CBBBD832E0020 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		8085FE18D6FA8E5EE15EEF8B /* ExportServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportServiceTests.swift; sourceTree = "<group>"; };
+		8362347A971FD98E28A81361 /* CategoryLimitEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryLimitEditorSheet.swift; sourceTree = "<group>"; };
 		8478E3F3AECFFE556A3EE0DC /* NotificationReconciliationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationReconciliationService.swift; sourceTree = "<group>"; };
 		859A5576CD7D5A38E8B31B35 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		86B0D6C1B51A39DFA4F4BB68 /* PainLocationGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PainLocationGrid.swift; sourceTree = "<group>"; };
@@ -570,6 +572,7 @@
 		84D341D07CE116E5E19B7A9A /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				8362347A971FD98E28A81361 /* CategoryLimitEditorSheet.swift */,
 				991D1B18E100523D65A4D710 /* CategoryLimitsScreen.swift */,
 				37ECB95AD7F3FB5D454AE773 /* DatabaseErrorView.swift */,
 				D2905118EC1EC29D6FAFC7F3 /* DataSettingsScreen.swift */,
@@ -936,6 +939,7 @@
 				29755CB3B94B55DE3E6859C0 /* ArchivedMedicationsScreen.swift in Sources */,
 				E4011CB90D144F08B4F5B03D /* BackupService.swift in Sources */,
 				CB02A4A43A1AFD4CE9203B4B /* CacheManager.swift in Sources */,
+				98DB843B84819207C6D78E41 /* CategoryLimitEditorSheet.swift in Sources */,
 				0928538AEA784C7F30D2F8A9 /* CategoryLimitsScreen.swift in Sources */,
 				71ABE5D0124CE628C539BB7B /* CategoryLimitsViewModel.swift in Sources */,
 				CFBA2301DAE29CE76C6C7395 /* CategoryUsageLimitRepository.swift in Sources */,

--- a/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		27A0391303646CF5E48C1247 /* LogMedicationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E432E407C0D036939A0788 /* LogMedicationViewModelTests.swift */; };
 		29755CB3B94B55DE3E6859C0 /* ArchivedMedicationsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06640B1C2F15795CC008C8B /* ArchivedMedicationsScreen.swift */; };
 		2A1B4DD1A4D7094B0FF06414 /* LogUpdateScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F297C313657784597A4A5B /* LogUpdateScreen.swift */; };
+		2B2B6E7906E4C3010839692E /* CategoryLimitsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC77BDEAF7D2C5338261C97A /* CategoryLimitsViewModelTests.swift */; };
 		2D14C25CEADEFB3BCC5E4840 /* MedicationsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D384AA6DA7F843009EEC84 /* MedicationsListViewModelTests.swift */; };
 		301A0660561DF9239237C0B6 /* ErrorHandlingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9016CBE2B824AE5F5B6FA89B /* ErrorHandlingUITests.swift */; };
 		32FDC6C19F3E21A4C748F43D /* CacheManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F899D4AAC4135CFB9D8D34 /* CacheManagerTests.swift */; };
@@ -330,6 +331,7 @@
 		FB611FF702E7A5E56F48248B /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		FC14C0BEF174570CFFFAADA2 /* NotificationResponseHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationResponseHandlerTests.swift; sourceTree = "<group>"; };
 		FC4261430F353F44B3DFAAC7 /* MedicationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationRepository.swift; sourceTree = "<group>"; };
+		FC77BDEAF7D2C5338261C97A /* CategoryLimitsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryLimitsViewModelTests.swift; sourceTree = "<group>"; };
 		FD1B3027A560A4D082F503A1 /* IntensitySparklineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntensitySparklineView.swift; sourceTree = "<group>"; };
 		FD92CE0E5A2F8B92AF7000C7 /* ExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportService.swift; sourceTree = "<group>"; };
 		FDAA8AD4C7F64C9ADE576C6B /* MigraLogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigraLogUITests.swift; sourceTree = "<group>"; };
@@ -419,6 +421,7 @@
 			children = (
 				6E3EB2C7C80B90165E71117D /* AddMedicationViewModelTests.swift */,
 				2D3F7165AEE8A6DFA8A24BA3 /* AnalyticsViewModelTests.swift */,
+				FC77BDEAF7D2C5338261C97A /* CategoryLimitsViewModelTests.swift */,
 				F9498E260C8EFE377BC05547 /* DailyCheckinSettingsViewModelTests.swift */,
 				D5C72860862DA711BCBEAFCE /* DailyStatusViewModelTests.swift */,
 				FA2FCE655D884ED8CDBEEE8D /* DashboardViewModelTests.swift */,
@@ -875,6 +878,7 @@
 				8B0F482B6F32B51DAD53AD0F /* AnalyticsViewModelTests.swift in Sources */,
 				51F7B9FC4B1407E3CEBB6606 /* BackupServiceTests.swift in Sources */,
 				32FDC6C19F3E21A4C748F43D /* CacheManagerTests.swift in Sources */,
+				2B2B6E7906E4C3010839692E /* CategoryLimitsViewModelTests.swift in Sources */,
 				26CEBF458CA5E1F01A67CD36 /* CategoryUsageLimitRepositoryTests.swift in Sources */,
 				44AC4BC8FB621A75B0A7BC85 /* CategoryUsageStatusTests.swift in Sources */,
 				66773FB67CA32096A054235C /* ColorContrastTests.swift in Sources */,

--- a/mobile-apps/ios/MigraLog/Models/Enums.swift
+++ b/mobile-apps/ios/MigraLog/Models/Enums.swift
@@ -151,6 +151,19 @@ enum MedicationCategory: String, Codable, CaseIterable, Identifiable {
     }
 }
 
+extension MedicationCategory {
+    /// Common MOH (medication overuse headache) guideline defaults used to pre-fill
+    /// the Add Limit sheet. Informational only — not medical advice.
+    var mohPreset: (maxDays: Int, windowDays: Int)? {
+        switch self {
+        case .nsaid:   return (15, 30)
+        case .triptan: return (10, 30)
+        case .otc, .cgrp, .preventive, .supplement, .other:
+            return nil
+        }
+    }
+}
+
 // MARK: - Daily Status Enums
 
 enum DayStatus: String, Codable, CaseIterable, Identifiable {

--- a/mobile-apps/ios/MigraLog/ViewModels/CategoryLimitsViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/CategoryLimitsViewModel.swift
@@ -13,6 +13,17 @@ final class CategoryLimitsViewModel {
 
     private let repository: CategoryUsageLimitRepositoryProtocol
 
+    /// Categories not yet configured — used to populate the Add Limit picker.
+    /// Preserves `MedicationCategory.allCases` order.
+    var availableCategoriesForAdd: [MedicationCategory] {
+        MedicationCategory.allCases.filter { limits[$0] == nil }
+    }
+
+    /// Whether the toolbar "+" should be enabled.
+    var canAddMoreLimits: Bool {
+        !availableCategoriesForAdd.isEmpty
+    }
+
     init(
         repository: CategoryUsageLimitRepositoryProtocol = CategoryUsageLimitRepository(dbManager: DatabaseManager.shared)
     ) {

--- a/mobile-apps/ios/MigraLog/ViewModels/MedicationDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/MedicationDetailViewModel.swift
@@ -13,6 +13,21 @@ final class MedicationDetailViewModel {
     var isLoading = false
     var error: String?
 
+    /// Current cooldown status, derived from the medication's min-interval and the
+    /// most recent dose in `recentDoses`. Recomputed on demand so it stays fresh
+    /// after loadMedication / logDose / deleteDose without additional plumbing.
+    var cooldownStatus: MedicationCooldown.Status {
+        guard let med = medication else {
+            return MedicationCooldown.Status(
+                isOnCooldown: false,
+                hoursSinceLastDose: nil,
+                hoursUntilNextDose: 0,
+                minIntervalHours: nil
+            )
+        }
+        return MedicationCooldown.evaluate(medication: med, lastDose: recentDoses.first)
+    }
+
     // MARK: - Dependencies
 
     private let medicationRepository: MedicationRepositoryProtocol

--- a/mobile-apps/ios/MigraLog/Views/Components/MedicationSafetyBanners.swift
+++ b/mobile-apps/ios/MigraLog/Views/Components/MedicationSafetyBanners.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// Small banner rows shown above medication dose-log buttons to surface safety
+/// information: cooldown (minimum interval since last dose) and MOH (medication
+/// overuse headache) risk. Renders 0, 1, or 2 lines depending on which statuses
+/// apply. Used on the Dashboard rows, the Log Medication cards, and inside the
+/// Log Dose sheet so the same info is visible everywhere a dose can be logged.
+struct MedicationSafetyBanners: View {
+    /// Cooldown status (pre-evaluated). Banner shown whenever the medication has
+    /// a prior dose, regardless of whether the cooldown has expired — users still
+    /// want to see how long it's been since their last dose.
+    var cooldown: MedicationCooldown.Status?
+    /// Category MOH status (pre-evaluated). Banner shown only when the status is
+    /// `.approaching` or `.atOrOver` — below that, it's just noise.
+    var categoryStatus: CategoryUsageStatus?
+    /// The medication's category — required to format the MOH summary string.
+    var medicationCategory: MedicationCategory?
+    /// Used to build stable accessibility identifiers. When nil, identifiers are omitted.
+    var medicationId: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let cooldown, let text = cooldownText(cooldown) {
+                Label(text, systemImage: "clock.fill")
+                    .font(.caption)
+                    .foregroundStyle(cooldownColor(cooldown))
+                    .accessibilityIdentifier(medicationId.map { "cooldown-warning-\($0)" } ?? "")
+            }
+
+            if let categoryStatus, categoryStatus.isWarning,
+               let medicationCategory,
+               let summary = categoryStatus.summary(category: medicationCategory) {
+                Label(summary, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(categoryStatus.isStrong ? Color.red : Color.orange)
+                    .accessibilityIdentifier(medicationId.map { "category-warning-\($0)" } ?? "")
+            }
+        }
+    }
+
+    private func cooldownText(_ status: MedicationCooldown.Status) -> String? {
+        guard let elapsed = status.hoursSinceLastDose else { return nil }
+        let elapsedStr = formatDuration(elapsed)
+        if status.isOnCooldown {
+            let waitStr = formatDuration(status.hoursUntilNextDose)
+            return "Last dose \(elapsedStr) ago — wait \(waitStr)"
+        }
+        return "Last dose \(elapsedStr) ago"
+    }
+
+    private func cooldownColor(_ status: MedicationCooldown.Status) -> Color {
+        status.isOnCooldown ? .orange : .secondary
+    }
+
+    /// Friendlier duration format than the existing `MedicationCooldown.summary`
+    /// ("2h 15m" / "45m" / "2.1d") — shown inline with prose so decimal hours
+    /// and bare "h"/"m" suffixes read awkwardly.
+    private func formatDuration(_ hours: Double) -> String {
+        if hours < 1 {
+            let minutes = Int((hours * 60).rounded())
+            return "\(minutes)m"
+        }
+        if hours < 24 {
+            let wholeHours = Int(hours)
+            let mins = Int(((hours - Double(wholeHours)) * 60).rounded())
+            if mins == 0 { return "\(wholeHours)h" }
+            return "\(wholeHours)h \(mins)m"
+        }
+        let days = Int(hours / 24)
+        let remHours = Int(hours.truncatingRemainder(dividingBy: 24))
+        if remHours == 0 { return "\(days)d" }
+        return "\(days)d \(remHours)h"
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -251,24 +251,16 @@ struct MedicationScheduleRow: View {
     var body: some View {
         let status = cooldownStatus
         let catStatus = categoryStatus
-        let showCooldownBanner = sizeClass == .regular && status.isOnCooldown && item.dose == nil
-        let showCategoryBanner = sizeClass == .regular && catStatus.isWarning && item.dose == nil
+        let showBanners = item.dose == nil
 
         VStack(alignment: .leading, spacing: 4) {
-            if showCooldownBanner, let summary = MedicationCooldown.summary(status) {
-                Label(summary, systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-                    .accessibilityIdentifier("cooldown-warning-\(item.medication.id)")
-            }
-
-            if showCategoryBanner,
-               let category = item.medication.category,
-               let summary = catStatus.summary(category: category) {
-                Label(summary, systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundStyle(catStatus.isStrong ? .red : .yellow)
-                    .accessibilityIdentifier("category-warning-\(item.medication.id)")
+            if showBanners {
+                MedicationSafetyBanners(
+                    cooldown: status,
+                    categoryStatus: catStatus,
+                    medicationCategory: item.medication.category,
+                    medicationId: item.medication.id
+                )
             }
 
             HStack {
@@ -297,13 +289,13 @@ struct MedicationScheduleRow: View {
                     } label: {
                         HStack(spacing: 4) {
                             if status.isOnCooldown {
-                                Image(systemName: "exclamationmark.triangle.fill")
+                                Image(systemName: "clock.fill")
                                     .foregroundStyle(.orange)
                                     .accessibilityIdentifier("cooldown-icon-\(item.medication.id)")
                             }
                             if catStatus.isWarning {
                                 Image(systemName: "exclamationmark.triangle.fill")
-                                    .foregroundStyle(catStatus.isStrong ? .red : .yellow)
+                                    .foregroundStyle(catStatus.isStrong ? Color.red : Color.orange)
                                     .accessibilityIdentifier("category-icon-\(item.medication.id)")
                             }
                             Text("Log \(doseLabel)")

--- a/mobile-apps/ios/MigraLog/Views/Medications/LogDoseDetailsSheet.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/LogDoseDetailsSheet.swift
@@ -23,6 +23,19 @@ struct LogDoseDetailsSheet: View {
     var body: some View {
         NavigationStack {
             Form {
+                let cooldown = viewModel.cooldownStatus
+                let category = viewModel.categoryStatus
+                if shouldShowSafetySection(cooldown: cooldown, category: category) {
+                    Section {
+                        MedicationSafetyBanners(
+                            cooldown: cooldown,
+                            categoryStatus: category,
+                            medicationCategory: medication.category,
+                            medicationId: medication.id
+                        )
+                    }
+                }
+
                 Section("Amount") {
                     HStack {
                         TextField("Quantity", text: $quantity)
@@ -71,6 +84,13 @@ struct LogDoseDetailsSheet: View {
                 Text("Please enter a valid amount greater than 0.")
             }
         }
+    }
+
+    private func shouldShowSafetySection(
+        cooldown: MedicationCooldown.Status,
+        category: CategoryUsageStatus
+    ) -> Bool {
+        cooldown.hoursSinceLastDose != nil || category.isWarning
     }
 
     private func save() async {

--- a/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
@@ -49,7 +49,11 @@ struct LogMedicationScreen: View {
         }
         .sheet(item: $detailMedication) { med in
             NavigationStack {
-                LogMedicationDetailSheet(medication: med) { dose in
+                LogMedicationDetailSheet(
+                    medication: med,
+                    lastDose: viewModel.lastDoseByMedication[med.id],
+                    categoryStatus: med.category.flatMap { viewModel.categoryUsage[$0] } ?? .noLimit
+                ) { dose in
                     Task {
                         let repo = MedicationRepository(dbManager: DatabaseManager.shared)
                         try? await repo.createDose(dose)
@@ -95,34 +99,24 @@ struct LogMedicationCard: View {
                     .foregroundStyle(.secondary)
             }
 
-            if sizeClass == .regular, status.isOnCooldown, let summary = MedicationCooldown.summary(status) {
-                Label(summary, systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-                    .accessibilityIdentifier("cooldown-warning-\(medication.id)")
-            }
-
-            if sizeClass == .regular,
-               catStatus.isWarning,
-               let category = medication.category,
-               let catSummary = catStatus.summary(category: category) {
-                Label(catSummary, systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundStyle(catStatus.isStrong ? .red : .yellow)
-                    .accessibilityIdentifier("category-warning-\(medication.id)")
-            }
+            MedicationSafetyBanners(
+                cooldown: status,
+                categoryStatus: catStatus,
+                medicationCategory: medication.category,
+                medicationId: medication.id
+            )
 
             HStack(spacing: 8) {
                 Button(action: onQuickLog) {
                     HStack(spacing: 6) {
                         if status.isOnCooldown {
-                            Image(systemName: "exclamationmark.triangle.fill")
+                            Image(systemName: "clock.fill")
                                 .foregroundStyle(.orange)
                                 .accessibilityIdentifier("cooldown-icon-\(medication.id)")
                         }
                         if catStatus.isWarning {
                             Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundStyle(catStatus.isStrong ? .red : .yellow)
+                                .foregroundStyle(catStatus.isStrong ? Color.red : Color.orange)
                                 .accessibilityIdentifier("category-icon-\(medication.id)")
                         }
                         Text("Log \(MedicationFormatting.formatDose(quantity: medication.defaultQuantity ?? 1, amount: medication.dosageAmount, unit: medication.dosageUnit))")
@@ -154,20 +148,45 @@ struct LogMedicationCard: View {
 
 struct LogMedicationDetailSheet: View {
     let medication: Medication
+    var lastDose: MedicationDose? = nil
+    var categoryStatus: CategoryUsageStatus = .noLimit
     let onSave: (MedicationDose) -> Void
     @Environment(\.dismiss) private var dismiss
     @State private var quantity: Double
     @State private var timestamp = Date()
     @State private var notes: String = ""
 
-    init(medication: Medication, onSave: @escaping (MedicationDose) -> Void) {
+    init(
+        medication: Medication,
+        lastDose: MedicationDose? = nil,
+        categoryStatus: CategoryUsageStatus = .noLimit,
+        onSave: @escaping (MedicationDose) -> Void
+    ) {
         self.medication = medication
+        self.lastDose = lastDose
+        self.categoryStatus = categoryStatus
         self.onSave = onSave
         self._quantity = State(initialValue: medication.defaultQuantity ?? 1)
     }
 
+    private var cooldownStatus: MedicationCooldown.Status {
+        MedicationCooldown.evaluate(medication: medication, lastDose: lastDose)
+    }
+
     var body: some View {
         Form {
+            let cooldown = cooldownStatus
+            if cooldown.hoursSinceLastDose != nil || categoryStatus.isWarning {
+                Section {
+                    MedicationSafetyBanners(
+                        cooldown: cooldown,
+                        categoryStatus: categoryStatus,
+                        medicationCategory: medication.category,
+                        medicationId: medication.id
+                    )
+                }
+            }
+
             Section("Medication") {
                 LabeledContent("Name", value: medication.name)
                 LabeledContent("Dosage", value: MedicationFormatting.formatDosage(amount: medication.dosageAmount, unit: medication.dosageUnit))

--- a/mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift
@@ -24,7 +24,6 @@ struct CategoryLimitEditorSheet: View {
             Form {
                 categorySection
                 limitSection
-                guidanceSection
             }
             .navigationTitle(navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
@@ -71,7 +70,7 @@ struct CategoryLimitEditorSheet: View {
     }
 
     private var limitSection: some View {
-        Section("Limit") {
+        Section {
             TextField("Max days", text: $maxDaysText)
                 .keyboardType(.numberPad)
                 .accessibilityIdentifier("limit-editor-max-days")
@@ -85,12 +84,8 @@ struct CategoryLimitEditorSheet: View {
                     .font(.footnote)
                     .foregroundStyle(.red)
             }
-        }
-    }
-
-    private var guidanceSection: some View {
-        Section {
-            EmptyView()
+        } header: {
+            Text("Limit")
         } footer: {
             Text("Based on common MOH (medication overuse headache) guidelines — informational only. Talk to your doctor about thresholds appropriate for your situation. This app does not provide medical advice.")
                 .font(.footnote)
@@ -147,6 +142,9 @@ struct CategoryLimitEditorSheet: View {
         }
     }
 
+    // Re-selecting a category (or selecting a new one) re-applies its preset,
+    // overwriting any user edits. Intentional: treats picker changes as a
+    // reset. Cancel is always available if the user wants to abandon.
     private func applyPresetIfAvailable(for category: MedicationCategory?) {
         guard case .add = mode, let category, let preset = category.mohPreset else {
             return

--- a/mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift
@@ -169,3 +169,14 @@ struct CategoryLimitEditorSheet: View {
         dismiss()
     }
 }
+
+// MARK: - Identifiable (for .sheet(item:) presentation)
+
+extension CategoryLimitEditorSheet.Mode: Identifiable {
+    var id: String {
+        switch self {
+        case .add:                 return "add"
+        case .edit(let existing):  return "edit-\(existing.category.rawValue)"
+        }
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift
@@ -71,13 +71,23 @@ struct CategoryLimitEditorSheet: View {
 
     private var limitSection: some View {
         Section {
-            TextField("Max days", text: $maxDaysText)
-                .keyboardType(.numberPad)
-                .accessibilityIdentifier("limit-editor-max-days")
+            LabeledContent("Max days taken") {
+                TextField("", text: $maxDaysText, prompt: Text("e.g. 15"))
+                    .keyboardType(.numberPad)
+                    .multilineTextAlignment(.trailing)
+                    .accessibilityIdentifier("limit-editor-max-days")
+            }
 
-            TextField("Window (days)", text: $windowDaysText)
-                .keyboardType(.numberPad)
-                .accessibilityIdentifier("limit-editor-window-days")
+            LabeledContent("In any rolling window of") {
+                HStack(spacing: 4) {
+                    TextField("", text: $windowDaysText, prompt: Text("e.g. 30"))
+                        .keyboardType(.numberPad)
+                        .multilineTextAlignment(.trailing)
+                        .accessibilityIdentifier("limit-editor-window-days")
+                    Text("days")
+                        .foregroundStyle(.secondary)
+                }
+            }
 
             if let warning = validationWarning {
                 Text(warning)

--- a/mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitEditorSheet.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+
+/// Modal sheet for adding or editing a single `CategoryUsageLimit`.
+/// In add mode the user picks a category from the supplied list and the fields
+/// auto-fill with the category's `mohPreset` if one exists. In edit mode the
+/// category is locked and the fields are pre-populated from the existing limit.
+struct CategoryLimitEditorSheet: View {
+    enum Mode: Equatable {
+        case add(available: [MedicationCategory])
+        case edit(existing: CategoryUsageLimit)
+    }
+
+    let mode: Mode
+    let onSave: (CategoryUsageLimit) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedCategory: MedicationCategory?
+    @State private var maxDaysText: String = ""
+    @State private var windowDaysText: String = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                categorySection
+                limitSection
+                guidanceSection
+            }
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .accessibilityIdentifier("limit-editor-cancel")
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        .disabled(!isValid)
+                        .accessibilityIdentifier("limit-editor-save")
+                }
+            }
+            .onAppear(perform: configureInitialState)
+            .presentationDetents([.medium])
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var categorySection: some View {
+        switch mode {
+        case .add(let available):
+            Section("Category") {
+                Picker("Category", selection: $selectedCategory) {
+                    Text("Select a category").tag(MedicationCategory?.none)
+                    ForEach(available) { category in
+                        Text(category.displayName).tag(Optional(category))
+                    }
+                }
+                .accessibilityIdentifier("limit-editor-category-picker")
+                .onChange(of: selectedCategory) { _, newValue in
+                    applyPresetIfAvailable(for: newValue)
+                }
+            }
+        case .edit(let existing):
+            Section("Category") {
+                Text(existing.category.displayName)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var limitSection: some View {
+        Section("Limit") {
+            TextField("Max days", text: $maxDaysText)
+                .keyboardType(.numberPad)
+                .accessibilityIdentifier("limit-editor-max-days")
+
+            TextField("Window (days)", text: $windowDaysText)
+                .keyboardType(.numberPad)
+                .accessibilityIdentifier("limit-editor-window-days")
+
+            if let warning = validationWarning {
+                Text(warning)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var guidanceSection: some View {
+        Section {
+            EmptyView()
+        } footer: {
+            Text("Based on common MOH (medication overuse headache) guidelines — informational only. Talk to your doctor about thresholds appropriate for your situation. This app does not provide medical advice.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - State / actions
+
+    private var navigationTitle: String {
+        switch mode {
+        case .add: return "Add Limit"
+        case .edit(let existing): return existing.category.displayName
+        }
+    }
+
+    private var parsedMaxDays: Int? {
+        guard let v = Int(maxDaysText), v > 0 else { return nil }
+        return v
+    }
+
+    private var parsedWindowDays: Int? {
+        guard let v = Int(windowDaysText), v > 0 else { return nil }
+        return v
+    }
+
+    private var resolvedCategory: MedicationCategory? {
+        switch mode {
+        case .add:                 return selectedCategory
+        case .edit(let existing):  return existing.category
+        }
+    }
+
+    private var isValid: Bool {
+        guard resolvedCategory != nil,
+              let maxDays = parsedMaxDays,
+              let windowDays = parsedWindowDays else {
+            return false
+        }
+        return maxDays <= windowDays
+    }
+
+    private var validationWarning: String? {
+        guard let maxDays = parsedMaxDays, let windowDays = parsedWindowDays else {
+            return nil
+        }
+        return maxDays > windowDays ? "Max days can't exceed the window." : nil
+    }
+
+    private func configureInitialState() {
+        if case .edit(let existing) = mode {
+            maxDaysText = String(existing.maxDays)
+            windowDaysText = String(existing.windowDays)
+        }
+    }
+
+    private func applyPresetIfAvailable(for category: MedicationCategory?) {
+        guard case .add = mode, let category, let preset = category.mohPreset else {
+            return
+        }
+        maxDaysText = String(preset.maxDays)
+        windowDaysText = String(preset.windowDays)
+    }
+
+    private func save() {
+        guard let category = resolvedCategory,
+              let maxDays = parsedMaxDays,
+              let windowDays = parsedWindowDays,
+              maxDays <= windowDays else {
+            return
+        }
+        let limit = CategoryUsageLimit(
+            category: category,
+            maxDays: maxDays,
+            windowDays: windowDays
+        )
+        onSave(limit)
+        dismiss()
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitsScreen.swift
@@ -1,120 +1,127 @@
 import SwiftUI
 
-/// Configuration screen for per-category medication usage limits used to warn
-/// about MOH (medication overuse headache) risk.
+/// Settings screen listing the user's configured medication usage limits.
+/// Users add a new limit via the toolbar "+" (or the empty-state button),
+/// tap a row to edit, and swipe to delete. At most one limit per category.
 struct CategoryLimitsScreen: View {
     @State private var viewModel = CategoryLimitsViewModel()
+    @State private var editorMode: CategoryLimitEditorSheet.Mode?
 
     var body: some View {
-        Form {
-            ForEach(MedicationCategory.allCases) { category in
-                CategoryLimitSection(
-                    category: category,
-                    existing: viewModel.limits[category],
-                    onSave: { maxDays, windowDays in
-                        let limit = CategoryUsageLimit(
-                            category: category,
-                            maxDays: maxDays,
-                            windowDays: windowDays
-                        )
-                        viewModel.saveLimit(limit)
-                    },
-                    onClear: {
-                        viewModel.clearLimit(category)
-                    }
-                )
-            }
-
-            Section {
-                EmptyView()
-            } footer: {
-                Text("These limits are informational warnings only — they are not medical advice. The app will not block you from logging doses. Talk to your doctor about appropriate thresholds for your situation. Common examples: NSAIDs 15 days / 30 days, Triptans 10 days / 30 days.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+        Group {
+            if viewModel.limits.isEmpty {
+                emptyState
+            } else {
+                limitsList
             }
         }
         .navigationTitle("Medication Safety Limits")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    presentAddSheet()
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .disabled(!viewModel.canAddMoreLimits)
+                .accessibilityIdentifier("category-limits-add")
+            }
+        }
+        .sheet(item: $editorMode) { mode in
+            CategoryLimitEditorSheet(mode: mode) { limit in
+                viewModel.saveLimit(limit)
+            }
+        }
         .task {
             viewModel.loadLimits()
         }
     }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("No Limits Configured", systemImage: "shield.lefthalf.filled")
+        } description: {
+            Text("Optional warnings for medication-overuse headache risk. These are informational only — talk to your doctor before relying on them.")
+        } actions: {
+            Button {
+                presentAddSheet()
+            } label: {
+                Text("Add Limit")
+                    .fontWeight(.semibold)
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("category-limits-empty-add")
+        }
+    }
+
+    // MARK: - List
+
+    private var limitsList: some View {
+        List {
+            Section {
+                ForEach(configuredLimitsInOrder) { limit in
+                    Button {
+                        editorMode = .edit(existing: limit)
+                    } label: {
+                        limitRow(limit)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("limit-row-\(limit.category.rawValue)")
+                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                        Button(role: .destructive) {
+                            viewModel.clearLimit(limit.category)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        .accessibilityIdentifier("limit-row-delete-\(limit.category.rawValue)")
+                    }
+                }
+            } footer: {
+                Text("Informational warnings only — not medical advice. The app will not block you from logging doses. Talk to your doctor about appropriate thresholds. Common guidelines: NSAIDs 15/30, Triptans 10/30.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func limitRow(_ limit: CategoryUsageLimit) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(limit.category.displayName)
+                    .font(.body)
+                Text("\(limit.maxDays) days in any \(limit.windowDays) days")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.footnote)
+                .foregroundStyle(.tertiary)
+        }
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Helpers
+
+    private var configuredLimitsInOrder: [CategoryUsageLimit] {
+        MedicationCategory.allCases.compactMap { viewModel.limits[$0] }
+    }
+
+    private func presentAddSheet() {
+        editorMode = .add(available: viewModel.availableCategoriesForAdd)
+    }
 }
 
-// MARK: - Per-Category Section
+// MARK: - Sheet Identifiable
 
-private struct CategoryLimitSection: View {
-    let category: MedicationCategory
-    let existing: CategoryUsageLimit?
-    let onSave: (Int, Int) -> Void
-    let onClear: () -> Void
-
-    @State private var maxDaysText: String = ""
-    @State private var windowDaysText: String = ""
-    @FocusState private var maxDaysFocused: Bool
-    @FocusState private var windowDaysFocused: Bool
-
-    var body: some View {
-        Section(category.displayName) {
-            TextField("Max days", text: $maxDaysText)
-                .keyboardType(.numberPad)
-                .focused($maxDaysFocused)
-                .accessibilityIdentifier("max-days-\(category.rawValue)")
-                .onChange(of: maxDaysFocused) { _, focused in
-                    if !focused { commitIfValid() }
-                }
-
-            TextField("Window (days)", text: $windowDaysText)
-                .keyboardType(.numberPad)
-                .focused($windowDaysFocused)
-                .accessibilityIdentifier("window-days-\(category.rawValue)")
-                .onChange(of: windowDaysFocused) { _, focused in
-                    if !focused { commitIfValid() }
-                }
-
-            HStack {
-                Button("Save") {
-                    commitIfValid()
-                }
-                .disabled(!hasValidInput)
-                .accessibilityIdentifier("save-limit-\(category.rawValue)")
-
-                Spacer()
-
-                if existing != nil {
-                    Button("Clear", role: .destructive) {
-                        onClear()
-                        maxDaysText = ""
-                        windowDaysText = ""
-                    }
-                    .accessibilityIdentifier("clear-limit-\(category.rawValue)")
-                }
-            }
+extension CategoryLimitEditorSheet.Mode: Identifiable {
+    var id: String {
+        switch self {
+        case .add:                 return "__add__"
+        case .edit(let existing):  return existing.category.rawValue
         }
-        .onAppear {
-            if let e = existing {
-                maxDaysText = String(e.maxDays)
-                windowDaysText = String(e.windowDays)
-            }
-        }
-        .onChange(of: existing) { _, new in
-            if let e = new {
-                maxDaysText = String(e.maxDays)
-                windowDaysText = String(e.windowDays)
-            }
-        }
-    }
-
-    private var hasValidInput: Bool {
-        guard let maxDays = Int(maxDaysText), maxDays > 0 else { return false }
-        guard let windowDays = Int(windowDaysText), windowDays > 0 else { return false }
-        return maxDays <= windowDays
-    }
-
-    private func commitIfValid() {
-        guard let maxDays = Int(maxDaysText), maxDays > 0 else { return }
-        guard let windowDays = Int(windowDaysText), windowDays > 0 else { return }
-        guard maxDays <= windowDays else { return }
-        onSave(maxDays, windowDays)
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/CategoryLimitsScreen.swift
@@ -100,6 +100,7 @@ struct CategoryLimitsScreen: View {
             Image(systemName: "chevron.right")
                 .font(.footnote)
                 .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
         }
         .contentShape(Rectangle())
     }
@@ -112,16 +113,5 @@ struct CategoryLimitsScreen: View {
 
     private func presentAddSheet() {
         editorMode = .add(available: viewModel.availableCategoriesForAdd)
-    }
-}
-
-// MARK: - Sheet Identifiable
-
-extension CategoryLimitEditorSheet.Mode: Identifiable {
-    var id: String {
-        switch self {
-        case .add:                 return "__add__"
-        case .edit(let existing):  return existing.category.rawValue
-        }
     }
 }

--- a/mobile-apps/ios/MigraLogTests/Models/MedicationCategoryTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Models/MedicationCategoryTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import MigraLog
+
+final class MedicationCategoryTests: XCTestCase {
+    func test_mohPreset_forNSAID_is15DaysIn30Days() {
+        let preset = MedicationCategory.nsaid.mohPreset
+        XCTAssertEqual(preset?.maxDays, 15)
+        XCTAssertEqual(preset?.windowDays, 30)
+    }
+
+    func test_mohPreset_forTriptan_is10DaysIn30Days() {
+        let preset = MedicationCategory.triptan.mohPreset
+        XCTAssertEqual(preset?.maxDays, 10)
+        XCTAssertEqual(preset?.windowDays, 30)
+    }
+
+    func test_mohPreset_forOTC_isNil() {
+        XCTAssertNil(MedicationCategory.otc.mohPreset)
+    }
+
+    func test_mohPreset_forCGRP_isNil() {
+        XCTAssertNil(MedicationCategory.cgrp.mohPreset)
+    }
+
+    func test_mohPreset_forPreventive_isNil() {
+        XCTAssertNil(MedicationCategory.preventive.mohPreset)
+    }
+
+    func test_mohPreset_forSupplement_isNil() {
+        XCTAssertNil(MedicationCategory.supplement.mohPreset)
+    }
+
+    func test_mohPreset_forOther_isNil() {
+        XCTAssertNil(MedicationCategory.other.mohPreset)
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Repositories/CategoryUsageLimitRepositoryTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Repositories/CategoryUsageLimitRepositoryTests.swift
@@ -120,8 +120,10 @@ final class CategoryUsageLimitRepositoryTests: XCTestCase {
 
     func testCountUsageDays_multipleDosesSameDay_countsAsOne() throws {
         let med = try medRepo.createMedication(makeMedication(category: .nsaid))
-        let now = Date()
-        // Three doses all "today"
+        // Anchor at noon local time so adding 2h stays on the same calendar day
+        // regardless of the wall clock when the test runs (previous `Date()` +2h
+        // offset flaked when the test ran after 22:00 local).
+        let now = Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: Date())!
         _ = try medRepo.createDose(makeDose(medicationId: med.id, at: now))
         _ = try medRepo.createDose(makeDose(medicationId: med.id, at: now.addingTimeInterval(3600)))
         _ = try medRepo.createDose(makeDose(medicationId: med.id, at: now.addingTimeInterval(7200)))

--- a/mobile-apps/ios/MigraLogTests/ViewModels/CategoryLimitsViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/CategoryLimitsViewModelTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import MigraLog
+
+@MainActor
+final class CategoryLimitsViewModelTests: XCTestCase {
+    private var mockRepo: MockCategoryUsageLimitRepository!
+    private var sut: CategoryLimitsViewModel!
+
+    override func setUp() {
+        super.setUp()
+        mockRepo = MockCategoryUsageLimitRepository()
+        sut = CategoryLimitsViewModel(repository: mockRepo)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockRepo = nil
+        super.tearDown()
+    }
+
+    // MARK: - loadLimits
+
+    func test_loadLimits_populatesLimitsMapKeyedByCategory() {
+        let nsaid = CategoryUsageLimit(category: .nsaid, maxDays: 15, windowDays: 30)
+        let triptan = CategoryUsageLimit(category: .triptan, maxDays: 10, windowDays: 30)
+        mockRepo.limits = [.nsaid: nsaid, .triptan: triptan]
+
+        sut.loadLimits()
+
+        XCTAssertEqual(sut.limits[.nsaid], nsaid)
+        XCTAssertEqual(sut.limits[.triptan], triptan)
+        XCTAssertNil(sut.limits[.otc])
+    }
+
+    // MARK: - availableCategoriesForAdd
+
+    func test_availableCategoriesForAdd_whenEmpty_returnsAllCategories() {
+        sut.loadLimits()
+
+        XCTAssertEqual(Set(sut.availableCategoriesForAdd), Set(MedicationCategory.allCases))
+    }
+
+    func test_availableCategoriesForAdd_excludesConfiguredCategories() {
+        mockRepo.limits = [
+            .nsaid: CategoryUsageLimit(category: .nsaid, maxDays: 15, windowDays: 30)
+        ]
+        sut.loadLimits()
+
+        XCTAssertFalse(sut.availableCategoriesForAdd.contains(.nsaid))
+        XCTAssertTrue(sut.availableCategoriesForAdd.contains(.triptan))
+        XCTAssertEqual(sut.availableCategoriesForAdd.count, MedicationCategory.allCases.count - 1)
+    }
+
+    func test_availableCategoriesForAdd_preservesAllCasesOrder() {
+        mockRepo.limits = [
+            .triptan: CategoryUsageLimit(category: .triptan, maxDays: 10, windowDays: 30)
+        ]
+        sut.loadLimits()
+
+        let expected = MedicationCategory.allCases.filter { $0 != .triptan }
+        XCTAssertEqual(sut.availableCategoriesForAdd, expected)
+    }
+
+    // MARK: - canAddMoreLimits
+
+    func test_canAddMoreLimits_whenEmpty_isTrue() {
+        sut.loadLimits()
+        XCTAssertTrue(sut.canAddMoreLimits)
+    }
+
+    func test_canAddMoreLimits_whenAllConfigured_isFalse() {
+        var map: [MedicationCategory: CategoryUsageLimit] = [:]
+        for c in MedicationCategory.allCases {
+            map[c] = CategoryUsageLimit(category: c, maxDays: 1, windowDays: 1)
+        }
+        mockRepo.limits = map
+        sut.loadLimits()
+
+        XCTAssertFalse(sut.canAddMoreLimits)
+    }
+
+    // MARK: - saveLimit
+
+    func test_saveLimit_addsToLimitsMap() {
+        let limit = CategoryUsageLimit(category: .nsaid, maxDays: 15, windowDays: 30)
+        sut.saveLimit(limit)
+
+        XCTAssertEqual(sut.limits[.nsaid], limit)
+        XCTAssertTrue(mockRepo.setLimitCalled)
+    }
+
+    // MARK: - clearLimit
+
+    func test_clearLimit_removesFromLimitsMap() {
+        mockRepo.limits = [
+            .nsaid: CategoryUsageLimit(category: .nsaid, maxDays: 15, windowDays: 30)
+        ]
+        sut.loadLimits()
+        XCTAssertNotNil(sut.limits[.nsaid])
+
+        sut.clearLimit(.nsaid)
+
+        XCTAssertNil(sut.limits[.nsaid])
+        XCTAssertTrue(mockRepo.clearLimitCalled)
+    }
+}


### PR DESCRIPTION
## Summary
- Redesign Settings → Medication Safety Limits: replaces all-categories form with an Add-based flow (list of configured limits, modal editor sheet with category picker + preset auto-fill for NSAID 15/30 and Triptan 10/30, swipe-to-delete).
- Add safety banners above the Log button on the Dashboard rows and Log Medication cards, and at the top of both dose-log sheets: orange clock for cooldown, orange triangle for MOH approaching, red triangle for at/over.
- Fix a timezone-brittle repo test that flaked when run late evening.

## Test plan
- [x] Unit + UI suites pass locally
- [ ] Empty state, add with/without preset, picker filtering, edit, swipe-to-delete, all-configured state
- [ ] Banners render on Dashboard, Log Medication list, and both dose-log sheets; colors readable in light and dark mode
- [ ] Cooldown clock + MOH triangle visible simultaneously when both apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)