### PR TITLE
fix(ios): suppress daily check-in on days with an active episode

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/DailyCheckinNotificationService.swift
+++ b/mobile-apps/ios/MigraLog/Services/DailyCheckinNotificationService.swift
@@ -254,12 +254,16 @@ final class DailyCheckinNotificationService: DailyCheckinNotificationServiceProt
                 return true
             }
 
-            // 2. Any episode on this date = red day
+            // 2. Any episode overlapping this date = red day. Test for overlap
+            // rather than start-time membership so multi-day episodes suppress
+            // every day they span, not just the day they began.
             if let dateObj = DateFormatting.date(from: date) {
                 let startOfDay = Int64(dateObj.timeIntervalSince1970 * 1000)
                 let endOfDay = Int64(dateObj.addingTimeInterval(86400).timeIntervalSince1970 * 1000)
-                let episodes = try episodeRepo.getEpisodesByDateRange(start: startOfDay, end: endOfDay)
-                if !episodes.isEmpty {
+                let overlaps = try episodeRepo.getAllEpisodes().contains { ep in
+                    ep.startTime < endOfDay && (ep.endTime ?? Int64.max) > startOfDay
+                }
+                if overlaps {
                     return true
                 }
             }

--- a/mobile-apps/ios/MigraLog/Views/Episodes/NewEpisodeScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/NewEpisodeScreen.swift
@@ -131,15 +131,17 @@ struct NewEpisodeScreen: View {
             )
             try await repo.createIntensityReading(reading)
 
-            // Cancel today's daily check-in — starting an episode makes it a red day
-            let todayStr = DateFormatting.dateString(from: Date())
+            // Cancel all pending daily check-ins — an active episode means we
+            // shouldn't prompt "how was your day?" on any day it spans. The
+            // notifications are rebuilt (with correct suppression) when the
+            // episode ends via scheduleNotifications().
             let checkinService = DailyCheckinNotificationService(
                 notificationService: NotificationService.shared,
                 scheduledNotificationRepo: ScheduledNotificationRepository(dbManager: DatabaseManager.shared),
                 episodeRepo: repo,
                 dailyStatusRepo: DailyStatusRepository(dbManager: DatabaseManager.shared)
             )
-            await checkinService.cancelForDate(todayStr)
+            await checkinService.cancelAll()
 
             dismiss()
         } catch {

--- a/mobile-apps/ios/MigraLogTests/Services/DailyCheckinNotificationServiceTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/DailyCheckinNotificationServiceTests.swift
@@ -207,6 +207,35 @@ final class DailyCheckinNotificationServiceTests: XCTestCase {
                         "Date with an ended episode should be suppressed")
     }
 
+    func testSchedule_suppressesAllDaysSpannedByMultiDayEpisode() async throws {
+        // A multi-day episode that started on day 1 and ended on day 3 should
+        // suppress the check-in on day 2 and day 3 as well — not just the day it
+        // began. The episode is ended, so this exercises the overlap check
+        // rather than the active-episode short-circuit.
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let day1 = calendar.date(byAdding: .day, value: 1, to: today)!
+        let day2 = calendar.date(byAdding: .day, value: 2, to: today)!
+        let day3 = calendar.date(byAdding: .day, value: 3, to: today)!
+        let day2Str = DateFormatting.dateString(from: day2)
+        let day3Str = DateFormatting.dateString(from: day3)
+
+        let startTs = TimestampHelper.fromDate(day1)
+        let endTs = TimestampHelper.fromDate(day3) + 12 * 3600_000 // midday on day 3
+
+        mockEpisodeRepo.episodes = [
+            TestFixtures.makeEpisode(id: "ep-multiday", startTime: startTs, endTime: endTs)
+        ]
+
+        try await sut.scheduleNotifications()
+
+        let scheduledIds = Set(mockNotificationService.scheduledNotifications.map(\.id))
+        XCTAssertFalse(scheduledIds.contains("daily_checkin_\(day2Str)"),
+                        "Day fully inside a multi-day episode should be suppressed")
+        XCTAssertFalse(scheduledIds.contains("daily_checkin_\(day3Str)"),
+                        "Day the multi-day episode ended on should be suppressed")
+    }
+
     func testSchedule_activeEpisode_suppressesAllFutureDates() async throws {
         // Active episode (no endTime) — should suppress ALL 14 days
         mockEpisodeRepo.episodes = [


### PR DESCRIPTION
## Problem

The "How was your day?" daily check-in was still firing at 9pm on days with an active migraine episode — which is counterproductive, since we already know it wasn't a good day.

Suppression logic existed but only ran at *scheduling* time, while check-ins are pre-scheduled 14 days out. Two gaps let the prompt slip through:

1. **Multi-day episodes leaked.** Starting an episode only cancelled *today's* check-in. Check-ins already scheduled for the following days the episode spans were never removed — they'd only get suppressed if the app was relaunched on that day (re-running `scheduleNotifications`). No relaunch → the 9pm prompt fired mid-episode.
2. **Overlap wasn't detected on reschedule.** `shouldSuppressForDate` found episodes via a `start_time`-only query, so a multi-day episode that started earlier but ended today wasn't recognized when notifications were rebuilt at episode-end — and it re-scheduled today's prompt for a day that had an active episode.

## Fix

- **On episode start** (`NewEpisodeScreen`): cancel *all* pending check-ins instead of just today's. While an episode is active we want zero prompts regardless of span; they're rebuilt with correct suppression by the existing `scheduleNotifications()` call when the episode ends.
- **In `shouldSuppressForDate`**: test for date overlap (`startTime < dayEnd && (endTime ?? .max) > dayStart`), matching the pattern already used in `DashboardViewModel`.

## Testing

- Added a regression test covering an episode spanning multiple days.
- `DailyCheckinNotificationServiceTests`: 27 tests, 0 failures.

Note: `NewEpisodeViewModel.saveEpisode()` is a parallel, test-only episode-create path (no production view uses it) and was left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)