### PR TITLE
feat(ios): add Log Medication button to active episode detail

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeActionButtons.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeActionButtons.swift
@@ -7,6 +7,7 @@ struct EpisodeActionButtons: View {
     let episodeId: String
     let viewModel: EpisodeDetailViewModel
     @Binding var showLogUpdate: Bool
+    @Binding var showLogMedication: Bool
     @Binding var customEndTime: Date
     @Binding var showEndTimePicker: Bool
 
@@ -23,6 +24,18 @@ struct EpisodeActionButtons: View {
                     .clipShape(RoundedRectangle(cornerRadius: 12))
             }
             .accessibilityIdentifier("log-update-button")
+
+            Button {
+                showLogMedication = true
+            } label: {
+                Label("Log Medication", systemImage: "pills")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.green.opacity(0.1))
+                    .foregroundStyle(.green)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .accessibilityIdentifier("log-medication-button")
 
             HStack(spacing: 8) {
                 Button {

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -6,6 +6,7 @@ struct EpisodeDetailScreen: View {
     @State private var showEndTimePicker = false
     @State private var showEditSheet = false
     @State private var showLogUpdate = false
+    @State private var showLogMedication = false
     @State private var customEndTime = Date()
 
     // Timeline editing state
@@ -52,6 +53,7 @@ struct EpisodeDetailScreen: View {
                                 episodeId: episodeId,
                                 viewModel: viewModel,
                                 showLogUpdate: $showLogUpdate,
+                                showLogMedication: $showLogMedication,
                                 customEndTime: $customEndTime,
                                 showEndTimePicker: $showEndTimePicker
                             )
@@ -89,6 +91,13 @@ struct EpisodeDetailScreen: View {
                 NavigationStack {
                     LogUpdateScreen(episodeId: details.episode.id, viewModel: viewModel)
                 }
+            }
+        }
+        .sheet(isPresented: $showLogMedication, onDismiss: {
+            Task { await viewModel.loadEpisode(episodeId) }
+        }) {
+            NavigationStack {
+                LogMedicationScreen()
             }
         }
         .sheet(isPresented: $showEndTimePicker) {


### PR DESCRIPTION
## Summary
- Adds a green, full-width "Log Medication" button to the active episode detail screen, sitting between "Log Update" and the End Now / End… row.
- Sheet-presents the existing `LogMedicationScreen`; reloads the episode on dismiss so newly logged doses appear in the timeline.
- Only shown for active episodes (existing `isActive` gate).

## Test plan
- [x] Unit tests pass locally (743/743)
- [x] First 10 UI test suites green locally (run was cut short; full suite running on CI via `run-ui-tests` label)
- [ ] CI: Build & Test green
- [ ] CI: UI Tests green
- [ ] Manual: Start an episode, tap "Log Medication", log a dose, confirm it appears in the timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)