### PR TITLE
fix(ios): restore day separators on multi-day episode timeline

### DIFF
--- a/mobile-apps/ios/MigraLog/Utils/DateFormatting.swift
+++ b/mobile-apps/ios/MigraLog/Utils/DateFormatting.swift
@@ -29,6 +29,12 @@ enum DateFormatting {
         return f
     }()
 
+    private static let timelineDayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.setLocalizedDateFormatFromTemplate("EEEMMMd")
+        return f
+    }()
+
     // MARK: - Date String (YYYY-MM-DD)
 
     static func dateString(from date: Date) -> String {
@@ -51,6 +57,17 @@ enum DateFormatting {
 
     static func displayDateTime(_ date: Date) -> String {
         displayDateTimeFormatter.string(from: date)
+    }
+
+    /// Compact day label for timeline day separators (e.g. "Today", "Yesterday", "Mon, May 26").
+    static func timelineDayHeader(_ date: Date) -> String {
+        let calendar = Calendar.current
+        if calendar.isDateInToday(date) {
+            return "Today"
+        } else if calendar.isDateInYesterday(date) {
+            return "Yesterday"
+        }
+        return timelineDayFormatter.string(from: date)
     }
 
     // MARK: - Duration Formatting

--- a/mobile-apps/ios/MigraLog/Views/Episodes/TimelineView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/TimelineView.swift
@@ -79,42 +79,51 @@ struct TimelineView: View {
                 let isLast = index == events.count - 1
                 let isEpisodeEnd = event.kind.isEpisodeEnded
                 let showLineBelow = !isLast && !isEpisodeEnd
+                let showDayHeader = index == 0
+                    || !Calendar.current.isDate(event.date, inSameDayAs: events[index - 1].date)
 
-                VStack(spacing: 0) {
-                    // Top row: time, dot, title — all vertically centered
-                    HStack(spacing: 0) {
-                        Text(DateFormatting.displayTime(event.date))
-                            .font(.subheadline.monospacedDigit())
-                            .foregroundStyle(.secondary)
-                            .frame(width: 75, alignment: .trailing)
-
-                        timelineDot(for: event)
-                            .frame(width: 32)
-
-                        timelineTitle(for: event)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                VStack(alignment: .leading, spacing: 0) {
+                    // Day separator — shown at the first event of each calendar day
+                    if showDayHeader {
+                        dayHeader(for: event.date, isFirst: index == 0)
                     }
 
-                    // Detail content + line below dot
-                    HStack(alignment: .top, spacing: 0) {
-                        // Spacer for time column
-                        Color.clear
-                            .frame(width: 75)
+                    VStack(spacing: 0) {
+                        // Top row: time, dot, title — all vertically centered
+                        HStack(spacing: 0) {
+                            Text(DateFormatting.displayTime(event.date))
+                                .font(.subheadline.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                                .frame(width: 75, alignment: .trailing)
 
-                        // Vertical line below the dot
-                        Rectangle()
-                            .fill(showLineBelow ? Color.secondary.opacity(0.2) : .clear)
-                            .frame(width: 1)
-                            .frame(maxHeight: .infinity)
-                            .frame(width: 32)
+                            timelineDot(for: event)
+                                .frame(width: 32)
 
-                        // Detail content (bar, chips, subtitle, etc.)
-                        timelineDetail(for: event)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                            timelineTitle(for: event)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+
+                        // Detail content + line below dot
+                        HStack(alignment: .top, spacing: 0) {
+                            // Spacer for time column
+                            Color.clear
+                                .frame(width: 75)
+
+                            // Vertical line below the dot
+                            Rectangle()
+                                .fill(showLineBelow ? Color.secondary.opacity(0.2) : .clear)
+                                .frame(width: 1)
+                                .frame(maxHeight: .infinity)
+                                .frame(width: 32)
+
+                            // Detail content (bar, chips, subtitle, etc.)
+                            timelineDetail(for: event)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
                     }
+                    .padding(.vertical, 6)
+                    .contextMenu { timelineContextMenu(for: event) }
                 }
-                .padding(.vertical, 6)
-                .contextMenu { timelineContextMenu(for: event) }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -216,6 +225,21 @@ struct TimelineView: View {
 
         events.sort { $0.timestamp < $1.timestamp }
         return events
+    }
+
+    /// Day separator row marking the start of a calendar day within the timeline.
+    @ViewBuilder
+    private func dayHeader(for date: Date, isFirst: Bool) -> some View {
+        HStack(spacing: 8) {
+            Text(DateFormatting.timelineDayHeader(date))
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Rectangle()
+                .fill(Color.secondary.opacity(0.2))
+                .frame(height: 1)
+        }
+        .padding(.top, isFirst ? 0 : 12)
+        .padding(.bottom, 4)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Problem
On multi-day episodes the timeline showed only event times with no indication of which calendar day each event fell on (issue #431). The prior React Native app grouped events under day headers; the Swift port dropped this.

## Fix
- `DateFormatting.swift` — add `timelineDayHeader(_:)` returning `"Today"`/`"Yesterday"` or a compact `"Tue, May 26"` label.
- `TimelineView.swift` — render a day-separator row at the first event of each calendar day (detected via `Calendar.isDate(_:inSameDayAs:)` against the previous event).

## Verification
Built and ran in the iOS simulator with a seeded 3-day episode (May 26–28). Day headers render at each boundary (`Tue, May 26`, `Wed, May 27`, `Thu, May 28`) and cleanly delineate intensity updates, pain-location changes, notes, and "Episode Ended".

Fixes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)