### PR TITLE
chore(ios): add App Store screenshot generator

### DIFF
--- a/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		5D598ECF458B861B5872A63E /* ExportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8085FE18D6FA8E5EE15EEF8B /* ExportServiceTests.swift */; };
 		600D3A118054B46BF84D7830 /* DomainModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6C1F41FAD082FBF1127456 /* DomainModels.swift */; };
 		62050772CC4D955CEB7AB14F /* MedicationDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214A8765DEC2DF37F06DAA67 /* MedicationDetailViewModelTests.swift */; };
+		63E0B5CA7FBED9AAE78CC271 /* ScreenshotsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A6905B51EA6B7CDACCD1C5 /* ScreenshotsUITests.swift */; };
 		65A81759C47FC910A264AD25 /* Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E34001E8564D2F9938B679C /* Enums.swift */; };
 		66773FB67CA32096A054235C /* ColorContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E303BA2AD06087C298A076 /* ColorContrastTests.swift */; };
 		669E145F46FCA1B168DB57DA /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F4C6E5D8BA6E8376D07723 /* Notifications.swift */; };
@@ -84,6 +85,7 @@
 		796AFB13119C6E3D86504CA8 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8B9C30690CBBBD832E0020 /* Logger.swift */; };
 		7A3740B482B2C0A54A943595 /* MedicationSafetyBanners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D878ADD80369542076806E /* MedicationSafetyBanners.swift */; };
 		7A525B8D0D71FF77ADEA45D0 /* EditEpisodeNoteScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342535FA23D1E520269A5F56 /* EditEpisodeNoteScreen.swift */; };
+		7AF524867996E08174A02C2F /* ScheduledNotificationsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14AD848FE4E57573A23BEE5 /* ScheduledNotificationsScreen.swift */; };
 		7F1E89BCE3CA857B918126AE /* MedicationNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE8ECC3DA7FE72FE8D60A39 /* MedicationNotificationService.swift */; };
 		8104BEC89E7FB49DAC7B9E1B /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A94F406EFF4E5DCB0805C800 /* Sentry */; };
 		81D0543475BA0D1E9C380EB7 /* EpisodeDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FE225FDDAA5ECC550754B1 /* EpisodeDetailViewModel.swift */; };
@@ -93,6 +95,7 @@
 		87F25A63EC5156E4D0819674 /* MedicationTypeColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607D34D4F6637214F7B05DD8 /* MedicationTypeColors.swift */; };
 		8B0F482B6F32B51DAD53AD0F /* AnalyticsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3F7165AEE8A6DFA8A24BA3 /* AnalyticsViewModelTests.swift */; };
 		96763618847DBF5CF4F697AC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859A5576CD7D5A38E8B31B35 /* ContentView.swift */; };
+		9E2B271FB9945D92F3671249 /* TestNotificationsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A97D8D3D027610CA4A34B90 /* TestNotificationsScreen.swift */; };
 		9E3BE09BF5DB1CA80A42CA6C /* TimezoneChangeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AFC602F51C0713E7E983A25 /* TimezoneChangeService.swift */; };
 		9ED614E5CA0DA670062E2BE2 /* CategoryUsageStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135285FDC99350DFF3A19D24 /* CategoryUsageStatus.swift */; };
 		A0A99870B0A9155C2896E4D3 /* CategorySafetyRuleEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE7DFD4860A45AC7C2F3BB9 /* CategorySafetyRuleEditorSheet.swift */; };
@@ -105,6 +108,7 @@
 		A721A6CD0194E63346C295D9 /* ScheduledNotificationRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30277775F68FCEA93A7E4D /* ScheduledNotificationRepositoryTests.swift */; };
 		A7D5C82C319DA925E7BA5193 /* EpisodeDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113CA1FF77A2157F0AA0DD18 /* EpisodeDetailScreen.swift */; };
 		A833B2FF669024EE0A6B7AF4 /* OverlayRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344065F3C1F6EDCC4EC84CC3 /* OverlayRepositoryTests.swift */; };
+		AB5479B9BCBC796448E41E0F /* LogViewerScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DDD004E080B74AD16F02D6 /* LogViewerScreen.swift */; };
 		AB9927A99FFE04573DD797A4 /* NotificationSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27D19F38C235C0F81CB5738 /* NotificationSettingsScreen.swift */; };
 		AED420EE1EF5279040758794 /* NotificationDismissalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ACA4C8E92F6B53F4F7B743 /* NotificationDismissalService.swift */; };
 		B0D478AA906E2F6E84F2B2F6 /* EditDoseFromTimelineScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7410FEEB825318A4F38A40 /* EditDoseFromTimelineScreen.swift */; };
@@ -152,9 +156,6 @@
 		EF2F89545E73FA4D4AB17CC7 /* MedicationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4261430F353F44B3DFAAC7 /* MedicationRepository.swift */; };
 		F0F59FF647D4E49F57F00790 /* EditDoseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FFA573403CE8CEB235A4EB /* EditDoseScreen.swift */; };
 		F1F11A1CCD0760620DEF5357 /* DeveloperToolsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BF70F8D6B06F72BB0220C8 /* DeveloperToolsScreen.swift */; };
-		80BBEF0C8C7CC6E15977E882 /* LogViewerScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8723DFADE6091E24DE9C012 /* LogViewerScreen.swift */; };
-		847AA74F5C0150D7043106BB /* ScheduledNotificationsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725CF86FED6252387F53662D /* ScheduledNotificationsScreen.swift */; };
-		CC91B8E7AE74EE232AA60301 /* TestNotificationsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DEA4BB3A511DF04BAFEFF2 /* TestNotificationsScreen.swift */; };
 		F2F77C696F2663C559C35D71 /* MedicationDoseUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADC08BE6A41699C6F17044C /* MedicationDoseUITests.swift */; };
 		F3120A99E69C1A8938045FA3 /* NotificationResponseHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC14C0BEF174570CFFFAADA2 /* NotificationResponseHandlerTests.swift */; };
 		F52FE6FFA0FC59B2F7F661AE /* ToastService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDF642917EDCDFE97E3E8E6 /* ToastService.swift */; };
@@ -209,6 +210,7 @@
 		232D17AEE0F9291C479CD1C7 /* OnboardingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingUITests.swift; sourceTree = "<group>"; };
 		24958A6C17AF95BAC07D7A8E /* EpisodeValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeValidationTests.swift; sourceTree = "<group>"; };
 		264B699836D51DFF4D4B8962 /* CategorySafetyRulesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySafetyRulesViewModel.swift; sourceTree = "<group>"; };
+		26A6905B51EA6B7CDACCD1C5 /* ScreenshotsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotsUITests.swift; sourceTree = "<group>"; };
 		27D3A271598E0C2FBD9B61A2 /* NotificationDismissalServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDismissalServiceTests.swift; sourceTree = "<group>"; };
 		28D878ADD80369542076806E /* MedicationSafetyBanners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationSafetyBanners.swift; sourceTree = "<group>"; };
 		2AFC602F51C0713E7E983A25 /* TimezoneChangeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimezoneChangeService.swift; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 		68E2B05FCEFB6493EF0C2FE1 /* DailyCheckinSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCheckinSettingsViewModel.swift; sourceTree = "<group>"; };
 		68F365D4D845E349BD354A39 /* MedicationCooldown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationCooldown.swift; sourceTree = "<group>"; };
 		69B8D2570A843C4069DD91CA /* MigraLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigraLogTests.swift; sourceTree = "<group>"; };
+		6A97D8D3D027610CA4A34B90 /* TestNotificationsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNotificationsScreen.swift; sourceTree = "<group>"; };
 		6B437D8468CA5BAD36F5009D /* NewEpisodeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewEpisodeViewModel.swift; sourceTree = "<group>"; };
 		6C655C4327B2A2443B6CB590 /* SelectableChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableChip.swift; sourceTree = "<group>"; };
 		6E3EB2C7C80B90165E71117D /* AddMedicationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMedicationViewModelTests.swift; sourceTree = "<group>"; };
@@ -315,6 +318,7 @@
 		CB6BDCD7B9E391412F1D4EA7 /* CacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheManager.swift; sourceTree = "<group>"; };
 		CE30277775F68FCEA93A7E4D /* ScheduledNotificationRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledNotificationRepositoryTests.swift; sourceTree = "<group>"; };
 		D1401FC91C5F0EF17B803BA1 /* EpisodeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeRepository.swift; sourceTree = "<group>"; };
+		D14AD848FE4E57573A23BEE5 /* ScheduledNotificationsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledNotificationsScreen.swift; sourceTree = "<group>"; };
 		D1BF06D4B0AF537BEAF4698D /* WelcomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeScreen.swift; sourceTree = "<group>"; };
 		D1F340F63DF6C366F048A48B /* DatabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseManager.swift; sourceTree = "<group>"; };
 		D2905118EC1EC29D6FAFC7F3 /* DataSettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSettingsScreen.swift; sourceTree = "<group>"; };
@@ -322,6 +326,7 @@
 		D5FDFB70D7FBD2F40C33EEA2 /* PresetMedications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetMedications.swift; sourceTree = "<group>"; };
 		D63D77F78450B572B22BACE5 /* MigraLogTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MigraLogTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8321C0BDDF1FFCFE742186A /* EditSymptomLogScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSymptomLogScreen.swift; sourceTree = "<group>"; };
+		D8DDD004E080B74AD16F02D6 /* LogViewerScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewerScreen.swift; sourceTree = "<group>"; };
 		DE6C1F41FAD082FBF1127456 /* DomainModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainModels.swift; sourceTree = "<group>"; };
 		DEDDA6C3CE07321D64D36D2C /* NotificationResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationResponseHandler.swift; sourceTree = "<group>"; };
 		DEF8B890D3D69DC1E55A96AA /* PainIntensitySlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PainIntensitySlider.swift; sourceTree = "<group>"; };
@@ -337,9 +342,6 @@
 		F46D676D5280C5AABA6BB139 /* DateFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormattingTests.swift; sourceTree = "<group>"; };
 		F5147500FD77DA3DEF2C4008 /* TrendsAnalyticsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendsAnalyticsUITests.swift; sourceTree = "<group>"; };
 		F5BF70F8D6B06F72BB0220C8 /* DeveloperToolsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperToolsScreen.swift; sourceTree = "<group>"; };
-		D8723DFADE6091E24DE9C012 /* LogViewerScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewerScreen.swift; sourceTree = "<group>"; };
-		725CF86FED6252387F53662D /* ScheduledNotificationsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledNotificationsScreen.swift; sourceTree = "<group>"; };
-		E6DEA4BB3A511DF04BAFEFF2 /* TestNotificationsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNotificationsScreen.swift; sourceTree = "<group>"; };
 		F8F03791D799269B5B3B07E6 /* NewEpisodeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewEpisodeScreen.swift; sourceTree = "<group>"; };
 		F9286988E56D53AEBF4E9205 /* BackupServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupServiceTests.swift; sourceTree = "<group>"; };
 		F9498E260C8EFE377BC05547 /* DailyCheckinSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCheckinSettingsViewModelTests.swift; sourceTree = "<group>"; };
@@ -540,6 +542,7 @@
 				FDAA8AD4C7F64C9ADE576C6B /* MigraLogUITests.swift */,
 				67A30B1978FA36B8ECAC71F5 /* NotificationSettingsUITests.swift */,
 				232D17AEE0F9291C479CD1C7 /* OnboardingUITests.swift */,
+				26A6905B51EA6B7CDACCD1C5 /* ScreenshotsUITests.swift */,
 				F5147500FD77DA3DEF2C4008 /* TrendsAnalyticsUITests.swift */,
 				6EE19AF6509CF8DC4DB455A7 /* UITestHelpers.swift */,
 			);
@@ -593,11 +596,11 @@
 				D2905118EC1EC29D6FAFC7F3 /* DataSettingsScreen.swift */,
 				F5BF70F8D6B06F72BB0220C8 /* DeveloperToolsScreen.swift */,
 				F96ADD663FB891445B7511E5 /* LocationSettingsScreen.swift */,
-				D8723DFADE6091E24DE9C012 /* LogViewerScreen.swift */,
+				D8DDD004E080B74AD16F02D6 /* LogViewerScreen.swift */,
 				F27D19F38C235C0F81CB5738 /* NotificationSettingsScreen.swift */,
-				725CF86FED6252387F53662D /* ScheduledNotificationsScreen.swift */,
+				D14AD848FE4E57573A23BEE5 /* ScheduledNotificationsScreen.swift */,
 				FB611FF702E7A5E56F48248B /* SettingsScreen.swift */,
-				E6DEA4BB3A511DF04BAFEFF2 /* TestNotificationsScreen.swift */,
+				6A97D8D3D027610CA4A34B90 /* TestNotificationsScreen.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -889,6 +892,7 @@
 				030483BABF25F9CD663030C3 /* MigraLogUITests.swift in Sources */,
 				BA97F018FE92C2F933236029 /* NotificationSettingsUITests.swift in Sources */,
 				055AF4F8C351C8DB9461AE70 /* OnboardingUITests.swift in Sources */,
+				63E0B5CA7FBED9AAE78CC271 /* ScreenshotsUITests.swift in Sources */,
 				5231CD914E2D56662A49A0E9 /* TrendsAnalyticsUITests.swift in Sources */,
 				77F1955DB2EE63D1C537E642 /* UITestHelpers.swift in Sources */,
 			);
@@ -982,9 +986,6 @@
 				E919E2044D68ED0932A9D71D /* DatabaseManager.swift in Sources */,
 				B198B47C0F880F123164B743 /* DateFormatting.swift in Sources */,
 				F1F11A1CCD0760620DEF5357 /* DeveloperToolsScreen.swift in Sources */,
-				80BBEF0C8C7CC6E15977E882 /* LogViewerScreen.swift in Sources */,
-				847AA74F5C0150D7043106BB /* ScheduledNotificationsScreen.swift in Sources */,
-				CC91B8E7AE74EE232AA60301 /* TestNotificationsScreen.swift in Sources */,
 				600D3A118054B46BF84D7830 /* DomainModels.swift in Sources */,
 				B0D478AA906E2F6E84F2B2F6 /* EditDoseFromTimelineScreen.swift in Sources */,
 				F0F59FF647D4E49F57F00790 /* EditDoseScreen.swift in Sources */,
@@ -1012,6 +1013,7 @@
 				4BB7C163B4BE5DF919DC9474 /* LogMedicationScreen.swift in Sources */,
 				540E206542F9813929D8AB75 /* LogMedicationViewModel.swift in Sources */,
 				2A1B4DD1A4D7094B0FF06414 /* LogUpdateScreen.swift in Sources */,
+				AB5479B9BCBC796448E41E0F /* LogViewerScreen.swift in Sources */,
 				796AFB13119C6E3D86504CA8 /* Logger.swift in Sources */,
 				D6173D2C08ED96EB11691B30 /* MedicationCooldown.swift in Sources */,
 				42F105DE5B8A28F59DED8D65 /* MedicationDetailScreen.swift in Sources */,
@@ -1044,9 +1046,11 @@
 				F77853584FB6F2293AE0664E /* Protocols.swift in Sources */,
 				516777F8D1DDE83638B69F4F /* ScheduleSheets.swift in Sources */,
 				EC12E5589D56AC4E7CF9444B /* ScheduledNotificationRepository.swift in Sources */,
+				7AF524867996E08174A02C2F /* ScheduledNotificationsScreen.swift in Sources */,
 				586C19AB559F2DF5BAD57EE7 /* SelectableChip.swift in Sources */,
 				B75C8855AEF1DF6B07E89637 /* SentrySetup.swift in Sources */,
 				E608556506A3EEA3B97331E2 /* SettingsScreen.swift in Sources */,
+				9E2B271FB9945D92F3671249 /* TestNotificationsScreen.swift in Sources */,
 				37D0E1F50505C0DC8E0E210D /* TimelineView.swift in Sources */,
 				9E3BE09BF5DB1CA80A42CA6C /* TimezoneChangeService.swift in Sources */,
 				F52FE6FFA0FC59B2F7F661AE /* ToastService.swift in Sources */,

--- a/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
+++ b/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
@@ -141,6 +141,14 @@ final class AppState {
             self.onboardingSetByUITesting = true
             loadFixtureData()
         }
+
+        if arguments.contains("--load-screenshot-data") {
+            resetForUITesting()
+            UserDefaults.standard.set(true, forKey: onboardingKey)
+            self.isOnboardingComplete = true
+            self.onboardingSetByUITesting = true
+            loadScreenshotData()
+        }
     }
 
     private func resetForUITesting() {
@@ -241,6 +249,209 @@ final class AppState {
             }
         } catch {
             print("UI Testing: Failed to load fixture data: \(error)")
+        }
+    }
+
+    /// Loads a richer dataset for App Store screenshot generation: 90 days of episodes,
+    /// daily statuses, medication doses, and a calendar overlay so every screen has
+    /// realistic-looking content. Distinct from `loadFixtureData()` to keep
+    /// existing UI tests stable.
+    private func loadScreenshotData() {
+        let db = DatabaseManager.shared
+        let now = TimestampHelper.now
+        let cal = Calendar.current
+
+        do {
+            try db.dbQueue.write { database in
+                // --- Medications (generic names throughout) ---
+                let erenumabId = "screenshot-med-erenumab"
+                try database.execute(sql: """
+                    INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, default_quantity, schedule_frequency, active, category, created_at, updated_at)
+                    VALUES (?, 'Erenumab', 'preventative', 70.0, 'mg', 1.0, 'monthly', 1, 'cgrp', ?, ?)
+                    """, arguments: [erenumabId, now, now])
+                try database.execute(sql: """
+                    INSERT INTO medication_schedules (id, medication_id, time, timezone, dosage, enabled, reminder_enabled)
+                    VALUES (?, ?, '08:00', ?, 1.0, 1, 1)
+                    """, arguments: ["screenshot-sched-erenumab", erenumabId, TimeZone.current.identifier])
+
+                let magnesiumId = "screenshot-med-magnesium"
+                try database.execute(sql: """
+                    INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, default_quantity, schedule_frequency, active, category, created_at, updated_at)
+                    VALUES (?, 'Magnesium Glycinate', 'preventative', 400.0, 'mg', 1.0, 'daily', 1, 'supplement', ?, ?)
+                    """, arguments: [magnesiumId, now, now])
+                try database.execute(sql: """
+                    INSERT INTO medication_schedules (id, medication_id, time, timezone, dosage, enabled, reminder_enabled)
+                    VALUES (?, ?, '21:00', ?, 1.0, 1, 1)
+                    """, arguments: ["screenshot-sched-magnesium", magnesiumId, TimeZone.current.identifier])
+
+                let sumatriptanId = "screenshot-med-sumatriptan"
+                try database.execute(sql: """
+                    INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, default_quantity, active, category, min_interval_hours, created_at, updated_at)
+                    VALUES (?, 'Sumatriptan', 'rescue', 100.0, 'mg', 1.0, 1, 'triptan', 2.0, ?, ?)
+                    """, arguments: [sumatriptanId, now, now])
+
+                let ibuprofenId = "screenshot-med-ibuprofen"
+                try database.execute(sql: """
+                    INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, default_quantity, active, category, min_interval_hours, created_at, updated_at)
+                    VALUES (?, 'Ibuprofen', 'rescue', 400.0, 'mg', 2.0, 1, 'nsaid', 6.0, ?, ?)
+                    """, arguments: [ibuprofenId, now, now])
+
+                // --- Closed historical episodes spread over the last ~80 days ---
+                // Tuples: (daysAgo, durationHours, peakIntensity, symptoms JSON, triggers JSON, locations JSON, notes)
+                let episodes: [(Int, Double, Double, String, String, String, String)] = [
+                    (78, 6.0, 8.0, "[\"nausea\",\"photophobia\"]", "[\"weather\"]", "[\"left_temple\"]", "Storm front rolling in."),
+                    (71, 4.5, 6.0, "[\"photophobia\"]", "[\"sleep\"]", "[\"forehead\"]", "Slept 5 hours, woke up with it."),
+                    (62, 7.0, 9.0, "[\"nausea\",\"photophobia\",\"phonophobia\"]", "[\"stress\"]", "[\"right_temple\",\"right_eye\"]", "Bad week at work."),
+                    (54, 3.0, 5.0, "[\"nausea\"]", "[\"food\"]", "[\"forehead\"]", ""),
+                    (45, 5.5, 7.0, "[\"photophobia\"]", "[\"weather\",\"stress\"]", "[\"left_temple\",\"left_eye\"]", "Heat wave."),
+                    (38, 4.0, 6.0, "[\"nausea\"]", "[\"hormonal\"]", "[\"forehead\",\"right_temple\"]", ""),
+                    (30, 8.0, 9.0, "[\"nausea\",\"photophobia\",\"phonophobia\"]", "[\"stress\",\"sleep\"]", "[\"right_temple\",\"right_eye\",\"neck\"]", "Worst this month."),
+                    (24, 2.5, 4.0, "[]", "[\"food\"]", "[\"forehead\"]", "Caught it early."),
+                    (17, 6.0, 7.0, "[\"photophobia\"]", "[\"weather\"]", "[\"left_temple\"]", ""),
+                    (11, 4.0, 6.0, "[\"nausea\"]", "[\"stress\"]", "[\"forehead\",\"left_temple\"]", "Long meeting day."),
+                    (5, 5.0, 7.0, "[\"photophobia\",\"phonophobia\"]", "[\"sleep\"]", "[\"right_temple\"]", ""),
+                    (2, 3.5, 5.0, "[\"nausea\"]", "[\"food\"]", "[\"forehead\"]", "Skipped lunch.")
+                ]
+
+                for (idx, ep) in episodes.enumerated() {
+                    let (daysAgo, durationHours, peak, symptoms, triggers, locations, notes) = ep
+                    let day = cal.date(byAdding: .day, value: -daysAgo, to: Date())!
+                    let startOfDay = cal.startOfDay(for: day)
+                    let startHour = 9 + (idx % 6) // vary start time 9am-2pm
+                    let episodeStart = startOfDay.addingTimeInterval(Double(startHour) * 3600)
+                    let episodeEnd = episodeStart.addingTimeInterval(durationHours * 3600)
+                    let startMs = TimestampHelper.fromDate(episodeStart)
+                    let endMs = TimestampHelper.fromDate(episodeEnd)
+                    let episodeId = "screenshot-episode-\(daysAgo)"
+                    let notesValue: String? = notes.isEmpty ? nil : notes
+
+                    try database.execute(sql: """
+                        INSERT INTO episodes (id, start_time, end_time, locations, qualities, symptoms, triggers, notes, created_at, updated_at)
+                        VALUES (?, ?, ?, ?, '[\"throbbing\"]', ?, ?, ?, ?, ?)
+                        """, arguments: [episodeId, startMs, endMs, locations, symptoms, triggers, notesValue, startMs, endMs])
+
+                    // Intensity readings spread across the episode: rise → peak → fall
+                    let durationMs = Int64(durationHours * 3_600_000)
+                    let r1Time = startMs + durationMs / 5            // 20% in
+                    let peakTime = startMs + (durationMs * 11 / 20)  // 55% in (peak)
+                    let r3Time = startMs + (durationMs * 17 / 20)    // 85% in
+                    let r1 = max(2.0, peak - 4.0)
+                    let r2 = peak
+                    let r3 = max(1.0, peak - 5.0)
+                    try database.execute(sql: """
+                        INSERT INTO intensity_readings (id, episode_id, timestamp, intensity, created_at, updated_at)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        """, arguments: ["\(episodeId)-r1", episodeId, r1Time, r1, r1Time, r1Time])
+                    try database.execute(sql: """
+                        INSERT INTO intensity_readings (id, episode_id, timestamp, intensity, created_at, updated_at)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        """, arguments: ["\(episodeId)-r2", episodeId, peakTime, r2, peakTime, peakTime])
+                    try database.execute(sql: """
+                        INSERT INTO intensity_readings (id, episode_id, timestamp, intensity, created_at, updated_at)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        """, arguments: ["\(episodeId)-r3", episodeId, r3Time, r3, r3Time, r3Time])
+
+                    // Rescue dose for moderate+ episodes, ~30% into the episode
+                    if peak >= 6.0 {
+                        let doseTime = startMs + (durationMs * 3 / 10)
+                        let doseMed = peak >= 7.0 ? sumatriptanId : ibuprofenId
+                        let doseAmount: Double = peak >= 7.0 ? 100.0 : 400.0
+                        let doseUnit = "mg"
+                        try database.execute(sql: """
+                            INSERT INTO medication_doses (id, medication_id, timestamp, quantity, dosage_amount, dosage_unit, status, episode_id, effectiveness_rating, created_at, updated_at)
+                            VALUES (?, ?, ?, 1.0, ?, ?, 'taken', ?, ?, ?, ?)
+                            """, arguments: ["\(episodeId)-dose", doseMed, doseTime, doseAmount, doseUnit, episodeId, 7.0, doseTime, doseTime])
+                    }
+                }
+
+                // --- Active episode: started 2 hours ago, no end_time ---
+                let activeStart = Date().addingTimeInterval(-2 * 3600)
+                let activeStartMs = TimestampHelper.fromDate(activeStart)
+                let activeId = "screenshot-episode-active"
+                try database.execute(sql: """
+                    INSERT INTO episodes (id, start_time, locations, qualities, symptoms, triggers, notes, created_at, updated_at)
+                    VALUES (?, ?, '[\"left_temple\",\"left_eye\"]', '[\"throbbing\"]', '[\"photophobia\"]', '[\"weather\"]', 'Started after lunch.', ?, ?)
+                    """, arguments: [activeId, activeStartMs, activeStartMs, activeStartMs])
+                let activeMidMs = activeStartMs + 3600 * 1000
+                try database.execute(sql: """
+                    INSERT INTO intensity_readings (id, episode_id, timestamp, intensity, created_at, updated_at)
+                    VALUES (?, ?, ?, 4.0, ?, ?)
+                    """, arguments: ["\(activeId)-r1", activeId, activeStartMs, activeStartMs, activeStartMs])
+                try database.execute(sql: """
+                    INSERT INTO intensity_readings (id, episode_id, timestamp, intensity, created_at, updated_at)
+                    VALUES (?, ?, ?, 6.0, ?, ?)
+                    """, arguments: ["\(activeId)-r2", activeId, activeMidMs, activeMidMs, activeMidMs])
+                try database.execute(sql: """
+                    INSERT INTO medication_doses (id, medication_id, timestamp, quantity, dosage_amount, dosage_unit, status, episode_id, created_at, updated_at)
+                    VALUES (?, ?, ?, 1.0, 100.0, 'mg', 'taken', ?, ?, ?)
+                    """, arguments: ["\(activeId)-dose", sumatriptanId, activeMidMs, activeId, activeMidMs, activeMidMs])
+
+                // --- Daily status logs covering the last 90 days ---
+                // Episode days are 'red'; a few yellow prodrome/postdrome days; the rest 'green'.
+                let redDays = Set(episodes.map { $0.0 })
+                let postdromeDays = Set(episodes.map { $0.0 - 1 }.filter { $0 > 0 })
+                let prodromeDays: Set<Int> = [13, 26, 41, 73]
+                for daysAgo in 1...90 {
+                    let date = cal.date(byAdding: .day, value: -daysAgo, to: Date())!
+                    let dateStr = TimestampHelper.dateString(from: date)
+                    let status: String
+                    let statusType: String?
+                    if redDays.contains(daysAgo) {
+                        status = "red"
+                        statusType = nil
+                    } else if postdromeDays.contains(daysAgo) {
+                        status = "yellow"
+                        statusType = "postdrome"
+                    } else if prodromeDays.contains(daysAgo) {
+                        status = "yellow"
+                        statusType = "prodrome"
+                    } else {
+                        status = "green"
+                        statusType = nil
+                    }
+                    try database.execute(sql: """
+                        INSERT INTO daily_status_logs (id, date, status, status_type, prompted, created_at, updated_at)
+                        VALUES (?, ?, ?, ?, 1, ?, ?)
+                        """, arguments: ["screenshot-status-\(daysAgo)", dateStr, status, statusType, now, now])
+                }
+
+                // --- Calendar overlay (e.g. travel) ---
+                let overlayStart = cal.date(byAdding: .day, value: -50, to: Date())!
+                let overlayEnd = cal.date(byAdding: .day, value: -43, to: Date())!
+                try database.execute(sql: """
+                    INSERT INTO calendar_overlays (id, start_date, end_date, label, exclude_from_stats, created_at, updated_at)
+                    VALUES (?, ?, ?, 'Vacation', 0, ?, ?)
+                    """, arguments: [
+                        "screenshot-overlay-vacation",
+                        TimestampHelper.dateString(from: overlayStart),
+                        TimestampHelper.dateString(from: overlayEnd),
+                        now, now
+                    ])
+
+                // --- Routine doses ---
+                // Erenumab: monthly 70mg injection at 8am, last 3 months
+                for monthsAgo in 1...3 {
+                    let date = cal.date(byAdding: .month, value: -monthsAgo, to: Date())!
+                    let morning = cal.startOfDay(for: date).addingTimeInterval(8 * 3600)
+                    let mMs = TimestampHelper.fromDate(morning)
+                    try database.execute(sql: """
+                        INSERT INTO medication_doses (id, medication_id, timestamp, quantity, dosage_amount, dosage_unit, status, created_at, updated_at)
+                        VALUES (?, ?, ?, 1.0, 70.0, 'mg', 'taken', ?, ?)
+                        """, arguments: ["screenshot-dose-eren-\(monthsAgo)", erenumabId, mMs, mMs, mMs])
+                }
+                // Magnesium: nightly 400mg, last 30 days
+                for daysAgo in 1...30 {
+                    let date = cal.date(byAdding: .day, value: -daysAgo, to: Date())!
+                    let evening = cal.startOfDay(for: date).addingTimeInterval(21 * 3600)
+                    let eMs = TimestampHelper.fromDate(evening)
+                    try database.execute(sql: """
+                        INSERT INTO medication_doses (id, medication_id, timestamp, quantity, dosage_amount, dosage_unit, status, created_at, updated_at)
+                        VALUES (?, ?, ?, 1.0, 400.0, 'mg', 'taken', ?, ?)
+                        """, arguments: ["screenshot-dose-mag-\(daysAgo)", magnesiumId, eMs, eMs, eMs])
+                }
+            }
+        } catch {
+            print("UI Testing: Failed to load screenshot data: \(error)")
         }
     }
 }

--- a/mobile-apps/ios/MigraLogUITests/ScreenshotsUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/ScreenshotsUITests.swift
@@ -1,0 +1,101 @@
+import XCTest
+
+/// Generates App Store screenshots from a synthetic-but-realistic dataset.
+///
+/// Run on the device size you want to ship — e.g. iPhone 17 Pro Max for the 6.9"
+/// screenshots App Store Connect requires:
+///
+///     xcodebuild test \
+///       -scheme MigraLog \
+///       -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.0' \
+///       -only-testing:MigraLogUITests/ScreenshotsUITests
+///
+/// Screenshots are attached to the .xcresult bundle with `.keepAlways` lifetime.
+/// Extract them with:
+///
+///     xcrun xcresulttool get --legacy --path <path>.xcresult --format json
+///
+/// or by opening the result bundle in Xcode (Report Navigator → Test → Attachments).
+final class ScreenshotsUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["--uitesting", "--load-screenshot-data"]
+        app.launch()
+        UITestHelpers.waitForDashboard(in: app)
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    // MARK: - Screenshots
+
+    /// 1. Dashboard — daily driver: today's medications, daily status, recent episodes.
+    func test01_Dashboard() throws {
+        UITestHelpers.navigateTo(tab: .dashboard, in: app)
+        Thread.sleep(forTimeInterval: 1.0)
+        attachScreenshot(named: "01-Dashboard")
+    }
+
+    /// 2. Episode timeline — the centerpiece. Opens a recent closed episode
+    /// with intensity readings, doses, and notes laid out chronologically.
+    func test02_EpisodeTimeline() throws {
+        UITestHelpers.navigateTo(tab: .episodes, in: app)
+        // Index 1 = most recent closed episode (index 0 is the active "ongoing" one,
+        // which has thinner timeline content).
+        let episodeCard = UITestHelpers.findElement("episode-card-1", in: app)
+        UITestHelpers.waitForHittable(episodeCard).tap()
+        Thread.sleep(forTimeInterval: 1.5)
+        attachScreenshot(named: "02-Episode-Timeline")
+    }
+
+    /// 3. Medications — preventatives + rescue list with schedules.
+    func test03_Medications() throws {
+        UITestHelpers.navigateTo(tab: .medications, in: app)
+        Thread.sleep(forTimeInterval: 1.0)
+        attachScreenshot(named: "03-Medications")
+    }
+
+    /// 4. Trends → Calendar — previous month with daily-status dots and overlay.
+    /// The current month often only has a few days populated, so step back one
+    /// to land on a fully-filled month.
+    func test04_Calendar() throws {
+        UITestHelpers.navigateTo(tab: .trends, in: app)
+        let prev = app.buttons["calendar-previous"]
+        UITestHelpers.waitForHittable(prev).tap()
+        Thread.sleep(forTimeInterval: 1.0)
+        attachScreenshot(named: "04-Calendar")
+    }
+
+    /// 5. Trends → Statistics — Day Statistics + Duration Metrics cards.
+    /// Scrolls past the calendar so the stats cards dominate the frame.
+    func test05_Statistics() throws {
+        UITestHelpers.navigateTo(tab: .trends, in: app)
+        let scroll = app.scrollViews.firstMatch
+        let durationMetrics = app.staticTexts["Duration Metrics"]
+        UITestHelpers.scrollToElement(durationMetrics, in: scroll)
+        Thread.sleep(forTimeInterval: 1.0)
+        attachScreenshot(named: "05-Statistics")
+    }
+
+    /// 6. Episodes list — episode history with intensity sparklines.
+    func test06_EpisodeHistory() throws {
+        UITestHelpers.navigateTo(tab: .episodes, in: app)
+        Thread.sleep(forTimeInterval: 1.0)
+        attachScreenshot(named: "06-Episode-History")
+    }
+
+    // MARK: - Helpers
+
+    private func attachScreenshot(named name: String) {
+        let screenshot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -48,6 +48,7 @@ targets:
     entitlements:
       path: MigraLog/App/MigraLog.entitlements
       properties:
+        com.apple.developer.usernotifications.critical-alerts: true
         com.apple.developer.usernotifications.time-sensitive: true
 
   MigraLogTests:


### PR DESCRIPTION
## Summary
- New `--load-screenshot-data` launch argument seeds rich, realistic data (12 historical episodes with rise/peak/fall intensity curves, an active episode, 90 days of daily statuses, calendar overlay, routine doses, 4 generic-named meds incl. CGRP and rescue triptan)
- New `ScreenshotsUITests` captures Dashboard, Episode Timeline, Medications, Calendar, Statistics, and Episode History as `XCTAttachment`s with `.keepAlways` lifetime
- Restores Critical Alerts entitlement to `project.yml` so xcodegen stops dropping it

## How to use

```bash
cd mobile-apps/ios
xcodebuild test -scheme MigraLog \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' \
  -only-testing:MigraLogUITests/ScreenshotsUITests \
  -resultBundlePath build/screenshots.xcresult
xcrun xcresulttool export attachments \
  --path build/screenshots.xcresult \
  --output-path /tmp/migralog-shots
```

Native iPhone 17 Pro Max output is 1320×2868 (6.9" — the size App Store Connect accepts for new submissions).

## Test plan
- [x] All 6 screenshot tests pass on iPhone 17 Pro Max / iOS 26.4
- [x] Existing `--load-fixtures` flow unchanged (separate code path)
- [x] Generated screenshots uploaded successfully to App Store Connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)