### PR TITLE
feat(ios): add Critical Alerts entitlement

### DIFF
--- a/mobile-apps/ios/MigraLog/App/MigraLog.entitlements
+++ b/mobile-apps/ios/MigraLog/App/MigraLog.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.usernotifications.critical-alerts</key>
+	<true/>
 	<key>com.apple.developer.usernotifications.time-sensitive</key>
 	<true/>
 </dict>


### PR DESCRIPTION
## Summary
Apple approved Critical Alerts on `com.eff3.migralog`. The provisioning profile has been regenerated with the new capability and the GitHub Actions secret updated. This declares the matching entitlement in the app so App Store Connect accepts the next signed build.

```diff
+	<key>com.apple.developer.usernotifications.critical-alerts</key>
+	<true/>
 	<key>com.apple.developer.usernotifications.time-sensitive</key>
 	<true/>
```

## Follow-up (not in this PR)
- Add `UNAuthorizationOptions.criticalAlert` to the notification permission request so the app actually asks for the capability at runtime.
- Decide which medication notifications should be marked critical.

## Test plan
- [x] Build passes (`xcodebuild build`)
- [ ] CI: Build & Test green
- [ ] Local UI tests pass before merge
- [ ] Next TestFlight upload accepted by App Store Connect (no entitlement-mismatch rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)