### PR TITLE
feat(ios): CloudKit sync schema + v29 updated_at migration (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/App/MigraLog.entitlements
+++ b/mobile-apps/ios/MigraLog/App/MigraLog.entitlements
@@ -6,5 +6,13 @@
 	<true/>
 	<key>com.apple.developer.usernotifications.time-sensitive</key>
 	<true/>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.eff3.migralog</string>
+	</array>
 </dict>
 </plist>

--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -4,7 +4,7 @@ import GRDB
 /// Central database manager. Owns the DatabaseQueue and handles schema creation/migration.
 final class DatabaseManager: Sendable {
     /// The current schema version
-    static let schemaVersion = 28
+    static let schemaVersion = 29
 
     /// Shared singleton for the app's main database
     static let shared = DatabaseManager()
@@ -132,6 +132,12 @@ final class DatabaseManager: Sendable {
             try DatabaseManager.migrateToCategorySafetyRules(in: db)
         }
 
+        // v29: Add the last-write-wins `updated_at` timestamps required by iCloud
+        // sync (#434) to synced tables that lacked them. See addSyncTimestampColumns.
+        migrator.registerMigration("v29") { db in
+            try DatabaseManager.addSyncTimestampColumns(in: db)
+        }
+
         return migrator
     }
 
@@ -146,6 +152,7 @@ final class DatabaseManager: Sendable {
                 period_hours REAL NOT NULL CHECK(period_hours > 0),
                 max_count INTEGER CHECK(max_count IS NULL OR max_count > 0),
                 created_at INTEGER NOT NULL CHECK(created_at > 0),
+                updated_at INTEGER CHECK(updated_at IS NULL OR updated_at > 0),
                 UNIQUE(category, type)
             )
             """)
@@ -182,7 +189,48 @@ final class DatabaseManager: Sendable {
         try db.execute(sql: "DROP TABLE category_usage_limits")
     }
 
-    /// Create all tables, indexes, and constraints matching schema-v25.sql
+    /// Add the last-write-wins `updated_at` timestamp required by iCloud sync (#434)
+    /// to the synced tables that lacked it. `medication_schedules` had no timestamp at
+    /// all, so it gains both `created_at` and `updated_at`. Idempotent (guarded by
+    /// table_info checks) so it is safe on both fresh-install and upgrade paths.
+    ///
+    /// The columns are nullable and are NOT yet maintained by any write path — they
+    /// sit inert until SyncService owns keeping them current. Existing rows are
+    /// backfilled so historical data carries a usable LWW timestamp.
+    static func addSyncTimestampColumns(in db: Database) throws {
+        func hasColumn(_ table: String, _ column: String) throws -> Bool {
+            let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(\(table))")
+            return columns.contains { (row: Row) in (row["name"] as String?) == column }
+        }
+
+        // Append-only / created_at-bearing tables: updated_at backfills from created_at.
+        for table in ["symptom_logs", "episode_notes", "category_safety_rules"] {
+            if try !hasColumn(table, "updated_at") {
+                try db.execute(sql: "ALTER TABLE \(table) ADD COLUMN updated_at INTEGER CHECK(updated_at IS NULL OR updated_at > 0)")
+                try db.execute(sql: "UPDATE \(table) SET updated_at = created_at WHERE updated_at IS NULL")
+            }
+        }
+
+        // medication_schedules has no timestamps at all; add both and stamp existing rows.
+        let now = TimestampHelper.now
+        if try !hasColumn("medication_schedules", "created_at") {
+            try db.execute(sql: "ALTER TABLE medication_schedules ADD COLUMN created_at INTEGER CHECK(created_at IS NULL OR created_at > 0)")
+            try db.execute(
+                sql: "UPDATE medication_schedules SET created_at = ? WHERE created_at IS NULL",
+                arguments: [now]
+            )
+        }
+        if try !hasColumn("medication_schedules", "updated_at") {
+            try db.execute(sql: "ALTER TABLE medication_schedules ADD COLUMN updated_at INTEGER CHECK(updated_at IS NULL OR updated_at > 0)")
+            try db.execute(
+                sql: "UPDATE medication_schedules SET updated_at = COALESCE(created_at, ?) WHERE updated_at IS NULL",
+                arguments: [now]
+            )
+        }
+    }
+
+    /// Create the v25 baseline schema. Later registered migrations evolve it to the
+    /// current version; see spec/schemas/sqlite/schema-v28.sql for the current end-state.
     // swiftlint:disable:next function_body_length
     static func createSchema(in db: Database) throws {
         // Episodes table
@@ -228,6 +276,7 @@ final class DatabaseManager: Sendable {
                 resolution_time INTEGER CHECK(resolution_time IS NULL OR resolution_time > onset_time),
                 severity REAL CHECK(severity IS NULL OR (severity >= 0 AND severity <= 10)),
                 created_at INTEGER NOT NULL CHECK(created_at > 0),
+                updated_at INTEGER CHECK(updated_at IS NULL OR updated_at > 0),
                 FOREIGN KEY (episode_id) REFERENCES episodes(id) ON DELETE CASCADE
             )
             """)
@@ -253,6 +302,7 @@ final class DatabaseManager: Sendable {
                 timestamp INTEGER NOT NULL CHECK(timestamp > 0),
                 note TEXT NOT NULL CHECK(length(note) > 0 AND length(note) <= 5000),
                 created_at INTEGER NOT NULL CHECK(created_at > 0),
+                updated_at INTEGER CHECK(updated_at IS NULL OR updated_at > 0),
                 FOREIGN KEY (episode_id) REFERENCES episodes(id) ON DELETE CASCADE
             )
             """)
@@ -288,6 +338,8 @@ final class DatabaseManager: Sendable {
                 enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
                 notification_id TEXT,
                 reminder_enabled INTEGER NOT NULL DEFAULT 1 CHECK(reminder_enabled IN (0, 1)),
+                created_at INTEGER CHECK(created_at IS NULL OR created_at > 0),
+                updated_at INTEGER CHECK(updated_at IS NULL OR updated_at > 0),
                 FOREIGN KEY (medication_id) REFERENCES medications(id) ON DELETE CASCADE
             )
             """)

--- a/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
@@ -183,7 +183,7 @@ final class DatabaseManagerTests: XCTestCase {
     // MARK: - Schema Version
 
     func testSchemaVersionIsTracked() throws {
-        XCTAssertEqual(DatabaseManager.schemaVersion, 28)
+        XCTAssertEqual(DatabaseManager.schemaVersion, 29)
     }
 
     func testMigrationIsRecordedInGRDB() throws {
@@ -193,6 +193,72 @@ final class DatabaseManagerTests: XCTestCase {
 
             let identifiers = migrations.map { $0["identifier"] as String }
             XCTAssertTrue(identifiers.contains("v25"), "Migration v25 should be recorded")
+        }
+    }
+
+    // MARK: - iCloud Sync Schema (v29)
+
+    /// v29 adds the last-write-wins `updated_at` timestamp to the synced tables that
+    /// lacked it, and `created_at` + `updated_at` to `medication_schedules` (#434).
+    func testV29AddsSyncTimestampColumns() throws {
+        try dbManager.dbQueue.read { db in
+            for table in ["symptom_logs", "episode_notes", "category_safety_rules", "medication_schedules"] {
+                let names = try Row.fetchAll(db, sql: "PRAGMA table_info(\(table))")
+                    .compactMap { $0["name"] as String? }
+                XCTAssertTrue(names.contains("updated_at"), "\(table) should have updated_at after v29")
+            }
+            let scheduleNames = try Row.fetchAll(db, sql: "PRAGMA table_info(medication_schedules)")
+                .compactMap { $0["name"] as String? }
+            XCTAssertTrue(scheduleNames.contains("created_at"), "medication_schedules should gain created_at in v29")
+        }
+    }
+
+    func testV29MigrationIsRecorded() throws {
+        try dbManager.dbQueue.read { db in
+            let identifiers = try Row.fetchAll(db, sql: "SELECT identifier FROM grdb_migrations")
+                .map { $0["identifier"] as String }
+            XCTAssertTrue(identifiers.contains("v29"), "Migration v29 should be recorded")
+        }
+    }
+
+    /// Exercises the upgrade path directly: an old-shape DB (no sync timestamps) is
+    /// migrated, and existing rows must be backfilled with usable timestamps.
+    func testAddSyncTimestampColumnsBackfillsExistingRows() throws {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            // Pre-v29 shapes (only the columns the helper reads).
+            try db.execute(sql: "CREATE TABLE symptom_logs (id TEXT PRIMARY KEY, created_at INTEGER NOT NULL)")
+            try db.execute(sql: "CREATE TABLE episode_notes (id TEXT PRIMARY KEY, created_at INTEGER NOT NULL)")
+            try db.execute(sql: "CREATE TABLE category_safety_rules (id TEXT PRIMARY KEY, created_at INTEGER NOT NULL)")
+            try db.execute(sql: "CREATE TABLE medication_schedules (id TEXT PRIMARY KEY, medication_id TEXT NOT NULL)")
+            try db.execute(sql: "INSERT INTO symptom_logs (id, created_at) VALUES ('s1', 5000)")
+            try db.execute(sql: "INSERT INTO medication_schedules (id, medication_id) VALUES ('sch1', 'med1')")
+        }
+
+        try queue.write { db in
+            try DatabaseManager.addSyncTimestampColumns(in: db)
+        }
+
+        try queue.read { db in
+            // Append-only table: updated_at backfills from created_at.
+            let updatedAt = try Int64.fetchOne(db, sql: "SELECT updated_at FROM symptom_logs WHERE id = 's1'")
+            XCTAssertEqual(updatedAt, 5000, "symptom_logs.updated_at should backfill from created_at")
+
+            // medication_schedules gains both timestamps, stamped and equal.
+            let row = try Row.fetchOne(db, sql: "SELECT created_at, updated_at FROM medication_schedules WHERE id = 'sch1'")
+            let createdAt = row?["created_at"] as Int64?
+            let scheduleUpdatedAt = row?["updated_at"] as Int64?
+            XCTAssertNotNil(createdAt)
+            XCTAssertGreaterThan(createdAt ?? 0, 0, "medication_schedules.created_at should be stamped")
+            XCTAssertEqual(createdAt, scheduleUpdatedAt, "schedule updated_at should equal backfilled created_at")
+        }
+    }
+
+    /// The migration must be safe to run again on an already-migrated DB.
+    func testAddSyncTimestampColumnsIsIdempotent() throws {
+        try dbManager.dbQueue.write { db in
+            try DatabaseManager.addSyncTimestampColumns(in: db)
+            try DatabaseManager.addSyncTimestampColumns(in: db)
         }
     }
 

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -50,6 +50,10 @@ targets:
       properties:
         com.apple.developer.usernotifications.critical-alerts: true
         com.apple.developer.usernotifications.time-sensitive: true
+        com.apple.developer.icloud-services:
+          - CloudKit
+        com.apple.developer.icloud-container-identifiers:
+          - iCloud.com.eff3.migralog
 
   MigraLogTests:
     type: bundle.unit-test

--- a/spec/ios/icloud-sync.md
+++ b/spec/ios/icloud-sync.md
@@ -27,7 +27,7 @@ MigraLog uses iCloud to sync migraine tracking data across a user's devices. Clo
 
 ## CloudKit Schema
 
-**Container:** `iCloud.com.eff3.app.headache-tracker`
+**Container:** `iCloud.com.eff3.migralog`
 
 The CloudKit schema is intentionally minimal. One record type handles all synced data.
 
@@ -112,7 +112,7 @@ See [`schemas/sqlite/sync-schema-v1.sql`](schemas/sqlite/sync-schema-v1.sql) for
 3. Go to **Signing & Capabilities**.
 4. Click **+ Capability** and add **iCloud**.
 5. Check **CloudKit** under iCloud services.
-6. Under **Containers**, select `iCloud.com.eff3.app.headache-tracker`. If it doesn't exist, click **+** and create it with that identifier.
+6. Under **Containers**, select `iCloud.com.eff3.migralog`. If it doesn't exist, click **+** and create it with that identifier.
 
 This updates the entitlements file and provisioning profile automatically.
 
@@ -127,7 +127,7 @@ The entitlements file (`MigraLog.entitlements`) should contain:
 </array>
 <key>com.apple.developer.icloud-container-identifiers</key>
 <array>
-    <string>iCloud.com.eff3.app.headache-tracker</string>
+    <string>iCloud.com.eff3.migralog</string>
 </array>
 ```
 
@@ -147,7 +147,7 @@ The schema is defined in [`schemas/sync/schema.ckdb`](schemas/sync/schema.ckdb) 
 ```bash
 xcrun cktool import-schema \
   --team-id YOUR_TEAM_ID \
-  --container-id iCloud.com.eff3.app.headache-tracker \
+  --container-id iCloud.com.eff3.migralog \
   --environment development \
   --file spec/schemas/sync/schema.ckdb
 ```
@@ -155,7 +155,7 @@ xcrun cktool import-schema \
 **Option B: Create manually in CloudKit Console**
 
 1. Go to [CloudKit Console](https://icloud.developer.apple.com).
-2. Select the container `iCloud.com.eff3.app.headache-tracker`.
+2. Select the container `iCloud.com.eff3.migralog`.
 3. Select the **Development** environment.
 4. Navigate to **Schema** → **Record Types**.
 5. Click **Create New Type** and name it `SyncRecord`.
@@ -187,7 +187,7 @@ Export the schema from the development container and diff against the checked-in
 ```bash
 xcrun cktool export-schema \
   --team-id YOUR_TEAM_ID \
-  --container-id iCloud.com.eff3.app.headache-tracker \
+  --container-id iCloud.com.eff3.migralog \
   --environment development \
   --output-file /tmp/exported-schema.ckdb
 

--- a/spec/schemas/sqlite/schema-v29.sql
+++ b/spec/schemas/sqlite/schema-v29.sql
@@ -1,6 +1,13 @@
--- MigraLog SQLite Schema v25
+-- MigraLog SQLite Schema v29
 -- Canonical schema definition for the migraine tracking database.
--- Source of truth: app/src/database/schema.ts
+-- Source of truth: mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+--   (createSchema + registered migrations). This .sql is a formal mirror and
+--   MUST be verified against that code — it is not what runs at runtime.
+--
+-- v29 (#434, iCloud sync): added `updated_at` to symptom_logs, episode_notes and
+--   category_safety_rules, and `created_at` + `updated_at` to medication_schedules,
+--   as the last-write-wins timestamps for sync. These columns are nullable and not
+--   yet maintained by write paths (SyncService will own that).
 --
 -- Conventions:
 --   - All IDs are TEXT (UUIDs)
@@ -47,6 +54,7 @@ CREATE TABLE IF NOT EXISTS symptom_logs (
   resolution_time INTEGER CHECK(resolution_time IS NULL OR resolution_time > onset_time),
   severity REAL CHECK(severity IS NULL OR (severity >= 0 AND severity <= 10)),
   created_at INTEGER NOT NULL CHECK(created_at > 0),
+  updated_at INTEGER CHECK(updated_at IS NULL OR updated_at > 0),  -- v29: LWW timestamp for sync
   FOREIGN KEY (episode_id) REFERENCES episodes(id) ON DELETE CASCADE
 );
 
@@ -68,6 +76,7 @@ CREATE TABLE IF NOT EXISTS episode_notes (
   timestamp INTEGER NOT NULL CHECK(timestamp > 0),
   note TEXT NOT NULL CHECK(length(note) > 0 AND length(note) <= 5000),
   created_at INTEGER NOT NULL CHECK(created_at > 0),
+  updated_at INTEGER CHECK(updated_at IS NULL OR updated_at > 0),  -- v29: LWW timestamp for sync
   FOREIGN KEY (episode_id) REFERENCES episodes(id) ON DELETE CASCADE
 );
 
@@ -85,7 +94,8 @@ CREATE TABLE IF NOT EXISTS medications (
   notes TEXT CHECK(notes IS NULL OR length(notes) <= 5000),
   category TEXT CHECK(category IS NULL OR category IN ('otc', 'nsaid', 'triptan', 'cgrp', 'preventive', 'supplement', 'other')),
   created_at INTEGER NOT NULL CHECK(created_at > 0),
-  updated_at INTEGER NOT NULL CHECK(updated_at > 0)
+  updated_at INTEGER NOT NULL CHECK(updated_at > 0),
+  min_interval_hours REAL CHECK(min_interval_hours IS NULL OR min_interval_hours > 0)  -- v26: per-med dose cooldown
 );
 
 -- Medication schedules table
@@ -98,6 +108,8 @@ CREATE TABLE IF NOT EXISTS medication_schedules (
   enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
   notification_id TEXT,
   reminder_enabled INTEGER NOT NULL DEFAULT 1 CHECK(reminder_enabled IN (0, 1)),
+  created_at INTEGER CHECK(created_at IS NULL OR created_at > 0),  -- v29: added for sync
+  updated_at INTEGER CHECK(updated_at IS NULL OR updated_at > 0),  -- v29: LWW timestamp for sync
   FOREIGN KEY (medication_id) REFERENCES medications(id) ON DELETE CASCADE
 );
 
@@ -183,6 +195,19 @@ CREATE TABLE IF NOT EXISTS scheduled_notifications (
   UNIQUE(medication_id, schedule_id, date, notification_type)
 );
 
+-- Category safety rules table (v27 added category_usage_limits; v28 renamed and
+-- reshaped it into this table with a cooldown/period_limit rule-type discriminator)
+CREATE TABLE IF NOT EXISTS category_safety_rules (
+  id TEXT PRIMARY KEY,
+  category TEXT NOT NULL,
+  type TEXT NOT NULL CHECK (type IN ('cooldown', 'period_limit')),
+  period_hours REAL NOT NULL CHECK(period_hours > 0),
+  max_count INTEGER CHECK(max_count IS NULL OR max_count > 0),
+  created_at INTEGER NOT NULL CHECK(created_at > 0),
+  updated_at INTEGER CHECK(updated_at IS NULL OR updated_at > 0),  -- v29: LWW timestamp for sync
+  UNIQUE(category, type)
+);
+
 -- =============================================================================
 -- Indexes
 -- =============================================================================
@@ -221,3 +246,6 @@ CREATE INDEX IF NOT EXISTS idx_scheduled_notifications_content ON scheduled_noti
 
 -- Calendar overlays indexes
 CREATE INDEX IF NOT EXISTS idx_calendar_overlays_dates ON calendar_overlays(start_date, end_date);
+
+-- Category safety rules indexes
+CREATE INDEX IF NOT EXISTS idx_category_safety_rules_category ON category_safety_rules(category);


### PR DESCRIPTION
## Summary
Schema groundwork for iCloud sync (#434) — the "schema is the heart of sync" round. It deploys the CloudKit container schema and adds the local last-write-wins timestamps, but **stops before SyncService**.

CloudKit is a minimal opaque `SyncRecord` pipe (signed off separately); all the moving parts here are local-schema + capability wiring, and everything is **inert until SyncService lands**.

## Changes
- **Capability:** iCloud/CloudKit entitlement + container `iCloud.com.eff3.migralog` in `project.yml` (xcodegen source of truth) and the generated entitlements. Profile name (`MigraLog App Store`) is unchanged, so no signing-reference edits — but the CI `SWIFT_PROVISIONING_PROFILE` secret was refreshed to the profile that now includes the container.
- **v29 migration:** adds `updated_at` to `symptom_logs`, `episode_notes`, `category_safety_rules`; `created_at` + `updated_at` to `medication_schedules` (the only synced table with no timestamp). Idempotent + backfilled, following the v26 `createSchema` + guarded-migration pattern. Nullable and unmaintained for now — SyncService will own keeping them current.
- **Deferred to the SyncService round:** the local `deleted` soft-delete column (its necessity depends on the delete mechanism, decided there) and the four `sync_*` state tables (shape validated by the code that uses them; GRDB migrations are immutable once shipped).
- **DDL reconciliation:** `schema-v25.sql` → `schema-v29.sql`, verified against `DatabaseManager` (it had drifted 3 versions: missing `min_interval_hours` and the `category_safety_rules` reshape).
- **CloudKit container name** corrected in `icloud-sync.md` (retired `headache-tracker` App ID → `iCloud.com.eff3.migralog`).
- CloudKit `schema.ckdb` validated and applied to the **Development** environment. Production deliberately left empty until sync works end-to-end.

## Testing
- New unit tests: v29 column presence, migration recorded, backfill-from-`created_at`, idempotency.
- Full unit suite: **753 tests, 0 failures** (local).
- No UI changes (UI test gate N/A).

## Out of scope (next round)
`SyncService` (container/zone setup, push/pull, change tokens, conflict resolution), the `sync_*` tables, delete propagation, and the `schemaVersion`-keyed migrate-on-read layer. Testability note: `SyncService` will put the CloudKit transport behind a protocol so the sync logic is fake-tested in CI, with `cktool` for schema smoke and manual two-device runs as the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
