### PR TITLE
fix(ios): correct dashboard dose quantity and omit implied "1 ×"

### DIFF
--- a/mobile-apps/ios/MigraLog/Utils/Formatting.swift
+++ b/mobile-apps/ios/MigraLog/Utils/Formatting.swift
@@ -11,12 +11,15 @@ enum MedicationFormatting {
         return needsSpace ? "\(amountStr) \(unit)" : "\(amountStr)\(unit)"
     }
 
-    /// Format a dose with quantity: "2 × 200mg", "1 × 75mg"
+    /// Format a dose with quantity: "2 × 200mg", "1.5 × 200mg".
+    /// A quantity of exactly 1 is implied — returns just the dosage ("200mg").
     static func formatDose(quantity: Double, amount: Double, unit: String) -> String {
+        let dosage = formatDosage(amount: amount, unit: unit)
+        if quantity == 1 { return dosage }
         let qtyStr = quantity.truncatingRemainder(dividingBy: 1) == 0
             ? String(Int(quantity))
             : String(format: "%.1f", quantity)
-        return "\(qtyStr) × \(formatDosage(amount: amount, unit: unit))"
+        return "\(qtyStr) × \(dosage)"
     }
 
     static func formatMedicationDisplay(_ medication: Medication) -> String {

--- a/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
@@ -104,7 +104,7 @@ final class DashboardViewModel {
             id: UUID().uuidString,
             medicationId: scheduleItem.medication.id,
             timestamp: now,
-            quantity: scheduleItem.schedule.dosage,
+            quantity: scheduleItem.medication.defaultQuantity ?? 1,
             dosageAmount: scheduleItem.medication.dosageAmount,
             dosageUnit: scheduleItem.medication.dosageUnit,
             status: .taken,

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -245,7 +245,7 @@ struct MedicationScheduleRow: View {
 
     private var doseLabel: String {
         MedicationFormatting.formatDose(
-            quantity: item.schedule.dosage,
+            quantity: item.medication.defaultQuantity ?? 1,
             amount: item.medication.dosageAmount,
             unit: item.medication.dosageUnit
         )

--- a/mobile-apps/ios/MigraLog/Views/Medications/AddMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/AddMedicationScreen.swift
@@ -185,14 +185,16 @@ struct AddMedicationScreen: View {
             let repo = MedicationRepository(dbManager: DatabaseManager.shared)
             try await repo.createMedication(medication)
 
-            // Create initial schedule for preventative meds with a frequency set
+            // Create initial schedule for preventative meds with a frequency set.
+            // schedule.dosage is the per-reminder pill count (mirrors
+            // medication.defaultQuantity), not the per-pill amount.
             if type == .preventative && scheduleFrequency != nil {
                 let schedule = MedicationSchedule(
                     id: UUID().uuidString,
                     medicationId: medication.id,
                     time: timeToString(reminderTime),
                     timezone: TimeZone.current.identifier,
-                    dosage: amount,
+                    dosage: medication.defaultQuantity ?? 1,
                     enabled: true,
                     notificationId: nil,
                     reminderEnabled: reminderEnabled

--- a/mobile-apps/ios/MigraLog/Views/Medications/MedicationDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/MedicationDetailScreen.swift
@@ -136,7 +136,7 @@ struct MedicationDetailScreen: View {
             if let medication = viewModel.medication {
                 AddScheduleSheet(
                     medicationId: medication.id,
-                    defaultDosage: medication.dosageAmount,
+                    defaultDosage: medication.defaultQuantity ?? 1,
                     viewModel: viewModel
                 )
             }

--- a/mobile-apps/ios/MigraLogTests/Utils/FormattingTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Utils/FormattingTests.swift
@@ -32,9 +32,14 @@ final class FormattingTests: XCTestCase {
 
     // MARK: - MedicationFormatting.formatDose
 
-    func testFormatDoseWholeQuantity() {
+    func testFormatDoseQuantityOne_omitsPrefix() {
         let result = MedicationFormatting.formatDose(quantity: 1, amount: 400, unit: "mg")
-        XCTAssertEqual(result, "1 \u{00d7} 400mg")
+        XCTAssertEqual(result, "400mg")
+    }
+
+    func testFormatDoseQuantityOne_omitsPrefixForUnitWithSpace() {
+        let result = MedicationFormatting.formatDose(quantity: 1, amount: 2, unit: "capsules")
+        XCTAssertEqual(result, "2 capsules")
     }
 
     func testFormatDoseFractionalQuantity() {


### PR DESCRIPTION
## Summary
- Dashboard "Today's Medications" log button was rendering a stale/incorrect quantity (e.g. `Log 400 × 200mg` for Magnesium, `Log 2 × 2 capsules` for Migraine MD) because it read `schedule.dosage`, which two schedule-creation paths were incorrectly seeding from `medication.dosageAmount` (per-pill mg) instead of `defaultQuantity` (pill count).
- Switched the dashboard display and `logDose` to read `medication.defaultQuantity` directly — same source the canonical `Log Dose` path on the detail screen uses — so the button label and the persisted dose record stay consistent.
- Fixed both schedule-creation sites (`AddMedicationScreen`, `MedicationDetailScreen` → `AddScheduleSheet`) so newly-created schedules store the correct quantity.
- Updated `MedicationFormatting.formatDose` to drop the implied `"1 ×"` prefix — a single-pill dose now renders as `"200mg"` or `"2 capsules"` instead of `"1 × 200mg"` / `"1 × 2 capsules"`. This propagates to the dashboard, the medication detail recent-activity list, the timeline view, and `LogMedicationScreen`.

## Test plan
- [x] All 746 unit tests pass locally
- [ ] UI tests pass locally
- [ ] Verify on device/simulator: Magnesium dashboard row shows `Log 2 × 200mg`; Migraine MD shows `Log 2 capsules`; Recent Activity entries with quantity 1 render without the `1 ×` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)