### PR TITLE
ci(swift): run UI tests on main and label-gated PRs

### DIFF
--- a/.github/workflows/ci-swift.yml
+++ b/.github/workflows/ci-swift.yml
@@ -55,3 +55,38 @@ jobs:
           name: swift-test-results
           path: mobile-apps/ios/TestResults.xcresult
           retention-days: 30
+
+  ui-test:
+    name: UI Tests
+    runs-on: macos-26
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-ui-tests')
+    defaults:
+      run:
+        working-directory: ./mobile-apps/ios
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Resolve SPM dependencies
+        run: xcodebuild -resolvePackageDependencies -scheme MigraLog
+
+      - name: Run UI tests
+        run: >
+          xcodebuild test
+          -scheme MigraLog
+          -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'
+          -only-testing:MigraLogUITests
+          -resultBundlePath UITestResults.xcresult
+
+      - name: Upload UI test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: swift-ui-test-results
+          path: mobile-apps/ios/UITestResults.xcresult
+          retention-days: 30


### PR DESCRIPTION
## Summary
- Adds a `ui-test` job to `.github/workflows/ci-swift.yml` so regressions in the UI suite are caught automatically.
- Runs on every push to `main`; on PRs only when labeled `run-ui-tests` (keeps default PR feedback fast — UI suite takes ~11 min locally).
- Uploads `UITestResults.xcresult` as an artifact for post-mortem.

## Why
The UI suite wasn't previously exercised by CI. A recent release stalled locally on environmental UI test failures that a green CI signal against main would have pre-empted — and genuine UI regressions would have gone unnoticed until the next release attempt.

## Test plan
- [ ] Merge triggers the `UI Tests` job on push to main — confirm it runs and passes.
- [ ] Open a throwaway PR without the label — confirm the `UI Tests` job is skipped, only `Build & Test` runs.
- [ ] Add the `run-ui-tests` label to a PR — confirm `UI Tests` job runs.
- [ ] Create the `run-ui-tests` label in the repo if it doesn't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)