### PR TITLE
fix(rn): remove 50-episode cap in JSON export, add metadata (#357)

### DIFF
--- a/mobile-apps/react-native/docs/json-export-format.md
+++ b/mobile-apps/react-native/docs/json-export-format.md
@@ -24,12 +24,27 @@ interface BackupData {
   episodes: Episode[];
   episodeNotes?: EpisodeNote[];
   intensityReadings?: IntensityReading[];
+  symptomLogs?: SymptomLog[];
+  painLocationLogs?: PainLocationLog[];
   dailyStatusLogs?: DailyStatusLog[];
+  calendarOverlays?: CalendarOverlay[];
   medications: Medication[];
   medicationDoses: MedicationDose[];
   medicationSchedules: MedicationSchedule[];
 }
 ```
+
+### Completeness
+
+As of Issue #357, the JSON export is **unbounded by default**: every episode,
+every medication dose, and every related child record (intensity readings,
+episode notes, symptom logs, pain location logs) is included. Earlier versions
+silently capped episodes at 50 and doses at 100 — that cap has been removed so
+that healthcare-provider reports contain the full history.
+
+To help consumers verify completeness, `metadata.counts` includes a
+per-entity row count that matches the length of each corresponding array in
+the export (see "Metadata" below).
 
 ### File Naming Convention
 
@@ -51,6 +66,22 @@ interface BackupMetadata {
   schemaVersion: number;        // Database schema version
   episodeCount: number;         // Total episodes in export
   medicationCount: number;      // Total medications in export
+  overlayCount?: number;        // Total calendar overlays in export
+  // Added in Issue #357: per-entity row counts that should match the
+  // length of each array in the export. Consumers can compare these to
+  // detect truncated or corrupt exports.
+  counts?: {
+    episodes: number;
+    episodeNotes: number;
+    intensityReadings: number;
+    symptomLogs: number;
+    painLocationLogs: number;
+    dailyStatusLogs: number;
+    medications: number;
+    medicationDoses: number;
+    medicationSchedules: number;
+    calendarOverlays: number;
+  };
 }
 ```
 
@@ -63,7 +94,20 @@ interface BackupMetadata {
     "version": "2.1.0",
     "schemaVersion": 19,
     "episodeCount": 45,
-    "medicationCount": 8
+    "medicationCount": 8,
+    "overlayCount": 2,
+    "counts": {
+      "episodes": 45,
+      "episodeNotes": 120,
+      "intensityReadings": 312,
+      "symptomLogs": 178,
+      "painLocationLogs": 90,
+      "dailyStatusLogs": 730,
+      "medications": 8,
+      "medicationDoses": 210,
+      "medicationSchedules": 3,
+      "calendarOverlays": 2
+    }
   }
 }
 ```

--- a/mobile-apps/react-native/src/models/types.ts
+++ b/mobile-apps/react-native/src/models/types.ts
@@ -198,6 +198,26 @@ export interface CalendarOverlay {
 }
 
 // Backup/Restore types
+
+/**
+ * Per-entity row counts included in JSON export metadata.
+ * Issue #357: consumers (healthcare providers, third-party importers) can
+ * compare these against the array lengths in the export to verify that no
+ * silent truncation occurred.
+ */
+export interface BackupEntityCounts {
+  episodes: number;
+  episodeNotes: number;
+  intensityReadings: number;
+  symptomLogs: number;
+  painLocationLogs: number;
+  dailyStatusLogs: number;
+  medications: number;
+  medicationDoses: number;
+  medicationSchedules: number;
+  calendarOverlays: number;
+}
+
 export interface BackupMetadata {
   id: string;
   timestamp: number;
@@ -206,6 +226,11 @@ export interface BackupMetadata {
   episodeCount: number;
   medicationCount: number;
   overlayCount?: number; // Optional for backward compatibility with older backups
+  /**
+   * Full per-entity counts. Present on JSON exports created after Issue #357.
+   * Optional for backward compatibility with older backup files.
+   */
+  counts?: BackupEntityCounts;
   fileSize: number;
   fileName: string;
   // Note: Only snapshot (.db) backups are supported (Issue #194)
@@ -220,6 +245,8 @@ export interface BackupData {
   episodes: Episode[];
   episodeNotes?: EpisodeNote[]; // Optional for backward compatibility
   intensityReadings?: IntensityReading[]; // Optional for backward compatibility
+  symptomLogs?: SymptomLog[]; // Added per Issue #357 for complete healthcare data
+  painLocationLogs?: PainLocationLog[]; // Added per Issue #357 for complete healthcare data
   dailyStatusLogs?: DailyStatusLog[]; // Optional for backward compatibility
   calendarOverlays?: CalendarOverlay[]; // Optional for backward compatibility
   medications: Medication[];

--- a/mobile-apps/react-native/src/services/__tests__/BackupExporter.test.ts
+++ b/mobile-apps/react-native/src/services/__tests__/BackupExporter.test.ts
@@ -2,7 +2,13 @@ import { backupExporter } from '../backup/BackupExporter';
 import * as FileSystem from 'expo-file-system/legacy';
 import * as Sharing from 'expo-sharing';
 import * as DocumentPicker from 'expo-document-picker';
-import { episodeRepository, episodeNoteRepository, intensityRepository } from '../../database/episodeRepository';
+import {
+  episodeRepository,
+  episodeNoteRepository,
+  intensityRepository,
+  symptomLogRepository,
+  painLocationLogRepository,
+} from '../../database/episodeRepository';
 import { medicationRepository, medicationDoseRepository, medicationScheduleRepository } from '../../database/medicationRepository';
 import { dailyStatusRepository } from '../../database/dailyStatusRepository';
 import { overlayRepository } from '../../database/overlayRepository';
@@ -42,6 +48,12 @@ jest.mock('../../database/episodeRepository', () => ({
     getByEpisodeId: jest.fn(),
   },
   intensityRepository: {
+    getByEpisodeId: jest.fn(),
+  },
+  symptomLogRepository: {
+    getByEpisodeId: jest.fn(),
+  },
+  painLocationLogRepository: {
     getByEpisodeId: jest.fn(),
   },
 }));
@@ -224,12 +236,40 @@ describe('BackupExporter', () => {
       },
     ];
 
+    const mockSymptomLogs = [
+      {
+        id: 'symptomlog1',
+        episodeId: 'ep1',
+        symptom: 'nausea' as const,
+        onsetTime: Date.now(),
+        severity: 5,
+        createdAt: Date.now(),
+      },
+    ];
+
+    const mockPainLocationLogs = [
+      {
+        id: 'painloclog1',
+        episodeId: 'ep1',
+        timestamp: Date.now(),
+        painLocations: ['left_temple' as const],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ];
+
     beforeEach(() => {
-      (episodeRepository.getAll as jest.Mock).mockResolvedValue(mockEpisodes);
+      // Default: first page returns mockEpisodes; subsequent pages empty so
+      // pagination loop terminates. Tests that need large datasets can override.
+      (episodeRepository.getAll as jest.Mock).mockImplementation(
+        async (_limit: number, offset: number) => (offset === 0 ? mockEpisodes : []),
+      );
       (medicationRepository.getAll as jest.Mock).mockResolvedValue(mockMedications);
       (medicationDoseRepository.getAll as jest.Mock).mockResolvedValue(mockMedicationDoses);
       (episodeNoteRepository.getByEpisodeId as jest.Mock).mockResolvedValue(mockEpisodeNotes);
       (intensityRepository.getByEpisodeId as jest.Mock).mockResolvedValue(mockIntensityReadings);
+      (symptomLogRepository.getByEpisodeId as jest.Mock).mockResolvedValue(mockSymptomLogs);
+      (painLocationLogRepository.getByEpisodeId as jest.Mock).mockResolvedValue(mockPainLocationLogs);
       (dailyStatusRepository.getDateRange as jest.Mock).mockResolvedValue(mockDailyStatusLogs);
       (overlayRepository.getAll as jest.Mock).mockResolvedValue([]);
       (medicationScheduleRepository.getByMedicationId as jest.Mock).mockResolvedValue(mockMedicationSchedules);
@@ -262,13 +302,26 @@ describe('BackupExporter', () => {
     it('should gather all data types for export', async () => {
       await backupExporter.exportDataAsJson();
 
-      expect(episodeRepository.getAll).toHaveBeenCalledWith(50, 0, mockDatabase);
+      // Issue #357: pagination pulls every episode rather than capping at 50.
+      // The first call uses offset=0; subsequent calls (offset>0) return empty
+      // and terminate the loop.
+      expect(episodeRepository.getAll).toHaveBeenCalledWith(expect.any(Number), 0, mockDatabase);
       expect(medicationRepository.getAll).toHaveBeenCalledWith(mockDatabase);
-      expect(medicationDoseRepository.getAll).toHaveBeenCalledWith(100, mockDatabase);
+      // Issue #357: medicationDoseRepository.getAll is now called with a large
+      // limit (not the old 100-row cap) to return every dose.
+      expect(medicationDoseRepository.getAll).toHaveBeenCalled();
+      const doseCallLimit = (medicationDoseRepository.getAll as jest.Mock).mock.calls[0][0];
+      expect(doseCallLimit).toBeGreaterThanOrEqual(1000);
       expect(episodeNoteRepository.getByEpisodeId).toHaveBeenCalledWith('ep1', mockDatabase);
       expect(episodeNoteRepository.getByEpisodeId).toHaveBeenCalledWith('ep2', mockDatabase);
       expect(intensityRepository.getByEpisodeId).toHaveBeenCalledWith('ep1', mockDatabase);
       expect(intensityRepository.getByEpisodeId).toHaveBeenCalledWith('ep2', mockDatabase);
+      // Issue #357: symptom and pain location logs are child entities of an
+      // episode and are now included in exports.
+      expect(symptomLogRepository.getByEpisodeId).toHaveBeenCalledWith('ep1', mockDatabase);
+      expect(symptomLogRepository.getByEpisodeId).toHaveBeenCalledWith('ep2', mockDatabase);
+      expect(painLocationLogRepository.getByEpisodeId).toHaveBeenCalledWith('ep1', mockDatabase);
+      expect(painLocationLogRepository.getByEpisodeId).toHaveBeenCalledWith('ep2', mockDatabase);
       expect(dailyStatusRepository.getDateRange).toHaveBeenCalled();
       expect(medicationScheduleRepository.getByMedicationId).toHaveBeenCalledWith('med1', mockDatabase);
       expect(migrationRunner.getCurrentVersion).toHaveBeenCalled();
@@ -281,8 +334,105 @@ describe('BackupExporter', () => {
       expect(fileContent.medicationDoses).toEqual(mockMedicationDoses);
       expect(fileContent.episodeNotes.length).toBeGreaterThan(0);
       expect(fileContent.intensityReadings.length).toBeGreaterThan(0);
+      expect(fileContent.symptomLogs.length).toBeGreaterThan(0);
+      expect(fileContent.painLocationLogs.length).toBeGreaterThan(0);
       expect(fileContent.dailyStatusLogs).toEqual(mockDailyStatusLogs);
       expect(fileContent.medicationSchedules.length).toBeGreaterThan(0);
+    });
+
+    it('exports every episode when more than 50 exist (Issue #357)', async () => {
+      // Generate 175 episodes — well over the prior 50-row cap.
+      const manyEpisodes = Array.from({ length: 175 }, (_, i) => ({
+        id: `ep_${i}`,
+        startTime: Date.now() - i * 60_000,
+        endTime: Date.now() - i * 60_000 + 1_000,
+        currentIntensity: 5,
+        triggers: [],
+        symptoms: [],
+        painLocations: [],
+        painQualities: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }));
+
+      // Simulate paginated repository: return batches of 500 sliced from the
+      // full dataset (first page returns all 175, second page returns empty).
+      (episodeRepository.getAll as jest.Mock).mockImplementation(
+        async (limit: number, offset: number) => manyEpisodes.slice(offset, offset + limit),
+      );
+      // Keep child-entity mocks empty for this volume-focused test to keep
+      // the assertion simple.
+      (episodeNoteRepository.getByEpisodeId as jest.Mock).mockResolvedValue([]);
+      (intensityRepository.getByEpisodeId as jest.Mock).mockResolvedValue([]);
+      (symptomLogRepository.getByEpisodeId as jest.Mock).mockResolvedValue([]);
+      (painLocationLogRepository.getByEpisodeId as jest.Mock).mockResolvedValue([]);
+
+      await backupExporter.exportDataAsJson();
+
+      const writeCall = (FileSystem.writeAsStringAsync as jest.Mock).mock.calls[0];
+      const fileContent = JSON.parse(writeCall[1]);
+
+      expect(fileContent.episodes).toHaveLength(175);
+      expect(fileContent.metadata.episodeCount).toBe(175);
+      expect(fileContent.metadata.counts.episodes).toBe(175);
+    });
+
+    it('includes metadata counts for every exported entity (Issue #357)', async () => {
+      await backupExporter.exportDataAsJson();
+
+      const writeCall = (FileSystem.writeAsStringAsync as jest.Mock).mock.calls[0];
+      const fileContent = JSON.parse(writeCall[1]);
+
+      // Counts must match the actual array lengths so consumers can verify
+      // completeness of the export.
+      expect(fileContent.metadata.counts).toEqual({
+        episodes: fileContent.episodes.length,
+        episodeNotes: fileContent.episodeNotes.length,
+        intensityReadings: fileContent.intensityReadings.length,
+        symptomLogs: fileContent.symptomLogs.length,
+        painLocationLogs: fileContent.painLocationLogs.length,
+        dailyStatusLogs: fileContent.dailyStatusLogs.length,
+        medications: fileContent.medications.length,
+        medicationDoses: fileContent.medicationDoses.length,
+        medicationSchedules: fileContent.medicationSchedules.length,
+        calendarOverlays: fileContent.calendarOverlays.length,
+      });
+      expect(fileContent.metadata.overlayCount).toBe(fileContent.calendarOverlays.length);
+    });
+
+    it('paginates across multiple pages when >500 episodes exist (Issue #357)', async () => {
+      // 1,250 episodes: exercises the pagination loop across 3 pages.
+      const manyEpisodes = Array.from({ length: 1250 }, (_, i) => ({
+        id: `ep_${i}`,
+        startTime: Date.now() - i * 60_000,
+        endTime: Date.now() - i * 60_000 + 1_000,
+        currentIntensity: 5,
+        triggers: [],
+        symptoms: [],
+        painLocations: [],
+        painQualities: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }));
+      (episodeRepository.getAll as jest.Mock).mockImplementation(
+        async (limit: number, offset: number) => manyEpisodes.slice(offset, offset + limit),
+      );
+      (episodeNoteRepository.getByEpisodeId as jest.Mock).mockResolvedValue([]);
+      (intensityRepository.getByEpisodeId as jest.Mock).mockResolvedValue([]);
+      (symptomLogRepository.getByEpisodeId as jest.Mock).mockResolvedValue([]);
+      (painLocationLogRepository.getByEpisodeId as jest.Mock).mockResolvedValue([]);
+
+      await backupExporter.exportDataAsJson();
+
+      const writeCall = (FileSystem.writeAsStringAsync as jest.Mock).mock.calls[0];
+      const fileContent = JSON.parse(writeCall[1]);
+      expect(fileContent.episodes).toHaveLength(1250);
+      // Should have called getAll multiple times with increasing offsets.
+      const episodeCalls = (episodeRepository.getAll as jest.Mock).mock.calls;
+      expect(episodeCalls.length).toBeGreaterThanOrEqual(3);
+      const offsets = episodeCalls.map(c => c[1]);
+      expect(offsets).toContain(0);
+      expect(offsets.some((o: number) => o > 0)).toBe(true);
     });
 
     it('should share file with correct metadata', async () => {

--- a/mobile-apps/react-native/src/services/__tests__/backupService.test.ts
+++ b/mobile-apps/react-native/src/services/__tests__/backupService.test.ts
@@ -7,6 +7,8 @@ import {
   episodeRepository,
   episodeNoteRepository,
   intensityRepository,
+  symptomLogRepository,
+  painLocationLogRepository,
 } from '../../database/episodeRepository';
 import {
   medicationRepository,
@@ -1851,6 +1853,8 @@ describe('backupService', () => {
         (intensityRepository.getByEpisodeId as jest.Mock).mockResolvedValue([
           { id: 'reading-1', episodeId: 'ep-1', timestamp: Date.now(), intensity: 5 },
         ]);
+        (symptomLogRepository.getByEpisodeId as jest.Mock).mockResolvedValue([]);
+        (painLocationLogRepository.getByEpisodeId as jest.Mock).mockResolvedValue([]);
         (dailyStatusRepository.getDateRange as jest.Mock).mockResolvedValue([]);
         (medicationScheduleRepository.getByMedicationId as jest.Mock).mockResolvedValue([
           { id: 'sched-1', medicationId: 'med-1', time: '08:00', daysOfWeek: [1, 2, 3, 4, 5] },
@@ -1883,6 +1887,8 @@ describe('backupService', () => {
         (episodeRepository.getAll as jest.Mock).mockResolvedValue([]);
         (medicationRepository.getAll as jest.Mock).mockResolvedValue([]);
         (medicationDoseRepository.getAll as jest.Mock).mockResolvedValue([]);
+        (symptomLogRepository.getByEpisodeId as jest.Mock).mockResolvedValue([]);
+        (painLocationLogRepository.getByEpisodeId as jest.Mock).mockResolvedValue([]);
         (dailyStatusRepository.getDateRange as jest.Mock).mockResolvedValue([]);
         (migrationRunner.getCurrentVersion as jest.Mock).mockResolvedValue(6);
         (FileSystem.writeAsStringAsync as jest.Mock).mockResolvedValue(undefined);

--- a/mobile-apps/react-native/src/services/backup/BackupExporter.ts
+++ b/mobile-apps/react-native/src/services/backup/BackupExporter.ts
@@ -4,7 +4,13 @@ import * as DocumentPicker from 'expo-document-picker';
 import { logger } from '../../utils/logger';
 // ARCHITECTURAL EXCEPTION: Backup/export needs direct repository access
 // because it requires complete database access independent of UI state. See docs/store-repository-guidelines.md
-import { episodeRepository, episodeNoteRepository, intensityRepository } from '../../database/episodeRepository';
+import {
+  episodeRepository,
+  episodeNoteRepository,
+  intensityRepository,
+  symptomLogRepository,
+  painLocationLogRepository,
+} from '../../database/episodeRepository';
 import { medicationRepository, medicationDoseRepository, medicationScheduleRepository } from '../../database/medicationRepository';
 import { dailyStatusRepository } from '../../database/dailyStatusRepository';
 import { overlayRepository } from '../../database/overlayRepository';
@@ -14,6 +20,8 @@ import {
   MedicationSchedule,
   EpisodeNote,
   IntensityReading,
+  SymptomLog,
+  PainLocationLog,
   BackupMetadata,
   BackupData,
   CalendarOverlay,
@@ -29,7 +37,54 @@ import {
  * BackupExporter - Handles export and import of backup files
  * Supports sharing snapshot backups and exporting data as JSON for portability
  */
+// Page size used when paginating repositories that only expose a limit/offset API.
+// Kept large to minimize round-trips while avoiding a single unbounded query.
+const EXPORT_PAGE_SIZE = 500;
+
 class BackupExporter {
+  /**
+   * Paginate through episodeRepository.getAll to load every episode.
+   * Issue #357: the previous export capped episodes at 50, which silently
+   * truncated exports for long-term users.
+   */
+  private async fetchAllEpisodes(
+    db: Awaited<ReturnType<typeof import('../../database/db').getDatabase>>,
+  ) {
+    const all = [] as Awaited<ReturnType<typeof episodeRepository.getAll>>;
+    let offset = 0;
+    // Defensive cap: 1M rows is far beyond any realistic personal dataset.
+    const safetyCap = 1_000_000;
+    while (offset < safetyCap) {
+      const batch = await episodeRepository.getAll(EXPORT_PAGE_SIZE, offset, db);
+      all.push(...batch);
+      if (batch.length < EXPORT_PAGE_SIZE) break;
+      offset += EXPORT_PAGE_SIZE;
+    }
+    return all;
+  }
+
+  /**
+   * Paginate through medicationDoseRepository.getAll to load every dose.
+   * Issue #357: the previous export capped doses at 100.
+   */
+  private async fetchAllMedicationDoses(
+    db: Awaited<ReturnType<typeof import('../../database/db').getDatabase>>,
+  ) {
+    // medicationDoseRepository.getAll only supports a single limit (no offset),
+    // so we pull in one large request. If we hit the ceiling we double and retry
+    // so callers always get the full dataset.
+    let limit = 10_000;
+    // Defensive cap: 1M doses.
+    const maxLimit = 1_000_000;
+    while (limit <= maxLimit) {
+      const batch = await medicationDoseRepository.getAll(limit, db);
+      if (batch.length < limit) return batch;
+      limit *= 2;
+    }
+    // Final attempt at the cap.
+    return medicationDoseRepository.getAll(maxLimit, db);
+  }
+
   /**
    * Export current database as JSON for data portability and healthcare sharing
    * 
@@ -59,21 +114,29 @@ class BackupExporter {
       const db = await import('../../database/db').then(m => m.getDatabase());
 
       // Gather all data
+      // Issue #357: Export ALL episodes and doses (no 50/100 cap) so that
+      // healthcare provider reports are complete. Pagination is used to avoid
+      // passing unbounded limits to SQLite while still returning every row.
       logger.log('[Export] Fetching all data...');
-      const episodes = await episodeRepository.getAll(50, 0, db);
+      const episodes = await this.fetchAllEpisodes(db);
       const medications = await medicationRepository.getAll(db);
-      const medicationDoses = await medicationDoseRepository.getAll(100, db);
+      const medicationDoses = await this.fetchAllMedicationDoses(db);
 
       const episodeNotes: EpisodeNote[] = [];
-      for (const ep of episodes) {
-        const notes = await episodeNoteRepository.getByEpisodeId(ep.id, db);
-        episodeNotes.push(...notes);
-      }
-
       const intensityReadings: IntensityReading[] = [];
+      const symptomLogs: SymptomLog[] = [];
+      const painLocationLogs: PainLocationLog[] = [];
       for (const ep of episodes) {
-        const readings = await intensityRepository.getByEpisodeId(ep.id, db);
+        const [notes, readings, symptoms, painLocs] = await Promise.all([
+          episodeNoteRepository.getByEpisodeId(ep.id, db),
+          intensityRepository.getByEpisodeId(ep.id, db),
+          symptomLogRepository.getByEpisodeId(ep.id, db),
+          painLocationLogRepository.getByEpisodeId(ep.id, db),
+        ]);
+        episodeNotes.push(...notes);
         intensityReadings.push(...readings);
+        symptomLogs.push(...symptoms);
+        painLocationLogs.push(...painLocs);
       }
 
       const twoYearsAgo = new Date();
@@ -89,7 +152,7 @@ class BackupExporter {
         medicationSchedules.push(...schedules);
       }
 
-      const calendarOverlays: CalendarOverlay[] = await overlayRepository.getAll(db);
+      const calendarOverlays: CalendarOverlay[] = (await overlayRepository.getAll(db)) ?? [];
 
       const schemaVersion = await migrationRunner.getCurrentVersion();
 
@@ -103,11 +166,28 @@ class BackupExporter {
           schemaVersion,
           episodeCount: episodes.length,
           medicationCount: medications.length,
+          overlayCount: calendarOverlays.length,
+          // Issue #357: expose full counts so healthcare consumers can verify
+          // that the export is complete (no silent truncation).
+          counts: {
+            episodes: episodes.length,
+            episodeNotes: episodeNotes.length,
+            intensityReadings: intensityReadings.length,
+            symptomLogs: symptomLogs.length,
+            painLocationLogs: painLocationLogs.length,
+            dailyStatusLogs: dailyStatusLogs.length,
+            medications: medications.length,
+            medicationDoses: medicationDoses.length,
+            medicationSchedules: medicationSchedules.length,
+            calendarOverlays: calendarOverlays.length,
+          },
         },
         // schemaSQL omitted - not needed for data sharing, only for backup/restore
         episodes,
         episodeNotes,
         intensityReadings,
+        symptomLogs,
+        painLocationLogs,
         dailyStatusLogs,
         medications,
         medicationDoses,

--- a/spec/schemas/export/migralog-export.schema.json
+++ b/spec/schemas/export/migralog-export.schema.json
@@ -20,6 +20,14 @@
       "type": "array",
       "items": { "$ref": "#/$defs/IntensityReading" }
     },
+    "symptomLogs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/SymptomLog" }
+    },
+    "painLocationLogs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/PainLocationLog" }
+    },
     "dailyStatusLogs": {
       "type": "array",
       "items": { "$ref": "#/$defs/DailyStatusLog" }
@@ -142,7 +150,31 @@
         "schemaVersion": { "type": "integer", "minimum": 1, "description": "Database schema version" },
         "episodeCount": { "type": "integer", "minimum": 0 },
         "medicationCount": { "type": "integer", "minimum": 0 },
-        "overlayCount": { "type": "integer", "minimum": 0 }
+        "overlayCount": { "type": "integer", "minimum": 0 },
+        "counts": { "$ref": "#/$defs/ExportCounts" }
+      }
+    },
+
+    "ExportCounts": {
+      "description": "Per-entity row counts. Added in Issue #357 so consumers can verify export completeness against array lengths.",
+      "type": "object",
+      "required": [
+        "episodes", "episodeNotes", "intensityReadings", "symptomLogs",
+        "painLocationLogs", "dailyStatusLogs", "medications",
+        "medicationDoses", "medicationSchedules", "calendarOverlays"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "episodes": { "type": "integer", "minimum": 0 },
+        "episodeNotes": { "type": "integer", "minimum": 0 },
+        "intensityReadings": { "type": "integer", "minimum": 0 },
+        "symptomLogs": { "type": "integer", "minimum": 0 },
+        "painLocationLogs": { "type": "integer", "minimum": 0 },
+        "dailyStatusLogs": { "type": "integer", "minimum": 0 },
+        "medications": { "type": "integer", "minimum": 0 },
+        "medicationDoses": { "type": "integer", "minimum": 0 },
+        "medicationSchedules": { "type": "integer", "minimum": 0 },
+        "calendarOverlays": { "type": "integer", "minimum": 0 }
       }
     },
 
@@ -187,6 +219,37 @@
         "episodeId": { "type": "string", "minLength": 1 },
         "timestamp": { "$ref": "#/$defs/Timestamp" },
         "intensity": { "type": "number", "minimum": 0, "maximum": 10 },
+        "createdAt": { "$ref": "#/$defs/Timestamp" },
+        "updatedAt": { "$ref": "#/$defs/Timestamp" }
+      }
+    },
+
+    "SymptomLog": {
+      "description": "Individual symptom onset/resolution tracking within an episode. Added to export in Issue #357.",
+      "type": "object",
+      "required": ["id", "episodeId", "symptom", "onsetTime", "createdAt"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "episodeId": { "type": "string", "minLength": 1 },
+        "symptom": { "$ref": "#/$defs/Symptom" },
+        "onsetTime": { "$ref": "#/$defs/Timestamp" },
+        "resolutionTime": { "$ref": "#/$defs/Timestamp" },
+        "severity": { "type": "number", "minimum": 0, "maximum": 10 },
+        "createdAt": { "$ref": "#/$defs/Timestamp" }
+      }
+    },
+
+    "PainLocationLog": {
+      "description": "Timestamped snapshot of pain locations within an episode. Added to export in Issue #357.",
+      "type": "object",
+      "required": ["id", "episodeId", "timestamp", "painLocations", "createdAt"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "episodeId": { "type": "string", "minLength": 1 },
+        "timestamp": { "$ref": "#/$defs/Timestamp" },
+        "painLocations": { "type": "array", "items": { "$ref": "#/$defs/PainLocation" } },
         "createdAt": { "$ref": "#/$defs/Timestamp" },
         "updatedAt": { "$ref": "#/$defs/Timestamp" }
       }


### PR DESCRIPTION
## Summary

Closes #357.

The JSON export for healthcare providers was silently truncating data:

- Episodes were capped at 50 (`episodeRepository.getAll(50, 0, ...)`).
- Medication doses were capped at 100 (`medicationDoseRepository.getAll(100, ...)`).
- Child entities `symptom_logs` and `pain_location_logs` weren't included at all.

This PR:

1. **Removes the caps.** Episodes are paginated through `episodeRepository.getAll` in 500-row pages until every row is loaded; medication doses are fetched with a large limit that auto-doubles if it fills (up to 1M rows) so the full dataset is returned.
2. **Adds child entities.** `symptomLogs` and `painLocationLogs` are now fetched per-episode and included in the export (joined with the existing per-episode fetches for notes/intensity readings).
3. **Adds export metadata.** A new `metadata.counts` object holds per-entity row counts (episodes, episodeNotes, intensityReadings, symptomLogs, painLocationLogs, dailyStatusLogs, medications, medicationDoses, medicationSchedules, calendarOverlays) so consumers can diff against the array lengths to detect truncation. `overlayCount` is also now populated.
4. **Updates the spec.** `BackupData` and `BackupMetadata` types gain the new fields; `docs/json-export-format.md` and `spec/schemas/export/migralog-export.schema.json` document the new shape, including new `SymptomLog` / `PainLocationLog` / `ExportCounts` $defs.

Follow-up (intentionally out of scope here to keep this PR tight): a `dateRange` parameter for scoped exports. Tracked as part of #357 discussion.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test:lint:ci` clean
- [x] `npm run test:ci` — 3299 tests pass
- [x] New tests in `BackupExporter.test.ts` cover: all episodes exported when >50 exist, pagination across multiple pages (1,250-episode dataset), child entity data (symptom + pain location logs) present in output, metadata counts equal array lengths
- [ ] Manual QA on device: verify export file contains all historical episodes and symptom/pain-location logs for a user with >50 episodes

Note: `npm audit` currently fails on `main` with pre-existing transitive-dependency advisories (handlebars, lodash, picomatch, etc.); no new advisories introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)