### PR TITLE
feat(ios): wire up developer screens for notifications, logs, backups

### DIFF
--- a/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
@@ -152,6 +152,9 @@
 		EF2F89545E73FA4D4AB17CC7 /* MedicationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4261430F353F44B3DFAAC7 /* MedicationRepository.swift */; };
 		F0F59FF647D4E49F57F00790 /* EditDoseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FFA573403CE8CEB235A4EB /* EditDoseScreen.swift */; };
 		F1F11A1CCD0760620DEF5357 /* DeveloperToolsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BF70F8D6B06F72BB0220C8 /* DeveloperToolsScreen.swift */; };
+		80BBEF0C8C7CC6E15977E882 /* LogViewerScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8723DFADE6091E24DE9C012 /* LogViewerScreen.swift */; };
+		847AA74F5C0150D7043106BB /* ScheduledNotificationsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725CF86FED6252387F53662D /* ScheduledNotificationsScreen.swift */; };
+		CC91B8E7AE74EE232AA60301 /* TestNotificationsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DEA4BB3A511DF04BAFEFF2 /* TestNotificationsScreen.swift */; };
 		F2F77C696F2663C559C35D71 /* MedicationDoseUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADC08BE6A41699C6F17044C /* MedicationDoseUITests.swift */; };
 		F3120A99E69C1A8938045FA3 /* NotificationResponseHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC14C0BEF174570CFFFAADA2 /* NotificationResponseHandlerTests.swift */; };
 		F52FE6FFA0FC59B2F7F661AE /* ToastService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDF642917EDCDFE97E3E8E6 /* ToastService.swift */; };
@@ -334,6 +337,9 @@
 		F46D676D5280C5AABA6BB139 /* DateFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormattingTests.swift; sourceTree = "<group>"; };
 		F5147500FD77DA3DEF2C4008 /* TrendsAnalyticsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendsAnalyticsUITests.swift; sourceTree = "<group>"; };
 		F5BF70F8D6B06F72BB0220C8 /* DeveloperToolsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperToolsScreen.swift; sourceTree = "<group>"; };
+		D8723DFADE6091E24DE9C012 /* LogViewerScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewerScreen.swift; sourceTree = "<group>"; };
+		725CF86FED6252387F53662D /* ScheduledNotificationsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledNotificationsScreen.swift; sourceTree = "<group>"; };
+		E6DEA4BB3A511DF04BAFEFF2 /* TestNotificationsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNotificationsScreen.swift; sourceTree = "<group>"; };
 		F8F03791D799269B5B3B07E6 /* NewEpisodeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewEpisodeScreen.swift; sourceTree = "<group>"; };
 		F9286988E56D53AEBF4E9205 /* BackupServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupServiceTests.swift; sourceTree = "<group>"; };
 		F9498E260C8EFE377BC05547 /* DailyCheckinSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCheckinSettingsViewModelTests.swift; sourceTree = "<group>"; };
@@ -587,8 +593,11 @@
 				D2905118EC1EC29D6FAFC7F3 /* DataSettingsScreen.swift */,
 				F5BF70F8D6B06F72BB0220C8 /* DeveloperToolsScreen.swift */,
 				F96ADD663FB891445B7511E5 /* LocationSettingsScreen.swift */,
+				D8723DFADE6091E24DE9C012 /* LogViewerScreen.swift */,
 				F27D19F38C235C0F81CB5738 /* NotificationSettingsScreen.swift */,
+				725CF86FED6252387F53662D /* ScheduledNotificationsScreen.swift */,
 				FB611FF702E7A5E56F48248B /* SettingsScreen.swift */,
+				E6DEA4BB3A511DF04BAFEFF2 /* TestNotificationsScreen.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -973,6 +982,9 @@
 				E919E2044D68ED0932A9D71D /* DatabaseManager.swift in Sources */,
 				B198B47C0F880F123164B743 /* DateFormatting.swift in Sources */,
 				F1F11A1CCD0760620DEF5357 /* DeveloperToolsScreen.swift in Sources */,
+				80BBEF0C8C7CC6E15977E882 /* LogViewerScreen.swift in Sources */,
+				847AA74F5C0150D7043106BB /* ScheduledNotificationsScreen.swift in Sources */,
+				CC91B8E7AE74EE232AA60301 /* TestNotificationsScreen.swift in Sources */,
 				600D3A118054B46BF84D7830 /* DomainModels.swift in Sources */,
 				B0D478AA906E2F6E84F2B2F6 /* EditDoseFromTimelineScreen.swift in Sources */,
 				F0F59FF647D4E49F57F00790 /* EditDoseScreen.swift in Sources */,

--- a/mobile-apps/ios/MigraLog/Services/BackupService.swift
+++ b/mobile-apps/ios/MigraLog/Services/BackupService.swift
@@ -157,6 +157,15 @@ final class BackupService: BackupServiceProtocol {
         return backups.sorted { $0.timestamp > $1.timestamp }
     }
 
+    // MARK: - Backup File URL
+
+    /// Returns the on-disk URL for a backup's `.db` file. The file may not exist;
+    /// callers should validate before sharing if that matters.
+    func backupFileURL(for id: String) throws -> URL {
+        let backupDir = try backupDirectoryURL()
+        return backupDir.appendingPathComponent("migralog_backup_\(id).db")
+    }
+
     // MARK: - Delete Backup
 
     func deleteBackup(id: String) throws {

--- a/mobile-apps/ios/MigraLog/Services/NotificationService.swift
+++ b/mobile-apps/ios/MigraLog/Services/NotificationService.swift
@@ -166,8 +166,11 @@ final class NotificationService: NotificationServiceProtocol {
 
     func requestPermission() async -> Bool {
         do {
+            // .timeSensitive is implicitly granted by the
+            // com.apple.developer.usernotifications.time-sensitive entitlement and
+            // is deprecated as an authorization option in iOS 15+.
             let granted = try await center.requestAuthorization(
-                options: [.alert, .sound, .badge, .criticalAlert, .timeSensitive]
+                options: [.alert, .sound, .badge, .criticalAlert]
             )
             logger.info("Notification permission \(granted ? "granted" : "denied")")
             return granted

--- a/mobile-apps/ios/MigraLog/Utils/Logger.swift
+++ b/mobile-apps/ios/MigraLog/Utils/Logger.swift
@@ -10,13 +10,42 @@ enum LogLevel: Int, Comparable {
     static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
         lhs.rawValue < rhs.rawValue
     }
+
+    var label: String {
+        switch self {
+        case .debug: return "DEBUG"
+        case .info: return "INFO"
+        case .warn: return "WARN"
+        case .error: return "ERROR"
+        }
+    }
 }
 
-final class AppLogger {
+struct AppLogEntry: Identifiable, Sendable {
+    let id: UUID
+    let timestamp: Date
+    let level: LogLevel
+    let message: String
+    let context: String?
+
+    init(timestamp: Date = Date(), level: LogLevel, message: String, context: String?) {
+        self.id = UUID()
+        self.timestamp = timestamp
+        self.level = level
+        self.message = message
+        self.context = context
+    }
+}
+
+final class AppLogger: @unchecked Sendable {
     static let shared = AppLogger()
 
     var minLevel: LogLevel = .debug
     private let osLog = os.Logger(subsystem: "com.migralog.app", category: "general")
+
+    private let bufferCapacity = 1000
+    private let queue = DispatchQueue(label: "com.migralog.applogger")
+    private var buffer: [AppLogEntry] = []
 
     func debug(_ message: String, context: [String: Any]? = nil) {
         log(.debug, message: message, context: context)
@@ -38,16 +67,34 @@ final class AppLogger {
         log(.error, message: message, context: ctx)
     }
 
+    /// Recent in-memory log entries, newest last. Bounded by `bufferCapacity`.
+    func recentEntries() -> [AppLogEntry] {
+        queue.sync { buffer }
+    }
+
+    /// Clears the in-memory buffer. The os.Logger sink is unaffected.
+    func clearBuffer() {
+        queue.sync { buffer.removeAll() }
+    }
+
     private func log(_ level: LogLevel, message: String, context: [String: Any]?) {
         guard level >= minLevel else { return }
-        let contextStr = context.map { " | \($0)" } ?? ""
-        let logMessage = "[\(level)] \(message)\(contextStr)"
+        let contextStr: String? = context.map { "\($0)" }
+        let logMessage = "[\(level.label)] \(message)\(contextStr.map { " | " + $0 } ?? "")"
 
         switch level {
         case .debug: osLog.debug("\(logMessage)")
         case .info: osLog.info("\(logMessage)")
         case .warn: osLog.warning("\(logMessage)")
         case .error: osLog.error("\(logMessage)")
+        }
+
+        let entry = AppLogEntry(level: level, message: message, context: contextStr)
+        queue.sync {
+            buffer.append(entry)
+            if buffer.count > bufferCapacity {
+                buffer.removeFirst(buffer.count - bufferCapacity)
+            }
         }
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Settings/DataSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DataSettingsScreen.swift
@@ -58,16 +58,14 @@ struct DataSettingsScreen: View {
             }
 
             if !backups.isEmpty {
-                Section("Existing Backups") {
+                Section {
                     ForEach(backups, id: \.id) { backup in
-                        VStack(alignment: .leading) {
-                            Text(backup.fileName ?? "Backup")
-                                .font(.subheadline)
-                            Text(DateFormatting.displayDateTime(TimestampHelper.toDate(backup.timestamp)))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
+                        backupRow(backup)
                     }
+                } header: {
+                    Text("Existing Backups")
+                } footer: {
+                    Text("Tap the share icon to send a backup to AirDrop, Files, or another app. Swipe a row to delete.")
                 }
             }
         }
@@ -103,6 +101,48 @@ struct DataSettingsScreen: View {
         }
         .task {
             await loadBackups()
+        }
+    }
+
+    @ViewBuilder
+    private func backupRow(_ backup: BackupMetadata) -> some View {
+        let url = (try? BackupService().backupFileURL(for: backup.id))
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(backup.fileName ?? "Backup")
+                    .font(.subheadline)
+                Text(DateFormatting.displayDateTime(TimestampHelper.toDate(backup.timestamp)))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if let url, FileManager.default.fileExists(atPath: url.path) {
+                ShareLink(item: url) {
+                    Image(systemName: "square.and.arrow.up")
+                        .foregroundStyle(.tint)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Share backup")
+            }
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) {
+                Task { await deleteBackup(id: backup.id) }
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+
+    private func deleteBackup(id: String) async {
+        do {
+            let service = BackupService()
+            try service.deleteBackup(id: id)
+            await loadBackups()
+        } catch {
+            ErrorLogger.shared.logError(error, context: ["screen": "DataSettingsScreen", "action": "deleteBackup"])
+            errorMessage = "Delete failed: \(error.localizedDescription)"
+            showError = true
         }
     }
 

--- a/mobile-apps/ios/MigraLog/Views/Settings/DeveloperToolsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DeveloperToolsScreen.swift
@@ -24,15 +24,15 @@ struct DeveloperToolsScreen: View {
                 }
 
                 NavigationLink {
-                    PerformanceScreen()
-                } label: {
-                    Label("Performance", systemImage: "gauge.with.dots.needle.bottom.50percent")
-                }
-
-                NavigationLink {
                     ScheduledNotificationsScreen()
                 } label: {
                     Label("Scheduled Notifications", systemImage: "bell.badge")
+                }
+
+                NavigationLink {
+                    TestNotificationsScreen()
+                } label: {
+                    Label("Test Notifications", systemImage: "bell.and.waves.left.and.right")
                 }
             }
 
@@ -80,32 +80,3 @@ struct ErrorLogsScreen: View {
     }
 }
 
-struct LogViewerScreen: View {
-    var body: some View {
-        List {
-            Text("Application logs will appear here.")
-                .foregroundStyle(.secondary)
-        }
-        .navigationTitle("Log Viewer")
-    }
-}
-
-struct PerformanceScreen: View {
-    var body: some View {
-        List {
-            Text("Performance metrics will appear here.")
-                .foregroundStyle(.secondary)
-        }
-        .navigationTitle("Performance")
-    }
-}
-
-struct ScheduledNotificationsScreen: View {
-    var body: some View {
-        List {
-            Text("Scheduled notifications will appear here.")
-                .foregroundStyle(.secondary)
-        }
-        .navigationTitle("Scheduled Notifications")
-    }
-}

--- a/mobile-apps/ios/MigraLog/Views/Settings/LogViewerScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/LogViewerScreen.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct LogViewerScreen: View {
+    @State private var entries: [AppLogEntry] = []
+    @State private var minLevel: LogLevel = .info
+
+    var body: some View {
+        List {
+            Section {
+                Picker("Minimum Level", selection: $minLevel) {
+                    Text("Debug").tag(LogLevel.debug)
+                    Text("Info").tag(LogLevel.info)
+                    Text("Warn").tag(LogLevel.warn)
+                    Text("Error").tag(LogLevel.error)
+                }
+                .pickerStyle(.segmented)
+            }
+
+            Section {
+                if filtered.isEmpty {
+                    Text("No log entries at or above \(minLevel.label).")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(filtered) { entry in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack(spacing: 8) {
+                                Text(entry.level.label)
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(color(for: entry.level))
+                                Text(DateFormatting.displayDateTime(entry.timestamp))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Text(entry.message)
+                                .font(.subheadline)
+                            if let context = entry.context {
+                                Text(context)
+                                    .font(.caption.monospaced())
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Log Viewer")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    refresh()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(role: .destructive) {
+                    AppLogger.shared.clearBuffer()
+                    refresh()
+                } label: {
+                    Image(systemName: "trash")
+                }
+            }
+        }
+        .onAppear { refresh() }
+    }
+
+    private var filtered: [AppLogEntry] {
+        entries
+            .filter { $0.level >= minLevel }
+            .reversed()
+    }
+
+    private func refresh() {
+        entries = AppLogger.shared.recentEntries()
+    }
+
+    private func color(for level: LogLevel) -> Color {
+        switch level {
+        case .debug: return .secondary
+        case .info: return .blue
+        case .warn: return .orange
+        case .error: return .red
+        }
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Settings/ScheduledNotificationsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/ScheduledNotificationsScreen.swift
@@ -1,0 +1,298 @@
+import SwiftUI
+import UserNotifications
+
+struct ScheduledNotificationEntry: Identifiable {
+    enum Status {
+        case both
+        case dbOnly
+        case osOnly
+
+        var label: String {
+            switch self {
+            case .both: return "DB + OS"
+            case .dbOnly: return "DB only"
+            case .osOnly: return "OS only (orphan)"
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .both: return .green
+            case .dbOnly: return .orange
+            case .osOnly: return .red
+            }
+        }
+    }
+
+    let id: String
+    let triggerDate: Date?
+    let status: Status
+    let dbRow: ScheduledNotification?
+    let osRequest: UNNotificationRequest?
+
+    var notificationId: String {
+        dbRow?.notificationId ?? osRequest?.identifier ?? id
+    }
+
+    var title: String {
+        osRequest?.content.title ?? dbRow?.notificationTitle ?? "(no title)"
+    }
+
+    var body: String {
+        osRequest?.content.body ?? dbRow?.notificationBody ?? ""
+    }
+}
+
+struct ScheduledNotificationsScreen: View {
+    @State private var entries: [ScheduledNotificationEntry] = []
+    @State private var loadError: String?
+    @State private var selected: ScheduledNotificationEntry?
+
+    var body: some View {
+        List {
+            if let loadError {
+                Section {
+                    Text(loadError).foregroundStyle(.red)
+                }
+            }
+
+            if entries.isEmpty {
+                Section {
+                    Text("No scheduled notifications.")
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Section {
+                    ForEach(entries) { entry in
+                        Button {
+                            selected = entry
+                        } label: {
+                            row(entry)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                } header: {
+                    Text("\(entries.count) entries")
+                }
+            }
+        }
+        .navigationTitle("Scheduled Notifications")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    Task { await refresh() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+        }
+        .task { await refresh() }
+        .sheet(item: $selected) { entry in
+            NavigationStack {
+                ScheduledNotificationDetailView(entry: entry)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func row(_ entry: ScheduledNotificationEntry) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text(entry.status.label)
+                    .font(.caption.weight(.semibold))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(entry.status.color.opacity(0.15))
+                    .foregroundStyle(entry.status.color)
+                    .clipShape(Capsule())
+
+                if let type = entry.dbRow?.notificationType {
+                    Text(type.rawValue)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if let date = entry.triggerDate {
+                    Text(DateFormatting.displayDateTime(date))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Text(entry.title)
+                .font(.subheadline)
+                .lineLimit(1)
+
+            if !entry.body.isEmpty {
+                Text(entry.body)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+    }
+
+    private func refresh() async {
+        do {
+            let repo = ScheduledNotificationRepository(dbManager: DatabaseManager.shared)
+            let dbRows = try repo.getAllPending()
+            let osRequests = await UNUserNotificationCenter.current().pendingNotificationRequests()
+
+            var byNotificationId: [String: (db: ScheduledNotification?, os: UNNotificationRequest?)] = [:]
+            for row in dbRows {
+                byNotificationId[row.notificationId, default: (nil, nil)].db = row
+            }
+            for req in osRequests {
+                byNotificationId[req.identifier, default: (nil, nil)].os = req
+            }
+
+            let combined: [ScheduledNotificationEntry] = byNotificationId.map { (id, pair) in
+                let status: ScheduledNotificationEntry.Status
+                switch (pair.db, pair.os) {
+                case (.some, .some): status = .both
+                case (.some, .none): status = .dbOnly
+                case (.none, .some): status = .osOnly
+                case (.none, .none): status = .both
+                }
+                let triggerDate = computeTriggerDate(db: pair.db, os: pair.os)
+                return ScheduledNotificationEntry(
+                    id: id,
+                    triggerDate: triggerDate,
+                    status: status,
+                    dbRow: pair.db,
+                    osRequest: pair.os
+                )
+            }
+
+            entries = combined.sorted {
+                switch ($0.triggerDate, $1.triggerDate) {
+                case let (l?, r?): return l < r
+                case (nil, _?): return false
+                case (_?, nil): return true
+                case (nil, nil): return false
+                }
+            }
+            loadError = nil
+        } catch {
+            loadError = "Failed to load: \(error.localizedDescription)"
+        }
+    }
+
+    private func computeTriggerDate(db: ScheduledNotification?, os: UNNotificationRequest?) -> Date? {
+        if let calendarTrigger = os?.trigger as? UNCalendarNotificationTrigger,
+           let next = calendarTrigger.nextTriggerDate() {
+            return next
+        }
+        if let intervalTrigger = os?.trigger as? UNTimeIntervalNotificationTrigger,
+           let next = intervalTrigger.nextTriggerDate() {
+            return next
+        }
+        guard let db,
+              let dateOnly = DateFormatting.date(from: db.date),
+              let timeStr = db.scheduledTriggerTime,
+              let parts = parseHHmm(timeStr) else {
+            return nil
+        }
+        return Calendar.current.date(
+            bySettingHour: parts.hour, minute: parts.minute, second: 0, of: dateOnly
+        )
+    }
+
+    private func parseHHmm(_ s: String) -> (hour: Int, minute: Int)? {
+        let parts = s.split(separator: ":")
+        guard parts.count == 2,
+              let h = Int(parts[0]),
+              let m = Int(parts[1]) else { return nil }
+        return (h, m)
+    }
+}
+
+private struct ScheduledNotificationDetailView: View {
+    let entry: ScheduledNotificationEntry
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List {
+            Section("Status") {
+                LabeledContent("State", value: entry.status.label)
+                LabeledContent("Notification ID", value: entry.notificationId)
+                if let trigger = entry.triggerDate {
+                    LabeledContent("Trigger", value: DateFormatting.displayDateTime(trigger))
+                }
+            }
+
+            if let db = entry.dbRow {
+                Section("Database") {
+                    LabeledContent("Type", value: db.notificationType.rawValue)
+                    LabeledContent("Source", value: db.sourceType.rawValue)
+                    LabeledContent("Date", value: db.date)
+                    if let time = db.scheduledTriggerTime {
+                        LabeledContent("Time", value: time)
+                    }
+                    LabeledContent("Grouped", value: db.isGrouped ? "yes" : "no")
+                    if let groupKey = db.groupKey {
+                        LabeledContent("Group key", value: groupKey)
+                    }
+                    if let medId = db.medicationId {
+                        LabeledContent("Medication ID", value: medId)
+                    }
+                    if let medName = db.medicationName {
+                        LabeledContent("Medication", value: medName)
+                    }
+                    if let scheduleId = db.scheduleId {
+                        LabeledContent("Schedule ID", value: scheduleId)
+                    }
+                    if let category = db.categoryIdentifier {
+                        LabeledContent("Category", value: category)
+                    }
+                    if let title = db.notificationTitle {
+                        LabeledContent("Title", value: title)
+                    }
+                    if let body = db.notificationBody {
+                        LabeledContent("Body", value: body)
+                    }
+                }
+            } else {
+                Section("Database") {
+                    Text("No matching DB row.").foregroundStyle(.secondary)
+                }
+            }
+
+            if let os = entry.osRequest {
+                Section("OS Pending") {
+                    LabeledContent("Identifier", value: os.identifier)
+                    LabeledContent("Title", value: os.content.title)
+                    LabeledContent("Body", value: os.content.body)
+                    LabeledContent("Sound", value: os.content.sound.map { "\($0)" } ?? "—")
+                    LabeledContent("Interruption", value: "\(os.content.interruptionLevel.rawValue)")
+                    if !os.content.userInfo.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("userInfo").font(.caption).foregroundStyle(.secondary)
+                            Text(formatUserInfo(os.content.userInfo))
+                                .font(.caption.monospaced())
+                        }
+                    }
+                }
+            } else {
+                Section("OS Pending") {
+                    Text("No matching OS request.").foregroundStyle(.secondary)
+                }
+            }
+        }
+        .navigationTitle("Notification Detail")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Done") { dismiss() }
+            }
+        }
+    }
+
+    private func formatUserInfo(_ info: [AnyHashable: Any]) -> String {
+        info.map { "\($0.key) = \($0.value)" }.sorted().joined(separator: "\n")
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Settings/TestNotificationsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/TestNotificationsScreen.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+import UserNotifications
+
+struct TestNotificationsScreen: View {
+    private let logger = AppLogger.shared
+
+    @State private var settings: UNNotificationSettings?
+
+    var body: some View {
+        List {
+            Section {
+                if let settings {
+                    permissionRow("Authorization", value: authStatusLabel(settings.authorizationStatus))
+                    permissionRow("Alert", value: settingLabel(settings.alertSetting))
+                    permissionRow("Sound", value: settingLabel(settings.soundSetting))
+                    permissionRow("Badge", value: settingLabel(settings.badgeSetting))
+                    permissionRow("Critical Alert", value: settingLabel(settings.criticalAlertSetting))
+                    permissionRow("Time-Sensitive", value: settingLabel(settings.timeSensitiveSetting))
+                    permissionRow("Notification Center", value: settingLabel(settings.notificationCenterSetting))
+                    permissionRow("Lock Screen", value: settingLabel(settings.lockScreenSetting))
+                    permissionRow("Banner", value: settingLabel(settings.alertSetting))
+                } else {
+                    Text("Loading…").foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("Permissions")
+            } footer: {
+                Text("These reflect what iOS reports right now. Toggle a permission in Settings → MigraLog → Notifications and tap Refresh to update.")
+            }
+
+            Section {
+                Button {
+                    Task { await requestPermission() }
+                } label: {
+                    Label("Request Permission", systemImage: "lock.shield")
+                }
+            } footer: {
+                Text("Asks for alert + sound + badge + critical-alert authorization. Time-sensitive is granted via the entitlement.")
+            }
+
+            Section {
+                Button {
+                    Task { await schedule(level: .active, critical: false, label: "Regular") }
+                } label: {
+                    Label("Send Regular in 10s", systemImage: "bell")
+                }
+
+                Button {
+                    Task { await schedule(level: .timeSensitive, critical: false, label: "Time-Sensitive") }
+                } label: {
+                    Label("Send Time-Sensitive in 10s", systemImage: "bell.badge")
+                }
+
+                Button {
+                    Task { await schedule(level: .critical, critical: true, label: "Critical") }
+                } label: {
+                    Label("Send Critical in 10s", systemImage: "exclamationmark.triangle.fill")
+                }
+            } header: {
+                Text("Test Triggers")
+            } footer: {
+                Text("Background the app after tapping — iOS routes notifications to the in-app delegate while the app is foregrounded.\n\nNote: critical sound (.defaultCritical) may crash SpringBoard on the iOS 26.0 simulator. Test critical on a real device via TestFlight.")
+            }
+        }
+        .navigationTitle("Test Notifications")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    Task { await loadSettings() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+        }
+        .task { await loadSettings() }
+    }
+
+    @ViewBuilder
+    private func permissionRow(_ name: String, value: String) -> some View {
+        LabeledContent(name, value: value)
+    }
+
+    private func loadSettings() async {
+        settings = await UNUserNotificationCenter.current().notificationSettings()
+    }
+
+    private func authStatusLabel(_ status: UNAuthorizationStatus) -> String {
+        switch status {
+        case .notDetermined: return "Not determined"
+        case .denied: return "Denied"
+        case .authorized: return "Authorized"
+        case .provisional: return "Provisional"
+        case .ephemeral: return "Ephemeral"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    private func settingLabel(_ setting: UNNotificationSetting) -> String {
+        switch setting {
+        case .notSupported: return "Not supported"
+        case .disabled: return "Disabled"
+        case .enabled: return "Enabled"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    private func requestPermission() async {
+        let granted = await NotificationService.shared.requestPermission()
+        logger.info("Test notifications: permission request returned \(granted)")
+        await loadSettings()
+    }
+
+    private func schedule(level: UNNotificationInterruptionLevel, critical: Bool, label: String) async {
+        let id = "test-\(label.lowercased())-\(UUID().uuidString)"
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 10, repeats: false)
+        do {
+            try await NotificationService.shared.scheduleNotification(
+                id: id,
+                title: "Test (\(label))",
+                body: "Fired 10s after tap.",
+                trigger: trigger,
+                categoryIdentifier: nil,
+                userInfo: ["test": true],
+                interruptionLevel: level,
+                useCriticalSound: critical
+            )
+            logger.info("Test notification scheduled: \(label) in 10s (id=\(id))")
+        } catch {
+            logger.error("Failed to schedule test notification (\(label))", error: error)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Test Notifications** screen surfaces live `UNNotificationSettings` (auth status + every per-feature setting) and exposes 10s-trigger buttons for regular / time-sensitive / critical so we can validate each interruption level on device. Includes a footer warning that `.defaultCritical` may crash SpringBoard on the iOS 26.0 simulator and to verify on real hardware.
- **Log Viewer** now backed by a 1,000-entry in-memory ring buffer in `AppLogger`. Filterable by minimum level (Debug/Info/Warn/Error). Cleared on relaunch.
- **Performance** screen removed — was a stub with no backing metrics service.
- **Scheduled Notifications** reads `ScheduledNotificationRepository.getAllPending()` and `UNUserNotificationCenter.pendingNotificationRequests()`, cross-references by notification ID, and renders entries sorted by trigger time. Status badges call out DB-only or OS-only orphans. Tap a row for full detail (userInfo, group key, interruption level).
- **Backup & Export**: each existing-backup row gets a `ShareLink` for the .db (system share covers AirDrop / Files / Mail) and swipe-to-delete that removes the .db plus its `.meta.json` sidecar. Closes the data-portability gap where backups created on-device had no UI path off-device.
- **`requestPermission`** drops `.timeSensitive` from the auth options (deprecated in iOS 15, granted via the entitlement). Silences a build warning.

## Test plan

- [x] All 745 unit tests pass on iPhone 17 Pro / iOS 26.0 sim
- [x] Built & sideloaded on simulator; verified each new screen renders
- [x] Test Notifications: regular + time-sensitive deliver correctly on simulator (critical crashes SpringBoard on iOS 26.0 sim — known Apple bug; will validate on TestFlight build)
- [ ] On-device via TestFlight: critical alert breaks through DND + silent mode
- [ ] On-device: share a backup .db via AirDrop, restore from the shared file on a second device

🤖 Generated with [Claude Code](https://claude.com/claude-code)