### PR TITLE
fix(ios): full-width Save button on day-log screen (#415)

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/DailyStatus/DailyStatusPromptScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/DailyStatus/DailyStatusPromptScreen.swift
@@ -226,13 +226,16 @@ struct DailyStatusPromptScreen: View {
                     .textFieldStyle(.roundedBorder)
                     .lineLimit(3...6)
 
-                Button("Save") {
+                Button {
                     Task { await save() }
+                } label: {
+                    Text("Save")
+                        .frame(maxWidth: .infinity)
                 }
                 .accessibilityIdentifier("save-status-button")
                 .buttonStyle(.borderedProminent)
+                .controlSize(.large)
                 .disabled(selectedStatus == nil || isSaving)
-                .frame(maxWidth: .infinity)
             }
 
             if existingStatus != nil {


### PR DESCRIPTION
## Summary
Fixes the undersized Save button on the Day Details (daily status) screen. The button previously used `.borderedProminent` with `.frame(maxWidth: .infinity)` applied on the button itself, which does not stretch the button with that style. The frame now lives on the button's label, matching the pattern already used in `DatabaseErrorView`, and `.controlSize(.large)` is added for a consistent prominent-CTA height.

## Changes
- `mobile-apps/ios/MigraLog/Views/DailyStatus/DailyStatusPromptScreen.swift`: rewrite the Save button to use an explicit label with `.frame(maxWidth: .infinity)` and apply `.controlSize(.large)`.

## Test plan
- [ ] Open Day Details for a day that is not logged; verify the Save button fills the card width once a status is selected.
- [ ] Tap Edit on an existing logged day; verify the Save button is full width while editing.
- [ ] Confirm no regressions to the disabled state (Save remains disabled until a status is chosen or while saving).

Fixes #415