### PR TITLE
feat(ios): critical alerts on follow-ups, time-sensitive primaries

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/MedicationNotificationService.swift
+++ b/mobile-apps/ios/MigraLog/Services/MedicationNotificationService.swift
@@ -1,6 +1,14 @@
 import Foundation
 import UserNotifications
 
+// MARK: - UserDefaults Keys
+
+private enum NotificationDefaultsKey {
+    static let followUpDelay = "notification_follow_up_delay"
+    static let timeSensitiveEnabled = "notification_time_sensitive_enabled"
+    static let criticalAlertsEnabled = "notification_critical_alerts_enabled"
+}
+
 // MARK: - Protocol
 
 protocol MedicationNotificationServiceProtocol: Sendable {
@@ -84,7 +92,7 @@ actor MedicationNotificationScheduler: MedicationNotificationServiceProtocol {
         // 5. Gather enabled schedules
         var items: [(Medication, MedicationSchedule)] = []
         var slotsPerDay = 0
-        let followUpDelay = UserDefaults.standard.integer(forKey: "notification_follow_up_delay")
+        let followUpDelay = UserDefaults.standard.integer(forKey: NotificationDefaultsKey.followUpDelay)
 
         for medication in preventativeDailyMeds {
             let schedules = try medicationRepo.getSchedulesByMedicationId(medication.id)
@@ -153,7 +161,7 @@ actor MedicationNotificationScheduler: MedicationNotificationServiceProtocol {
                 }
 
                 // Schedule follow-up if enabled
-                let followUpDelay = UserDefaults.standard.integer(forKey: "notification_follow_up_delay")
+                let followUpDelay = UserDefaults.standard.integer(forKey: NotificationDefaultsKey.followUpDelay)
                 if followUpDelay > 0 {
                     guard let followUpTrigger = calendar.date(byAdding: .minute, value: followUpDelay, to: trigger) else { continue }
                     guard followUpTrigger > Date() else { continue }
@@ -206,13 +214,17 @@ actor MedicationNotificationScheduler: MedicationNotificationServiceProtocol {
             userInfo["isFollowUp"] = true
         }
 
+        let (interruptionLevel, useCriticalSound) = interruptionSettings(isFollowUp: isFollowUp)
+
         try await notificationService.scheduleNotification(
             id: notificationId,
             title: title,
             body: body,
             trigger: trigger,
             categoryIdentifier: NotificationCategory.medication,
-            userInfo: userInfo
+            userInfo: userInfo,
+            interruptionLevel: interruptionLevel,
+            useCriticalSound: useCriticalSound
         )
 
         let mapping = ScheduledNotification(
@@ -270,13 +282,17 @@ actor MedicationNotificationScheduler: MedicationNotificationServiceProtocol {
             userInfo["isFollowUp"] = true
         }
 
+        let (interruptionLevel, useCriticalSound) = interruptionSettings(isFollowUp: isFollowUp)
+
         try await notificationService.scheduleNotification(
             id: notificationId,
             title: title,
             body: body,
             trigger: trigger,
             categoryIdentifier: NotificationCategory.multipleMedication,
-            userInfo: userInfo
+            userInfo: userInfo,
+            interruptionLevel: interruptionLevel,
+            useCriticalSound: useCriticalSound
         )
 
         // Create a mapping for each medication in the group
@@ -488,7 +504,7 @@ actor MedicationNotificationScheduler: MedicationNotificationServiceProtocol {
             }
 
             var items: [(Medication, MedicationSchedule)] = []
-            let followUpDelay = UserDefaults.standard.integer(forKey: "notification_follow_up_delay")
+            let followUpDelay = UserDefaults.standard.integer(forKey: NotificationDefaultsKey.followUpDelay)
             var slotsPerDay = 0
 
             for medication in preventativeDailyMeds {
@@ -624,7 +640,7 @@ actor MedicationNotificationScheduler: MedicationNotificationServiceProtocol {
             }
 
             var slotsPerDay = 0
-            let followUpDelay = UserDefaults.standard.integer(forKey: "notification_follow_up_delay")
+            let followUpDelay = UserDefaults.standard.integer(forKey: NotificationDefaultsKey.followUpDelay)
 
             var allSchedules: [(Medication, MedicationSchedule)] = []
             for medication in preventativeDailyMeds {
@@ -692,6 +708,17 @@ actor MedicationNotificationScheduler: MedicationNotificationServiceProtocol {
         guard let date = DateFormatting.date(from: dateString),
               let components = parseTime(time) else { return nil }
         return Calendar.current.date(bySettingHour: components.hour, minute: components.minute, second: 0, of: date)
+    }
+
+    private func interruptionSettings(isFollowUp: Bool) -> (UNNotificationInterruptionLevel, Bool) {
+        let defaults = UserDefaults.standard
+        if isFollowUp {
+            let critical = defaults.bool(forKey: NotificationDefaultsKey.criticalAlertsEnabled)
+            return (critical ? .critical : .active, critical)
+        } else {
+            let timeSensitive = defaults.bool(forKey: NotificationDefaultsKey.timeSensitiveEnabled)
+            return (timeSensitive ? .timeSensitive : .active, false)
+        }
     }
 
     private func parseTime(_ time: String) -> (hour: Int, minute: Int)? {

--- a/mobile-apps/ios/MigraLog/Services/NotificationService.swift
+++ b/mobile-apps/ios/MigraLog/Services/NotificationService.swift
@@ -30,7 +30,9 @@ protocol NotificationServiceProtocol: Sendable {
         body: String,
         trigger: UNNotificationTrigger,
         categoryIdentifier: String?,
-        userInfo: [String: Any]?
+        userInfo: [String: Any]?,
+        interruptionLevel: UNNotificationInterruptionLevel,
+        useCriticalSound: Bool
     ) async throws
     func cancelNotification(id: String)
     func cancelAllNotifications()
@@ -62,9 +64,21 @@ extension NotificationServiceProtocol {
         title: String,
         body: String,
         trigger: UNNotificationTrigger,
-        categoryIdentifier: String?
+        categoryIdentifier: String? = nil,
+        userInfo: [String: Any]? = nil,
+        interruptionLevel: UNNotificationInterruptionLevel = .active,
+        useCriticalSound: Bool = false
     ) async throws {
-        try await scheduleNotification(id: id, title: title, body: body, trigger: trigger, categoryIdentifier: categoryIdentifier, userInfo: nil)
+        try await scheduleNotification(
+            id: id,
+            title: title,
+            body: body,
+            trigger: trigger,
+            categoryIdentifier: categoryIdentifier,
+            userInfo: userInfo,
+            interruptionLevel: interruptionLevel,
+            useCriticalSound: useCriticalSound
+        )
     }
 }
 
@@ -153,7 +167,7 @@ final class NotificationService: NotificationServiceProtocol {
     func requestPermission() async -> Bool {
         do {
             let granted = try await center.requestAuthorization(
-                options: [.alert, .sound, .badge]
+                options: [.alert, .sound, .badge, .criticalAlert, .timeSensitive]
             )
             logger.info("Notification permission \(granted ? "granted" : "denied")")
             return granted
@@ -171,12 +185,15 @@ final class NotificationService: NotificationServiceProtocol {
         body: String,
         trigger: UNNotificationTrigger,
         categoryIdentifier: String? = nil,
-        userInfo: [String: Any]? = nil
+        userInfo: [String: Any]? = nil,
+        interruptionLevel: UNNotificationInterruptionLevel = .active,
+        useCriticalSound: Bool = false
     ) async throws {
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
-        content.sound = .default
+        content.sound = useCriticalSound ? .defaultCritical : .default
+        content.interruptionLevel = interruptionLevel
         content.userInfo = userInfo ?? [:]
         if let category = categoryIdentifier {
             content.categoryIdentifier = category

--- a/mobile-apps/ios/MigraLog/ViewModels/NotificationSettingsViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/NotificationSettingsViewModel.swift
@@ -59,7 +59,11 @@ final class NotificationSettingsViewModel {
             dailyStatusRepo: DailyStatusRepository(dbManager: DatabaseManager.shared)
         ),
         notificationService: NotificationServiceProtocol = NotificationService.shared,
-        medicationNotificationService: MedicationNotificationServiceProtocol? = nil
+        medicationNotificationService: MedicationNotificationServiceProtocol? = MedicationNotificationScheduler(
+            notificationService: NotificationService.shared,
+            scheduledNotificationRepo: ScheduledNotificationRepository(dbManager: DatabaseManager.shared),
+            medicationRepo: MedicationRepository(dbManager: DatabaseManager.shared)
+        )
     ) {
         self.defaults = defaults
         self.dailyCheckinService = dailyCheckinService
@@ -148,6 +152,16 @@ final class NotificationSettingsViewModel {
         } catch {
             AppLogger.shared.error("Failed to reschedule medication notifications after settings change", error: error)
         }
+    }
+
+    /// Apply a medication-notification setting change: re-request permission (in case the
+    /// user just enabled critical alerts or time-sensitive, which require explicit auth)
+    /// and reschedule all medication notifications so the new interruption level / sound
+    /// is reflected in pending notifications.
+    @MainActor
+    func applyMedicationNotificationSettingChange() async {
+        _ = await notificationService.requestPermission()
+        await syncMedicationNotifications()
     }
 
     func updateMedicationSettings(_ override: MedicationNotificationOverride) {

--- a/mobile-apps/ios/MigraLog/Views/Medications/MedicationDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/MedicationDetailScreen.swift
@@ -348,6 +348,7 @@ struct MedicationDetailScreen: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(Color(.secondarySystemBackground))
         .clipShape(RoundedRectangle(cornerRadius: 12))

--- a/mobile-apps/ios/MigraLog/Views/Settings/NotificationSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/NotificationSettingsScreen.swift
@@ -22,10 +22,11 @@ struct NotificationSettingsScreen: View {
             }
 
             if viewModel.notificationsEnabled {
-                Section("Medication Reminders") {
+                Section {
                     Toggle("Time-Sensitive Notifications", isOn: $viewModel.timeSensitiveEnabled)
                         .onChange(of: viewModel.timeSensitiveEnabled) { _, _ in
                             viewModel.saveSettings()
+                            Task { await viewModel.applyMedicationNotificationSettingChange() }
                         }
 
                     Picker("Follow-up Reminder", selection: $viewModel.followUpDelay) {
@@ -37,12 +38,18 @@ struct NotificationSettingsScreen: View {
                     }
                     .onChange(of: viewModel.followUpDelay) { _, _ in
                         viewModel.saveSettings()
+                        Task { await viewModel.applyMedicationNotificationSettingChange() }
                     }
 
                     Toggle("Critical Alerts", isOn: $viewModel.criticalAlertsEnabled)
                         .onChange(of: viewModel.criticalAlertsEnabled) { _, _ in
                             viewModel.saveSettings()
+                            Task { await viewModel.applyMedicationNotificationSettingChange() }
                         }
+                } header: {
+                    Text("Medication Reminders")
+                } footer: {
+                    Text("Time-sensitive reminders cut through Focus modes. Follow-up reminders fire after the chosen delay; turn on Critical Alerts to make them break through Do Not Disturb and silent mode.")
                 }
 
                 Section("Daily Check-in") {

--- a/mobile-apps/ios/MigraLogTests/Services/MedicationNotificationServiceTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/MedicationNotificationServiceTests.swift
@@ -828,6 +828,72 @@ final class MedicationNotificationServiceTests: XCTestCase {
                         "Each reminder should have a matching follow-up")
     }
 
+    // MARK: - Interruption Level / Critical Sound
+
+    func testRescheduleAll_followUp_withCriticalAlertsEnabled_usesCriticalLevelAndSound() async throws {
+        UserDefaults.standard.set(30, forKey: "notification_follow_up_delay")
+        UserDefaults.standard.set(true, forKey: "notification_critical_alerts_enabled")
+        UserDefaults.standard.set(true, forKey: "notification_time_sensitive_enabled")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "notification_follow_up_delay")
+            UserDefaults.standard.removeObject(forKey: "notification_critical_alerts_enabled")
+            UserDefaults.standard.removeObject(forKey: "notification_time_sensitive_enabled")
+        }
+
+        let med = TestFixtures.makeMedication(id: "med-1", name: "Topiramate", type: .preventative, scheduleFrequency: .daily)
+        let sched = TestFixtures.makeSchedule(id: "sched-1", medicationId: "med-1", time: "08:00")
+        mockMedicationRepo.medications = [med]
+        mockMedicationRepo.schedules = [sched]
+
+        try await sut.rescheduleAllMedicationNotifications()
+
+        // Find the IDs of follow-up vs reminder notifications via the DB mappings.
+        let followUpIds = Set(mockScheduledNotificationRepo.notifications
+            .filter { $0.notificationType == .followUp }
+            .map(\.notificationId))
+        let reminderIds = Set(mockScheduledNotificationRepo.notifications
+            .filter { $0.notificationType == .reminder }
+            .map(\.notificationId))
+
+        XCTAssertFalse(followUpIds.isEmpty, "expected at least one follow-up scheduled")
+        XCTAssertFalse(reminderIds.isEmpty, "expected at least one reminder scheduled")
+
+        let followUpRecords = mockNotificationService.scheduledNotifications.filter { followUpIds.contains($0.id) }
+        let reminderRecords = mockNotificationService.scheduledNotifications.filter { reminderIds.contains($0.id) }
+
+        for record in followUpRecords {
+            XCTAssertEqual(record.interruptionLevel, .critical, "follow-up should use critical interruption when critical alerts are enabled")
+            XCTAssertTrue(record.useCriticalSound, "follow-up should use critical sound when critical alerts are enabled")
+        }
+        for record in reminderRecords {
+            XCTAssertEqual(record.interruptionLevel, .timeSensitive, "primary reminder should be time-sensitive when enabled")
+            XCTAssertFalse(record.useCriticalSound, "primary reminder should not use critical sound")
+        }
+    }
+
+    func testRescheduleAll_followUp_withCriticalAlertsDisabled_usesActiveLevelAndDefaultSound() async throws {
+        UserDefaults.standard.set(30, forKey: "notification_follow_up_delay")
+        UserDefaults.standard.set(false, forKey: "notification_critical_alerts_enabled")
+        UserDefaults.standard.set(false, forKey: "notification_time_sensitive_enabled")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "notification_follow_up_delay")
+            UserDefaults.standard.removeObject(forKey: "notification_critical_alerts_enabled")
+            UserDefaults.standard.removeObject(forKey: "notification_time_sensitive_enabled")
+        }
+
+        let med = TestFixtures.makeMedication(id: "med-1", name: "Topiramate", type: .preventative, scheduleFrequency: .daily)
+        let sched = TestFixtures.makeSchedule(id: "sched-1", medicationId: "med-1", time: "08:00")
+        mockMedicationRepo.medications = [med]
+        mockMedicationRepo.schedules = [sched]
+
+        try await sut.rescheduleAllMedicationNotifications()
+
+        for record in mockNotificationService.scheduledNotifications {
+            XCTAssertEqual(record.interruptionLevel, .active, "all notifications should fall back to active when both toggles are off")
+            XCTAssertFalse(record.useCriticalSound, "no critical sound when toggle is off")
+        }
+    }
+
     // MARK: - Top-Up Edge Cases
 
     func testTopUp_belowThreshold_schedulesMoreDays() async throws {
@@ -1264,6 +1330,8 @@ final class MockNotificationService: NotificationServiceProtocol, @unchecked Sen
         let trigger: UNNotificationTrigger
         let categoryIdentifier: String?
         let userInfo: [String: Any]?
+        let interruptionLevel: UNNotificationInterruptionLevel
+        let useCriticalSound: Bool
     }
 
     var scheduledNotifications: [ScheduledNotificationRecord] = []
@@ -1292,7 +1360,9 @@ final class MockNotificationService: NotificationServiceProtocol, @unchecked Sen
         body: String,
         trigger: UNNotificationTrigger,
         categoryIdentifier: String?,
-        userInfo: [String: Any]?
+        userInfo: [String: Any]?,
+        interruptionLevel: UNNotificationInterruptionLevel,
+        useCriticalSound: Bool
     ) async throws {
         scheduledNotifications.append(ScheduledNotificationRecord(
             id: id,
@@ -1300,7 +1370,9 @@ final class MockNotificationService: NotificationServiceProtocol, @unchecked Sen
             body: body,
             trigger: trigger,
             categoryIdentifier: categoryIdentifier,
-            userInfo: userInfo
+            userInfo: userInfo,
+            interruptionLevel: interruptionLevel,
+            useCriticalSound: useCriticalSound
         ))
     }
 

--- a/mobile-apps/ios/MigraLogTests/ViewModels/NotificationSettingsViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/NotificationSettingsViewModelTests.swift
@@ -35,7 +35,9 @@ private final class MockNotifService: NotificationServiceProtocol, @unchecked Se
     func scheduleNotification(
         id: String, title: String, body: String,
         trigger: UNNotificationTrigger,
-        categoryIdentifier: String?, userInfo: [String: Any]?
+        categoryIdentifier: String?, userInfo: [String: Any]?,
+        interruptionLevel: UNNotificationInterruptionLevel,
+        useCriticalSound: Bool
     ) async throws {}
 
     func cancelNotification(id: String) {}


### PR DESCRIPTION
## Summary

- Primary medication reminders now ride the `.timeSensitive` interruption level when the global toggle is on, so they cut through Focus modes.
- Follow-up reminders ride `.critical` with `.defaultCritical` sound when Critical Alerts is enabled, breaking through DND and silent mode. Both fall back to `.active` when the corresponding toggle is off.
- `requestPermission()` now asks for `.criticalAlert` + `.timeSensitive` authorization, and the settings screen re-requests permission whenever the user flips a toggle, so iOS can show its auth sheet on first enable.
- Default `medicationNotificationService` injection on `NotificationSettingsViewModel` so a screen-default-init VM can actually drive a reschedule when settings change.
- Existing dose-logging cancel path already cancels the matching follow-up via `cancelNotificationForDate(.followUp)` — logging the dose before the follow-up time still suppresses it (no change needed).

## Out of scope

- Per-medication notification overrides — the data model exists but the disclosure on the medication detail screen is still a placeholder, and the scheduler reads only the global UserDefaults values. Filed as #422.

## Test plan

- [x] All 745 unit tests pass on iPhone 17 Pro / iOS 26.0 sim
- [x] New tests assert follow-ups carry `.critical` + critical sound with the toggle on, and primaries carry `.timeSensitive`; both fall back to `.active` when off
- [ ] On-device: enable Critical Alerts → confirm system permission prompt appears
- [ ] On-device: schedule a med with a 1-min follow-up, enable Focus mode, confirm primary breaks through Focus and the follow-up breaks through DND
- [ ] On-device: log dose before follow-up time, confirm follow-up is suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)