### PR TITLE
feat(ios): dashboard dose grace period + medication detail link

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/AdaptiveNavigation.swift
+++ b/mobile-apps/ios/MigraLog/Views/AdaptiveNavigation.swift
@@ -123,6 +123,7 @@ struct TrendsTab: View {
                 } detail: {
                     AnalyticsVisualizationPane(viewModel: viewModel)
                 }
+                .task { await viewModel.fetchData() }
             } else {
                 NavigationStack {
                     AnalyticsScreen()

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -201,24 +201,39 @@ struct DailyStatusWidgetView: View {
 struct TodaysMedicationsCard: View {
     @Bindable var viewModel: DashboardViewModel
 
-    var body: some View {
-        if !viewModel.todaysMedications.isEmpty {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Today's Medications")
-                    .font(.headline)
+    /// Logged doses linger on the dashboard this long before being hidden, so the
+    /// transition isn't jarring and the user has a window to undo.
+    private static let postLogVisibilityWindow: TimeInterval = 15 * 60
 
-                ForEach(viewModel.todaysMedications) { item in
-                    MedicationScheduleRow(item: item, viewModel: viewModel)
-                    if item.id != viewModel.todaysMedications.last?.id {
-                        Divider()
+    private func visibleItems(now: Date) -> [MedicationScheduleItem] {
+        viewModel.todaysMedications.filter { item in
+            guard let dose = item.dose else { return true }
+            let doseDate = Date(timeIntervalSince1970: TimeInterval(dose.timestamp) / 1000)
+            return now.timeIntervalSince(doseDate) < Self.postLogVisibilityWindow
+        }
+    }
+
+    var body: some View {
+        SwiftUI.TimelineView(.periodic(from: .now, by: 60)) { context in
+            let items = visibleItems(now: context.date)
+            if !items.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Today's Medications")
+                        .font(.headline)
+
+                    ForEach(items) { item in
+                        MedicationScheduleRow(item: item, viewModel: viewModel)
+                        if item.id != items.last?.id {
+                            Divider()
+                        }
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .accessibilityIdentifier("todays-medications-card")
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding()
-            .background(Color(.secondarySystemBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .accessibilityIdentifier("todays-medications-card")
         }
     }
 }
@@ -265,8 +280,16 @@ struct MedicationScheduleRow: View {
             }
 
             HStack {
-                Text(item.medication.name)
-                    .font(.subheadline.weight(.medium))
+                NavigationLink {
+                    MedicationDetailScreen(medicationId: item.medication.id)
+                } label: {
+                    Text(item.medication.name)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.primary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("medication-name-link-\(item.medication.id)")
+                .accessibilityHint("Open medication details")
 
                 Spacer()
 

--- a/mobile-apps/ios/MigraLogUITests/MedicationArchivingUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/MedicationArchivingUITests.swift
@@ -152,8 +152,9 @@ final class MedicationArchivingUITests: XCTestCase {
         // Step 2: Go to Dashboard — navigate via tab to force fresh load
         UITestHelpers.navigateTo(tab: .dashboard, in: app)
         Thread.sleep(forTimeInterval: 1)
-        let topText = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Test Topiramate'")).firstMatch
-        XCTAssertFalse(topText.exists, "Archived medication should not appear in Today's Medications")
+        // Medication name on the dashboard is a NavigationLink (button), not a static text.
+        let topRow = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Test Topiramate'")).firstMatch
+        XCTAssertFalse(topRow.exists, "Archived medication should not appear in Today's Medications")
 
         // Step 3: Restore the medication
         UITestHelpers.navigateTo(tab: .medications, in: app)
@@ -175,7 +176,7 @@ final class MedicationArchivingUITests: XCTestCase {
 
         // Step 4: Go to Dashboard, medication reappears
         UITestHelpers.navigateTo(tab: .dashboard, in: app)
-        let restoredText = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Test Topiramate'")).firstMatch
-        UITestHelpers.waitForElement(restoredText)
+        let restoredRow = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Test Topiramate'")).firstMatch
+        UITestHelpers.waitForElement(restoredRow)
     }
 }

--- a/mobile-apps/ios/MigraLogUITests/ScreenshotsUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/ScreenshotsUITests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UIKit
 
 /// Generates App Store screenshots from a synthetic-but-realistic dataset.
 ///
@@ -36,26 +37,40 @@ final class ScreenshotsUITests: XCTestCase {
 
     /// 1. Dashboard — daily driver: today's medications, daily status, recent episodes.
     func test01_Dashboard() throws {
-        UITestHelpers.navigateTo(tab: .dashboard, in: app)
+        navigate(to: "Dashboard")
         Thread.sleep(forTimeInterval: 1.0)
         attachScreenshot(named: "01-Dashboard")
     }
 
     /// 2. Episode timeline — the centerpiece. Opens a recent closed episode
     /// with intensity readings, doses, and notes laid out chronologically.
+    /// On iPad this also shows the list-detail split view in one frame.
     func test02_EpisodeTimeline() throws {
-        UITestHelpers.navigateTo(tab: .episodes, in: app)
-        // Index 1 = most recent closed episode (index 0 is the active "ongoing" one,
-        // which has thinner timeline content).
-        let episodeCard = UITestHelpers.findElement("episode-card-1", in: app)
-        UITestHelpers.waitForHittable(episodeCard).tap()
+        navigate(to: "Episodes")
+        if isIPad {
+            // iPad uses a List-with-selection split view; tap the second row
+            // (first row is the active episode; second is a closed one with
+            // a fuller timeline).
+            let cells = app.cells
+            _ = cells.firstMatch.waitForExistence(timeout: 5)
+            cells.element(boundBy: 1).tap()
+        } else {
+            let episodeCard = UITestHelpers.findElement("episode-card-1", in: app)
+            UITestHelpers.waitForHittable(episodeCard).tap()
+        }
         Thread.sleep(forTimeInterval: 1.5)
         attachScreenshot(named: "02-Episode-Timeline")
     }
 
     /// 3. Medications — preventatives + rescue list with schedules.
+    /// On iPad the split view shows the list + the selected medication's detail.
     func test03_Medications() throws {
-        UITestHelpers.navigateTo(tab: .medications, in: app)
+        navigate(to: "Medications")
+        if isIPad {
+            let erenumab = app.staticTexts["Erenumab"]
+            UITestHelpers.waitForHittable(erenumab).tap()
+            Thread.sleep(forTimeInterval: 1.0)
+        }
         Thread.sleep(forTimeInterval: 1.0)
         attachScreenshot(named: "03-Medications")
     }
@@ -64,7 +79,7 @@ final class ScreenshotsUITests: XCTestCase {
     /// The current month often only has a few days populated, so step back one
     /// to land on a fully-filled month.
     func test04_Calendar() throws {
-        UITestHelpers.navigateTo(tab: .trends, in: app)
+        navigate(to: "Trends")
         let prev = app.buttons["calendar-previous"]
         UITestHelpers.waitForHittable(prev).tap()
         Thread.sleep(forTimeInterval: 1.0)
@@ -72,24 +87,64 @@ final class ScreenshotsUITests: XCTestCase {
     }
 
     /// 5. Trends → Statistics — Day Statistics + Duration Metrics cards.
-    /// Scrolls past the calendar so the stats cards dominate the frame.
+    /// On iPhone scrolls past the calendar; on iPad the stats live in the
+    /// sidebar of the split view and are visible without scrolling. Uses
+    /// the 90d range so the iPad screenshot's numbers differ from
+    /// `test04_Calendar` (default 30d).
     func test05_Statistics() throws {
-        UITestHelpers.navigateTo(tab: .trends, in: app)
-        let scroll = app.scrollViews.firstMatch
-        let durationMetrics = app.staticTexts["Duration Metrics"]
-        UITestHelpers.scrollToElement(durationMetrics, in: scroll)
-        Thread.sleep(forTimeInterval: 1.0)
+        navigate(to: "Trends")
+        if isIPad {
+            // Switch to 90d so stats reflect a different aggregate than test04.
+            let range90d = app.buttons["time-range-90"]
+            if range90d.waitForExistence(timeout: 5) {
+                range90d.tap()
+            }
+            Thread.sleep(forTimeInterval: 1.5)
+        } else {
+            let scroll = app.scrollViews.firstMatch
+            let durationMetrics = app.staticTexts["Duration Metrics"]
+            UITestHelpers.scrollToElement(durationMetrics, in: scroll)
+            Thread.sleep(forTimeInterval: 1.0)
+        }
         attachScreenshot(named: "05-Statistics")
     }
 
     /// 6. Episodes list — episode history with intensity sparklines.
+    /// On iPad pre-selects the active "Today / Ongoing" episode so the detail
+    /// pane shows live in-progress tracking rather than the empty placeholder.
     func test06_EpisodeHistory() throws {
-        UITestHelpers.navigateTo(tab: .episodes, in: app)
+        navigate(to: "Episodes")
+        if isIPad {
+            let cells = app.cells
+            _ = cells.firstMatch.waitForExistence(timeout: 5)
+            cells.firstMatch.tap()
+            Thread.sleep(forTimeInterval: 1.0)
+        }
         Thread.sleep(forTimeInterval: 1.0)
         attachScreenshot(named: "06-Episode-History")
     }
 
     // MARK: - Helpers
+
+    /// True when running on iPad, where TabView renders as a top pill bar
+    /// (not a bottom tab bar) and Episodes/Medications/Trends use NavigationSplitView.
+    private var isIPad: Bool {
+        UIDevice.current.userInterfaceIdiom == .pad
+    }
+
+    /// Navigate to a top-level section. Handles both the iPhone bottom tab bar
+    /// and the iPad top horizontal pill bar (iOS 26+ TabView on iPad).
+    private func navigate(to label: String) {
+        let tabBarButton = app.tabBars.buttons[label]
+        if tabBarButton.waitForExistence(timeout: 1) {
+            UITestHelpers.waitForHittable(tabBarButton).tap()
+        } else {
+            // iPad: TabView renders tabs as plain buttons in a horizontal bar.
+            let button = app.buttons[label].firstMatch
+            UITestHelpers.waitForHittable(button).tap()
+        }
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+    }
 
     private func attachScreenshot(named name: String) {
         let screenshot = XCUIScreen.main.screenshot()


### PR DESCRIPTION
## Summary
- **Today's Medications:** logged doses linger 15 min before hiding, with a real-time `SwiftUI.TimelineView` 60s tick so the row disappears even without a manual reload.
- **Tap medication name → detail screen:** dashboard row's medication name is now a `NavigationLink` to `MedicationDetailScreen`.
- **iPad TrendsTab fix:** added `.task { await viewModel.fetchData() }` so analytics load on first appear in the split view.
- **Screenshots UI tests:** iPad-aware navigation + split-view branches (utility, not main app).
- **Test fix:** `MedicationArchivingUITests` dashboard queries switched to `app.buttons` since the medication name is now a button label.

## Test plan
- [x] Unit tests: 359/359 pass locally
- [x] UI tests: 47/47 pass locally (originally 2 failures: 1 fixed by test query update, 1 confirmed flake — passes alone)
- [x] Manual: logged a preventative dose on simulator, row stays visible with "Taken at HH:mm" and Undo
- [x] Manual: tapped medication name on dashboard row, pushed to detail screen