### PR TITLE
fix(ios): stabilize nightly archive UI test (#440)

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/Medications/MedicationsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/MedicationsScreen.swift
@@ -77,9 +77,10 @@ struct MedicationsScreen: View {
                 )
             }
         }
-        .task {
-            await viewModel.loadMedications()
-        }
+        // `.onAppear` covers both the initial appearance and every return to the
+        // Medications tab, so we deliberately avoid a redundant `.task` reload here:
+        // overlapping `loadMedications()` calls keep the list re-rendering and delay
+        // the view reaching an idle state (which UI tests wait on before interacting).
         .onAppear {
             Task { await viewModel.loadMedications() }
         }

--- a/mobile-apps/ios/MigraLogUITests/MedicationArchivingUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/MedicationArchivingUITests.swift
@@ -158,8 +158,15 @@ final class MedicationArchivingUITests: XCTestCase {
 
         // Step 3: Restore the medication
         UITestHelpers.navigateTo(tab: .medications, in: app)
+        // Wait for the active list to finish reloading (the just-archived medication
+        // is gone) before probing the archived link. Archiving triggers an async
+        // reload, and interacting mid-reload can leave the link not yet hittable on
+        // slower CI machines.
+        let archivedActiveCard = app.buttons["medication-card-Test Topiramate"]
+        UITestHelpers.waitForElementToDisappear(archivedActiveCard, timeout: 10)
         let archivedLink = app.buttons["archived-medications-link"]
-        UITestHelpers.waitForHittable(archivedLink)
+        UITestHelpers.scrollToElement(archivedLink, in: app.collectionViews.firstMatch)
+        UITestHelpers.waitForHittable(archivedLink, timeout: 10)
         archivedLink.tap()
         Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
 


### PR DESCRIPTION
## Summary
Fixes the nightly Full UI suite failure (#440): `testArchiveMedicationWithReminders` intermittently failed with `archived-medications-link Button did not become hittable within 5.0s`.

The link **does** become hittable — but on the loaded CI nightly runner, not within the test's 5s window. Reproduced locally: the test passes (link hittable ~1.5s after the tab switch), confirming a timing/synchronization gap rather than a product defect in the link itself.

## Root cause
- `MedicationsScreen` started `loadMedications()` from **both** `.task` and `.onAppear`, double-loading on first appearance. Combined with the `.medicationDataChanged` reload posted 0.5s after archiving, these overlapping async reloads kept the view re-rendering and delayed the app reaching an *idle* state — which XCUITest waits on before evaluating `isHittable`.
- The failing test probed the archived link immediately after a tab switch, without first waiting for the post-archive reload to settle (its passing sibling `testArchiveAndRestoreWorkflow` does wait).

## Changes
- **`MedicationsScreen.swift`** — drop the redundant `.task` reload. `.onAppear` already covers the initial appearance and every return to the Medications tab, so this strictly reduces overlapping reloads and lets the view settle faster.
- **`MedicationArchivingUITests.swift`** — wait for the active list to settle (the archived medication disappears) and scroll the archived link into view before tapping, with a longer hittable timeout.

## Verification
- Previously-failing `testArchiveMedicationWithReminders`: **5/5 pass** under stress.
- Full `MedicationArchivingUITests` class: **2/2 pass** locally (iPhone 17 Pro, iOS 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)