### PR TITLE
fix(ios): re-sync medication reminder schedule on dose change (#399)

### DIFF
--- a/mobile-apps/ios/MigraLog/ViewModels/MedicationDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/MedicationDetailViewModel.swift
@@ -111,10 +111,37 @@ final class MedicationDetailViewModel {
     @MainActor
     func updateMedication(_ updated: Medication) async {
         do {
+            let previous = medication
             _ = try medicationRepository.updateMedication(updated)
             medication = updated
+
+            // If defaultQuantity changed, sync all schedules' dosage to match. The
+            // dashboard "Today's Medications" card reads schedule.dosage for the
+            // "Log N × Xmg" button, so schedules must track the medication's
+            // default dose or the card will show a stale quantity (#399).
+            if previous?.defaultQuantity != updated.defaultQuantity,
+               let newQuantity = updated.defaultQuantity {
+                var updatedSchedules: [MedicationSchedule] = []
+                for schedule in schedules where schedule.dosage != newQuantity {
+                    var next = schedule
+                    next.dosage = newQuantity
+                    _ = try medicationRepository.updateSchedule(next)
+                    updatedSchedules.append(next)
+                }
+                // Reflect in local state
+                for updatedSchedule in updatedSchedules {
+                    if let index = schedules.firstIndex(where: { $0.id == updatedSchedule.id }) {
+                        schedules[index] = updatedSchedule
+                    }
+                }
+            }
+
             // Reschedule notifications when medication is updated
             await rescheduleNotifications(for: updated)
+
+            // Notify dashboard/list views so they refresh cached medication and
+            // schedule data (home card label, cooldown, etc.).
+            NotificationCenter.default.post(name: .medicationDataChanged, object: nil)
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "MedicationDetailViewModel"])
             self.error = error.localizedDescription

--- a/mobile-apps/ios/MigraLogTests/ViewModels/MedicationDetailViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/MedicationDetailViewModelTests.swift
@@ -167,4 +167,57 @@ final class MedicationDetailViewModelTests: XCTestCase {
 
         XCTAssertFalse(sut.schedules[0].enabled)
     }
+
+    // MARK: - Update Medication (defaultQuantity sync)
+
+    /// Regression test for #399: changing a medication's default dose must also
+    /// update the dosage on all associated schedules, because the dashboard home
+    /// card reads `schedule.dosage` (not `medication.defaultQuantity`) for its
+    /// "Log N × Xmg" label and the logDose flow.
+    func testUpdateMedication_whenDefaultQuantityChanges_updatesSchedulesDosage() async throws {
+        // Seed: medication with defaultQuantity 2 and a schedule whose dosage is
+        // also 2 (mirrors the state after AddMedicationScreen + typical usage).
+        var seededMed = TestFixtures.makeMedication(id: "med-1", name: "Ibuprofen")
+        seededMed.defaultQuantity = 2.0
+        mockRepo.medications = [seededMed]
+        mockRepo.schedules = [
+            TestFixtures.makeSchedule(id: "sched-1", medicationId: "med-1", time: "08:00", dosage: 2.0),
+            TestFixtures.makeSchedule(id: "sched-2", medicationId: "med-1", time: "20:00", dosage: 2.0)
+        ]
+
+        await sut.loadMedication()
+        XCTAssertEqual(sut.medication?.defaultQuantity, 2.0)
+        XCTAssertEqual(sut.schedules.count, 2)
+
+        // Act: user edits the medication and changes defaultQuantity from 2 → 1.
+        var updated = sut.medication!
+        updated.defaultQuantity = 1.0
+        await sut.updateMedication(updated)
+
+        // Assert: view-model schedules and the mock repo's schedules reflect the
+        // new quantity, not the old one.
+        XCTAssertEqual(sut.medication?.defaultQuantity, 1.0)
+        XCTAssertTrue(sut.schedules.allSatisfy { $0.dosage == 1.0 }, "All schedules should be updated to new defaultQuantity")
+        let storedSchedules = try mockRepo.getSchedulesByMedicationId("med-1")
+        XCTAssertTrue(storedSchedules.allSatisfy { $0.dosage == 1.0 }, "Persisted schedules should reflect new quantity")
+    }
+
+    func testUpdateMedication_whenDefaultQuantityUnchanged_doesNotTouchSchedules() async throws {
+        var seededMed = TestFixtures.makeMedication(id: "med-1", name: "Ibuprofen")
+        seededMed.defaultQuantity = 2.0
+        mockRepo.medications = [seededMed]
+        mockRepo.schedules = [
+            TestFixtures.makeSchedule(id: "sched-1", medicationId: "med-1", time: "08:00", dosage: 2.0)
+        ]
+
+        await sut.loadMedication()
+
+        // Act: change name only, leave defaultQuantity alone.
+        var updated = sut.medication!
+        updated.name = "Advil"
+        await sut.updateMedication(updated)
+
+        // Schedule dosage should be untouched.
+        XCTAssertEqual(sut.schedules[0].dosage, 2.0)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the issue where changing a medication's default dose would leave the home screen card showing the stale quantity (e.g. "Log 2 × 2 capsules" even after changing the default from 2 to 1).

### Root cause
The dashboard `MedicationScheduleRow` renders and logs doses using `item.schedule.dosage`, not `medication.defaultQuantity`. When the user edited the medication through `EditMedicationScreen → MedicationDetailViewModel.updateMedication`, only the `medications` row was updated — the `medication_schedules.dosage` field was left pointing at the original quantity, so the card kept rendering the old "N × amountUnit" string.

### Fix
Updated `MedicationDetailViewModel.updateMedication` to:

1. Detect when `defaultQuantity` changes on the updated medication.
2. Propagate the new quantity to every associated schedule's `dosage` field (persisted + in-memory), so the dashboard card and dose-logging paths pick up the new value.
3. Post `NotificationCenter.default.post(name: .medicationDataChanged)` so `DashboardScreen` and `MedicationsScreen` refresh their caches after the edit.

Notification bodies themselves don't embed the quantity (they use name + dosageAmount/unit), and the existing `rescheduleAllMedicationNotifications` call already re-creates reminders, so no additional notification plumbing was needed.

### Test plan
- [x] Added regression test `testUpdateMedication_whenDefaultQuantityChanges_updatesSchedulesDosage` that seeds a med + two schedules with quantity 2, updates default to 1, and asserts both schedules (view-model state and persisted repo state) now read 1.
- [x] Added `testUpdateMedication_whenDefaultQuantityUnchanged_doesNotTouchSchedules` to verify non-quantity edits don't disturb schedules.
- [x] `xcodebuild build` succeeds for the `MigraLog` scheme.
- [x] `xcodebuild test -only-testing:MigraLogTests/MedicationDetailViewModelTests` — 15/15 pass.

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)