### PR TITLE
fix(ios): cancel pending reminders when a dose is logged

### DIFF
--- a/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/MigraLog.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		580BD01E7022EB5494AD7CA8 /* MigraLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B8D2570A843C4069DD91CA /* MigraLogTests.swift */; };
 		586C19AB559F2DF5BAD57EE7 /* SelectableChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C655C4327B2A2443B6CB590 /* SelectableChip.swift */; };
 		5B4F7E5827C42A9A80403425 /* AnalyticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A66B0ABA189E553063FC3D /* AnalyticsViewModel.swift */; };
+		5B5594A680BEC564DDFD28A9 /* MedicationDoseLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE4BECB755106E1DD3B92F0 /* MedicationDoseLogger.swift */; };
 		5B55987A3DDDC73867B409C9 /* ErrorLoggerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CD3CFDD21A77E702EE03EA /* ErrorLoggerIntegrationTests.swift */; };
 		5D598ECF458B861B5872A63E /* ExportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8085FE18D6FA8E5EE15EEF8B /* ExportServiceTests.swift */; };
 		600D3A118054B46BF84D7830 /* DomainModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6C1F41FAD082FBF1127456 /* DomainModels.swift */; };
@@ -153,6 +154,7 @@
 		E919E2044D68ED0932A9D71D /* DatabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F340F63DF6C366F048A48B /* DatabaseManager.swift */; };
 		EA05D454D080FAB6E085E9C1 /* EditMedicationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F530B6FA951887607EF386 /* EditMedicationScreen.swift */; };
 		EC12E5589D56AC4E7CF9444B /* ScheduledNotificationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5A99C36AD937AF36559761 /* ScheduledNotificationRepository.swift */; };
+		EEF5443BD68A7FF687A1BE83 /* MedicationDoseLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08703D98FEFBFFB943E433A /* MedicationDoseLoggerTests.swift */; };
 		EF2F89545E73FA4D4AB17CC7 /* MedicationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4261430F353F44B3DFAAC7 /* MedicationRepository.swift */; };
 		F0F59FF647D4E49F57F00790 /* EditDoseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FFA573403CE8CEB235A4EB /* EditDoseScreen.swift */; };
 		F1F11A1CCD0760620DEF5357 /* DeveloperToolsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BF70F8D6B06F72BB0220C8 /* DeveloperToolsScreen.swift */; };
@@ -299,6 +301,7 @@
 		AE83488C5F14B1929639701B /* MigraLogUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MigraLogUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B033CF962A0DDA5B74596C49 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B06640B1C2F15795CC008C8B /* ArchivedMedicationsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedMedicationsScreen.swift; sourceTree = "<group>"; };
+		B08703D98FEFBFFB943E433A /* MedicationDoseLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationDoseLoggerTests.swift; sourceTree = "<group>"; };
 		B0F3680DFDBEC106CB0A12C0 /* PainScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PainScaleTests.swift; sourceTree = "<group>"; };
 		B2551F77B785AF46F1DB36B4 /* DailyStatusRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyStatusRepository.swift; sourceTree = "<group>"; };
 		B2FFA573403CE8CEB235A4EB /* EditDoseScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDoseScreen.swift; sourceTree = "<group>"; };
@@ -307,6 +310,7 @@
 		B6ACA4C8E92F6B53F4F7B743 /* NotificationDismissalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDismissalService.swift; sourceTree = "<group>"; };
 		B9D384AA6DA7F843009EEC84 /* MedicationsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationsListViewModelTests.swift; sourceTree = "<group>"; };
 		BA496F22EB7B4101C8AB5AEE /* EpisodeRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeRepositoryTests.swift; sourceTree = "<group>"; };
+		BAE4BECB755106E1DD3B92F0 /* MedicationDoseLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationDoseLogger.swift; sourceTree = "<group>"; };
 		BCFC54BF563A2D05F70E109E /* AdaptiveNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveNavigation.swift; sourceTree = "<group>"; };
 		BD9A1C95DF45ECBD6088584F /* MedicationsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedicationsScreen.swift; sourceTree = "<group>"; };
 		BE6D8CCB2F92DF5EF290B066 /* EditPainLocationLogScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPainLocationLogScreen.swift; sourceTree = "<group>"; };
@@ -616,6 +620,7 @@
 				FD92CE0E5A2F8B92AF7000C7 /* ExportService.swift */,
 				90E6D59A95E669BF94630D8F /* LocationService.swift */,
 				68F365D4D845E349BD354A39 /* MedicationCooldown.swift */,
+				BAE4BECB755106E1DD3B92F0 /* MedicationDoseLogger.swift */,
 				8FE8ECC3DA7FE72FE8D60A39 /* MedicationNotificationService.swift */,
 				B6ACA4C8E92F6B53F4F7B743 /* NotificationDismissalService.swift */,
 				10A99C28CDBEEE4B30A7A108 /* NotificationIntegrityService.swift */,
@@ -642,6 +647,7 @@
 				8085FE18D6FA8E5EE15EEF8B /* ExportServiceTests.swift */,
 				E2AD1D8121EECFDA46211D60 /* LocationServiceTests.swift */,
 				5EEA84A71D637DF8F280A3FF /* MedicationCooldownTests.swift */,
+				B08703D98FEFBFFB943E433A /* MedicationDoseLoggerTests.swift */,
 				8750E37C42400B8607707EB7 /* MedicationNotificationServiceTests.swift */,
 				27D3A271598E0C2FBD9B61A2 /* NotificationDismissalServiceTests.swift */,
 				15FD7B9C41B2CEBE275DFBCF /* NotificationIntegrationTests.swift */,
@@ -932,6 +938,7 @@
 				FA1B88D89140735D8D0B0540 /* MedicationCategoryTests.swift in Sources */,
 				116097B18DA82FE412F3C5BA /* MedicationCooldownTests.swift in Sources */,
 				62050772CC4D955CEB7AB14F /* MedicationDetailViewModelTests.swift in Sources */,
+				EEF5443BD68A7FF687A1BE83 /* MedicationDoseLoggerTests.swift in Sources */,
 				5526658ACE024ED2751F7B58 /* MedicationNotificationServiceTests.swift in Sources */,
 				C17D7AFF287E53975932CED3 /* MedicationRepositoryTests.swift in Sources */,
 				2D14C25CEADEFB3BCC5E4840 /* MedicationsListViewModelTests.swift in Sources */,
@@ -1018,6 +1025,7 @@
 				D6173D2C08ED96EB11691B30 /* MedicationCooldown.swift in Sources */,
 				42F105DE5B8A28F59DED8D65 /* MedicationDetailScreen.swift in Sources */,
 				2247422882867F75EF1E622A /* MedicationDetailViewModel.swift in Sources */,
+				5B5594A680BEC564DDFD28A9 /* MedicationDoseLogger.swift in Sources */,
 				7F1E89BCE3CA857B918126AE /* MedicationNotificationService.swift in Sources */,
 				EF2F89545E73FA4D4AB17CC7 /* MedicationRepository.swift in Sources */,
 				7A3740B482B2C0A54A943595 /* MedicationSafetyBanners.swift in Sources */,

--- a/mobile-apps/ios/MigraLog/Services/MedicationDoseLogger.swift
+++ b/mobile-apps/ios/MigraLog/Services/MedicationDoseLogger.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Single entry point for persisting a medication dose. Centralises the
+/// side effects that must accompany a `createDose`, in particular cancelling
+/// any pending reminder or follow-up notifications for the medication so
+/// the user is not pinged for a dose they've already acted on. Every dose
+/// logging path (dashboard, detail screen, log-medication sheet, and
+/// notification action handler) goes through here so the cancellation can't
+/// be forgotten when a new path is added.
+protocol MedicationDoseLoggerProtocol: Sendable {
+    @discardableResult
+    func record(_ dose: MedicationDose) async throws -> MedicationDose
+}
+
+final class MedicationDoseLogger: MedicationDoseLoggerProtocol {
+    private let medicationRepo: MedicationRepositoryProtocol
+    private let notificationService: MedicationNotificationServiceProtocol
+
+    init(
+        medicationRepo: MedicationRepositoryProtocol = MedicationRepository(dbManager: DatabaseManager.shared),
+        notificationService: MedicationNotificationServiceProtocol = MedicationNotificationScheduler(
+            notificationService: NotificationService.shared,
+            scheduledNotificationRepo: ScheduledNotificationRepository(dbManager: DatabaseManager.shared),
+            medicationRepo: MedicationRepository(dbManager: DatabaseManager.shared)
+        )
+    ) {
+        self.medicationRepo = medicationRepo
+        self.notificationService = notificationService
+    }
+
+    @discardableResult
+    func record(_ dose: MedicationDose) async throws -> MedicationDose {
+        let saved = try medicationRepo.createDose(dose)
+        await notificationService.cancelTodaysReminders(medicationId: saved.medicationId)
+        return saved
+    }
+}

--- a/mobile-apps/ios/MigraLog/Services/MedicationNotificationService.swift
+++ b/mobile-apps/ios/MigraLog/Services/MedicationNotificationService.swift
@@ -18,6 +18,7 @@ protocol MedicationNotificationServiceProtocol: Sendable {
         medicationId: String, scheduleId: String,
         date: String, notificationType: NotificationType
     ) async
+    func cancelTodaysReminders(medicationId: String) async
     func dismissMedicationNotification(medicationId: String, scheduleId: String) async
     func handleTakenResponse(medicationId: String, scheduleId: String) async
     func handleSkippedResponse(medicationId: String, scheduleId: String) async
@@ -449,6 +450,39 @@ actor MedicationNotificationScheduler: MedicationNotificationServiceProtocol {
             }
         } catch {
             logger.error("Failed to cancel notification for date", error: error)
+        }
+    }
+
+    /// Cancels today's pending reminder and follow-up notifications for the
+    /// given medication across all of its schedules, dismisses any matching
+    /// already-delivered notifications, and tops up future days. Call this
+    /// after a dose is logged (taken or skipped) so the user isn't reminded
+    /// for a dose they've already acted on.
+    func cancelTodaysReminders(medicationId: String) async {
+        do {
+            let schedules = try medicationRepo.getSchedulesByMedicationId(medicationId)
+            let today = DateFormatting.dateString(from: Date())
+            for schedule in schedules {
+                await cancelNotificationForDate(
+                    medicationId: medicationId,
+                    scheduleId: schedule.id,
+                    date: today,
+                    notificationType: .reminder
+                )
+                await cancelNotificationForDate(
+                    medicationId: medicationId,
+                    scheduleId: schedule.id,
+                    date: today,
+                    notificationType: .followUp
+                )
+                await dismissMedicationNotification(
+                    medicationId: medicationId,
+                    scheduleId: schedule.id
+                )
+            }
+            await topUp()
+        } catch {
+            logger.error("Failed to cancel today's reminders for \(medicationId)", error: error)
         }
     }
 

--- a/mobile-apps/ios/MigraLog/Services/NotificationResponseHandler.swift
+++ b/mobile-apps/ios/MigraLog/Services/NotificationResponseHandler.swift
@@ -9,6 +9,7 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
     private let notificationService: NotificationServiceProtocol
     private let dailyStatusRepo: DailyStatusRepositoryProtocol
     private let dailyCheckinService: DailyCheckinNotificationServiceProtocol
+    private let doseLogger: MedicationDoseLoggerProtocol
     private let logger = AppLogger.shared
 
     init(
@@ -16,13 +17,18 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
         medicationRepository: MedicationRepositoryProtocol,
         notificationService: NotificationServiceProtocol,
         dailyStatusRepo: DailyStatusRepositoryProtocol,
-        dailyCheckinService: DailyCheckinNotificationServiceProtocol
+        dailyCheckinService: DailyCheckinNotificationServiceProtocol,
+        doseLogger: MedicationDoseLoggerProtocol? = nil
     ) {
         self.medicationNotificationService = medicationNotificationService
         self.medicationRepository = medicationRepository
         self.notificationService = notificationService
         self.dailyStatusRepo = dailyStatusRepo
         self.dailyCheckinService = dailyCheckinService
+        self.doseLogger = doseLogger ?? MedicationDoseLogger(
+            medicationRepo: medicationRepository,
+            notificationService: medicationNotificationService
+        )
         super.init()
     }
 
@@ -298,7 +304,7 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
                 updatedAt: now
             )
 
-            _ = try medicationRepository.createDose(dose)
+            _ = try await doseLogger.record(dose)
             logger.info("Dose logged via notification: \(medication.name) - \(status)")
 
             await MainActor.run {

--- a/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
@@ -42,6 +42,7 @@ final class DashboardViewModel {
     private let dailyStatusRepository: DailyStatusRepositoryProtocol
     private let categoryLimitRepository: CategorySafetyRuleRepositoryProtocol
     private let dailyCheckinService: DailyCheckinNotificationServiceProtocol
+    private let doseLogger: MedicationDoseLoggerProtocol
 
     // MARK: - Init
 
@@ -55,13 +56,15 @@ final class DashboardViewModel {
             scheduledNotificationRepo: ScheduledNotificationRepository(dbManager: DatabaseManager.shared),
             episodeRepo: EpisodeRepository(dbManager: DatabaseManager.shared),
             dailyStatusRepo: DailyStatusRepository(dbManager: DatabaseManager.shared)
-        )
+        ),
+        doseLogger: MedicationDoseLoggerProtocol = MedicationDoseLogger()
     ) {
         self.episodeRepository = episodeRepository
         self.medicationRepository = medicationRepository
         self.dailyStatusRepository = dailyStatusRepository
         self.categoryLimitRepository = categoryLimitRepository
         self.dailyCheckinService = dailyCheckinService
+        self.doseLogger = doseLogger
     }
 
     // MARK: - Actions
@@ -117,7 +120,7 @@ final class DashboardViewModel {
             updatedAt: now
         )
         do {
-            let savedDose = try await medicationRepository.createDose(dose)
+            let savedDose = try await doseLogger.record(dose)
             if let index = todaysMedications.firstIndex(where: { $0.id == scheduleItem.id }) {
                 todaysMedications[index].dose = savedDose
             }
@@ -155,7 +158,7 @@ final class DashboardViewModel {
             updatedAt: now
         )
         do {
-            let savedDose = try await medicationRepository.createDose(dose)
+            let savedDose = try await doseLogger.record(dose)
             if let index = todaysMedications.firstIndex(where: { $0.id == scheduleItem.id }) {
                 todaysMedications[index].dose = savedDose
             }

--- a/mobile-apps/ios/MigraLog/ViewModels/LogMedicationViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/LogMedicationViewModel.swift
@@ -15,15 +15,18 @@ final class LogMedicationViewModel {
     private let medicationRepository: MedicationRepositoryProtocol
     private let episodeRepository: EpisodeRepositoryProtocol
     private let categoryLimitRepository: CategorySafetyRuleRepositoryProtocol
+    private let doseLogger: MedicationDoseLoggerProtocol
 
     init(
         medicationRepository: MedicationRepositoryProtocol = MedicationRepository(dbManager: DatabaseManager.shared),
         episodeRepository: EpisodeRepositoryProtocol = EpisodeRepository(dbManager: DatabaseManager.shared),
-        categoryLimitRepository: CategorySafetyRuleRepositoryProtocol = CategorySafetyRuleRepository(dbManager: DatabaseManager.shared)
+        categoryLimitRepository: CategorySafetyRuleRepositoryProtocol = CategorySafetyRuleRepository(dbManager: DatabaseManager.shared),
+        doseLogger: MedicationDoseLoggerProtocol = MedicationDoseLogger()
     ) {
         self.medicationRepository = medicationRepository
         self.episodeRepository = episodeRepository
         self.categoryLimitRepository = categoryLimitRepository
+        self.doseLogger = doseLogger
     }
 
     @MainActor
@@ -110,7 +113,7 @@ final class LogMedicationViewModel {
             updatedAt: now
         )
         do {
-            try await medicationRepository.createDose(dose)
+            _ = try await doseLogger.record(dose)
             let categories = Set(medications.compactMap { $0.category })
             categoryUsage = computeCategoryUsage(for: categories, now: Date())
             categoryCooldowns = computeCategoryCooldowns(for: medications, now: Date())

--- a/mobile-apps/ios/MigraLog/ViewModels/MedicationDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/MedicationDetailViewModel.swift
@@ -41,6 +41,7 @@ final class MedicationDetailViewModel {
     private let medicationRepository: MedicationRepositoryProtocol
     private let medicationNotificationService: MedicationNotificationServiceProtocol
     private let categoryLimitRepository: CategorySafetyRuleRepositoryProtocol
+    private let doseLogger: MedicationDoseLoggerProtocol
     private var medicationId: String
 
     // MARK: - Init
@@ -53,12 +54,17 @@ final class MedicationDetailViewModel {
             scheduledNotificationRepo: ScheduledNotificationRepository(dbManager: DatabaseManager.shared),
             medicationRepo: MedicationRepository(dbManager: DatabaseManager.shared)
         ),
-        categoryLimitRepository: CategorySafetyRuleRepositoryProtocol = CategorySafetyRuleRepository(dbManager: DatabaseManager.shared)
+        categoryLimitRepository: CategorySafetyRuleRepositoryProtocol = CategorySafetyRuleRepository(dbManager: DatabaseManager.shared),
+        doseLogger: MedicationDoseLoggerProtocol? = nil
     ) {
         self.medicationId = medicationId
         self.medicationRepository = medicationRepository
         self.medicationNotificationService = medicationNotificationService
         self.categoryLimitRepository = categoryLimitRepository
+        self.doseLogger = doseLogger ?? MedicationDoseLogger(
+            medicationRepo: medicationRepository,
+            notificationService: medicationNotificationService
+        )
     }
 
     // MARK: - Actions
@@ -214,33 +220,11 @@ final class MedicationDetailViewModel {
             updatedAt: now
         )
         do {
-            let saved = try await medicationRepository.createDose(dose)
+            let saved = try await doseLogger.record(dose)
             recentDoses.insert(saved, at: 0)
             recentDoses.sort { $0.timestamp > $1.timestamp }
             categoryStatus = computeCategoryStatus(for: medication, now: Date())
             categoryCooldown = computeCategoryCooldown(for: medication, now: Date())
-
-            // Cancel today's reminder and follow-up notifications for this medication
-            let today = DateFormatting.dateString(from: Date())
-            for schedule in schedules {
-                await medicationNotificationService.cancelNotificationForDate(
-                    medicationId: med.id,
-                    scheduleId: schedule.id,
-                    date: today,
-                    notificationType: .reminder
-                )
-                await medicationNotificationService.cancelNotificationForDate(
-                    medicationId: med.id,
-                    scheduleId: schedule.id,
-                    date: today,
-                    notificationType: .followUp
-                )
-            }
-            await medicationNotificationService.dismissMedicationNotification(
-                medicationId: med.id,
-                scheduleId: schedules.first?.id ?? ""
-            )
-            await medicationNotificationService.topUp()
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "MedicationDetailViewModel"])
             self.error = error.localizedDescription

--- a/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
@@ -57,8 +57,7 @@ struct LogMedicationScreen: View {
                     categoryCooldown: viewModel.categoryCooldowns[med.id]
                 ) { dose in
                     Task {
-                        let repo = MedicationRepository(dbManager: DatabaseManager.shared)
-                        try? await repo.createDose(dose)
+                        try? await MedicationDoseLogger().record(dose)
                         dismiss()
                     }
                 }

--- a/mobile-apps/ios/MigraLogTests/Services/MedicationDoseLoggerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/MedicationDoseLoggerTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import MigraLog
+
+final class MedicationDoseLoggerTests: XCTestCase {
+    private var mockMedicationRepo: MockMedicationRepository!
+    private var mockNotificationService: MockMedicationNotificationService!
+    private var sut: MedicationDoseLogger!
+
+    override func setUp() {
+        super.setUp()
+        mockMedicationRepo = MockMedicationRepository()
+        mockNotificationService = MockMedicationNotificationService()
+        sut = MedicationDoseLogger(
+            medicationRepo: mockMedicationRepo,
+            notificationService: mockNotificationService
+        )
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockMedicationRepo = nil
+        mockNotificationService = nil
+        super.tearDown()
+    }
+
+    func testRecord_persistsDoseAndCancelsTodaysReminders() async throws {
+        let dose = makeDose(medicationId: "med-1")
+
+        let saved = try await sut.record(dose)
+
+        XCTAssertEqual(saved.id, dose.id)
+        XCTAssertEqual(mockMedicationRepo.doses.count, 1, "Dose should be persisted")
+        XCTAssertEqual(mockMedicationRepo.doses.first?.id, dose.id)
+        XCTAssertEqual(
+            mockNotificationService.cancelTodaysRemindersCalls, ["med-1"],
+            "Should cancel today's reminders for the medication that was just logged"
+        )
+    }
+
+    func testRecord_doesNotCancelReminders_whenPersistFails() async {
+        mockMedicationRepo.errorToThrow = NSError(domain: "test", code: 1)
+        let dose = makeDose(medicationId: "med-1")
+
+        do {
+            _ = try await sut.record(dose)
+            XCTFail("Expected error to be rethrown")
+        } catch {
+            XCTAssertTrue(
+                mockNotificationService.cancelTodaysRemindersCalls.isEmpty,
+                "Reminders must not be cancelled if the dose was never written"
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeDose(medicationId: String) -> MedicationDose {
+        let now = TimestampHelper.now
+        return MedicationDose(
+            id: UUID().uuidString,
+            medicationId: medicationId,
+            timestamp: now,
+            quantity: 1,
+            dosageAmount: 10,
+            dosageUnit: "mg",
+            status: .taken,
+            episodeId: nil,
+            effectivenessRating: nil,
+            timeToRelief: nil,
+            sideEffects: [],
+            notes: nil,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Services/NotificationResponseHandlerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/NotificationResponseHandlerTests.swift
@@ -39,6 +39,7 @@ final class MockMedicationNotificationService: MedicationNotificationServiceProt
     var handleSkippedCalls: [(medicationId: String, scheduleId: String)] = []
     var rescheduleAllCalled = false
     var cancelCalls: [String] = []
+    var cancelTodaysRemindersCalls: [String] = []
     var topUpCalled = false
     var rebalanceCalled = false
 
@@ -54,6 +55,10 @@ final class MockMedicationNotificationService: MedicationNotificationServiceProt
         medicationId: String, scheduleId: String,
         date: String, notificationType: NotificationType
     ) async {}
+
+    func cancelTodaysReminders(medicationId: String) async {
+        cancelTodaysRemindersCalls.append(medicationId)
+    }
 
     func dismissMedicationNotification(medicationId: String, scheduleId: String) async {}
 

--- a/mobile-apps/ios/MigraLogTests/ViewModels/DashboardViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/DashboardViewModelTests.swift
@@ -19,7 +19,11 @@ final class DashboardViewModelTests: XCTestCase {
             episodeRepository: mockEpisodeRepo,
             medicationRepository: mockMedRepo,
             dailyStatusRepository: mockStatusRepo,
-            categoryLimitRepository: mockCategoryLimitRepo
+            categoryLimitRepository: mockCategoryLimitRepo,
+            doseLogger: MedicationDoseLogger(
+                medicationRepo: mockMedRepo,
+                notificationService: MockMedicationNotificationService()
+            )
         )
     }
 

--- a/mobile-apps/ios/MigraLogTests/ViewModels/LogMedicationViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/LogMedicationViewModelTests.swift
@@ -16,7 +16,11 @@ final class LogMedicationViewModelTests: XCTestCase {
         sut = LogMedicationViewModel(
             medicationRepository: mockMedRepo,
             episodeRepository: mockEpisodeRepo,
-            categoryLimitRepository: mockCategoryLimitRepo
+            categoryLimitRepository: mockCategoryLimitRepo,
+            doseLogger: MedicationDoseLogger(
+                medicationRepo: mockMedRepo,
+                notificationService: MockMedicationNotificationService()
+            )
         )
     }
 

--- a/mobile-apps/ios/MigraLogTests/ViewModels/NotificationSettingsViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/NotificationSettingsViewModelTests.swift
@@ -58,6 +58,7 @@ private final class MockMedNotifService: MedicationNotificationServiceProtocol, 
 
     func cancelMedicationReminders(for medicationId: String) async {}
     func cancelNotificationForDate(medicationId: String, scheduleId: String, date: String, notificationType: NotificationType) async {}
+    func cancelTodaysReminders(medicationId: String) async {}
     func dismissMedicationNotification(medicationId: String, scheduleId: String) async {}
     func handleTakenResponse(medicationId: String, scheduleId: String) async {}
     func handleSkippedResponse(medicationId: String, scheduleId: String) async {}


### PR DESCRIPTION
## Summary
- Logging a dose from the dashboard, log-medication sheet, or notification action did not cancel the OS-scheduled medication reminder or follow-up, so the user was still pinged at the scheduled time after taking the dose early. Only the medication-detail screen cancelled them.
- Introduce `MedicationDoseLogger` (`record(_:)` = `createDose` + `cancelTodaysReminders`) and route every dose-creation call site through it so the cancellation cannot be forgotten when a new path is added (Siri shortcut, widget, etc.).
- Adds `cancelTodaysReminders(medicationId:)` on `MedicationNotificationServiceProtocol` so the side effect is testable in isolation.

## Test plan
- [x] `MedicationDoseLoggerTests` verifies `record` persists and cancels reminders, and skips cancellation when persistence throws
- [x] All 748 unit tests pass locally
- [ ] Manual: log a preventative dose early from the dashboard card; confirm the scheduled reminder + follow-up do **not** fire
- [ ] Manual: log a preventative dose from the medication detail screen; confirm same
- [ ] Manual: tap "Take" on a delivered medication notification; confirm any pending follow-up for the same dose does not fire
- [ ] Manual: with two preventative meds at the same time, log one; confirm the grouped reminder still fires for the other med

🤖 Generated with [Claude Code](https://claude.com/claude-code)