### PR TITLE
fix(ios): notification action completion handler must run on main actor (#397)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/NotificationResponseHandler.swift
+++ b/mobile-apps/ios/MigraLog/Services/NotificationResponseHandler.swift
@@ -65,7 +65,13 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
                 logger.debug("Unhandled notification category: \(categoryIdentifier)")
             }
 
-            completionHandler()
+            // UNUserNotificationCenterDelegate requires the completion handler to
+            // be called on the main thread. Invoking it from this unstructured
+            // Task would run it off the main actor and trip a UIKit state
+            // restoration assertion (see issue #397 / TestFlight 1.0.26 crash).
+            await MainActor.run {
+                completionHandler()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a crash (SIGABRT / NSAssertionHandler failure) that occurred when a user tapped a medication reminder notification action ("Taken" / "Skipped" / "Snooze") while the app was in the background. Observed on TestFlight 1.0.26.

## Root cause

`UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)` contractually requires the completion handler to be invoked on the main thread. The current implementation wrapped the handling work in an unstructured `Task { ... }` and called `completionHandler()` from inside that task — i.e., off the main actor.

When UIKit subsequently processed the associated background state-restoration event, an assertion inside `-[UIApplication _performBlockAfterCATransactionCommitSynchronizes:]` fired, crashing the process. Crash backtrace from the report:

```
3  -[UIApplication _performBlockAfterCATransactionCommitSynchronizes:] + 276
4  -[UIApplication _updateStateRestorationArchiveForBackgroundEvent:saveState:exitIfCouldNotRestoreState:updateSnapshot:windowScene:]
6  closure #1 in NotificationResponseHandler.userNotificationCenter(_:didReceive:withCompletionHandler:) + 28 (NotificationResponseHandler.swift:68)
```

## Fix

Hop to `MainActor` before invoking `completionHandler()` at the end of the Task in `NotificationResponseHandler.swift`. The sibling `willPresent` delegate method already calls its completion handler synchronously (no Task), so no change is required there.

## Test plan

- [ ] Install build on a real device, schedule a medication reminder, background the app, tap "Taken" from the notification — app should not crash.
- [ ] Repeat with "Skipped" and "Snooze" actions.
- [ ] Verify the dose is logged correctly and the notification dismisses.
- [ ] Sanity-check daily check-in notification "Clear day" action still works.

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)