### PR TITLE
feat(ios): sync payload codec + syncable-table contract (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncPayloadCodec.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncPayloadCodec.swift
@@ -1,0 +1,93 @@
+import Foundation
+import GRDB
+
+/// Encodes a local SQLite row into the opaque JSON `payload` carried by a
+/// `SyncRecord`, and decodes it back into column values. Generic over all synced
+/// tables — there is no per-table struct — which keeps the payload decoupled from
+/// both the CloudKit schema and the app's domain models, so the local schema can
+/// evolve freely (see spec/ios/icloud-sync.md).
+///
+/// HIPAA: the payload contains health data. Callers must never log it.
+enum SyncPayloadCodec {
+
+    enum CodecError: Error, Equatable {
+        /// A column held a BLOB. No synced table is expected to contain one, so this
+        /// signals an unexpected schema rather than a value to silently drop.
+        case unsupportedBlob(column: String)
+        /// The payload string was not valid UTF-8 / JSON.
+        case malformedPayload
+    }
+
+    /// A single column value, preserving SQLite's storage class so a round-trip is
+    /// lossless for text, integers, and null. (A whole-number REAL may decode back as
+    /// an integer; that is harmless because SQLite column affinity coerces on apply.)
+    enum Value: Equatable, Codable {
+        case text(String)
+        case int(Int64)
+        case double(Double)
+        case null
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if container.decodeNil() {
+                self = .null
+            } else if let intValue = try? container.decode(Int64.self) {
+                self = .int(intValue)
+            } else if let doubleValue = try? container.decode(Double.self) {
+                self = .double(doubleValue)
+            } else {
+                self = .text(try container.decode(String.self))
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .text(let value): try container.encode(value)
+            case .int(let value): try container.encode(value)
+            case .double(let value): try container.encode(value)
+            case .null: try container.encodeNil()
+            }
+        }
+    }
+
+    /// Build the `payload` JSON string for a row, excluding the table's device-local
+    /// columns. Keys are sorted for deterministic, diff-friendly output.
+    static func encodePayload(row: Row, table: SyncableTable) throws -> String {
+        var values: [String: Value] = [:]
+        for (column, dbValue) in row where !table.deviceLocalColumns.contains(column) {
+            values[column] = try value(from: dbValue, column: column)
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(values)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// Decode a `payload` JSON string back into column values, keyed by column name.
+    static func decodePayload(_ payload: String) throws -> [String: Value] {
+        guard let data = payload.data(using: .utf8) else {
+            throw CodecError.malformedPayload
+        }
+        do {
+            return try JSONDecoder().decode([String: Value].self, from: data)
+        } catch {
+            throw CodecError.malformedPayload
+        }
+    }
+
+    private static func value(from dbValue: DatabaseValue, column: String) throws -> Value {
+        switch dbValue.storage {
+        case .null:
+            return .null
+        case .int64(let intValue):
+            return .int(intValue)
+        case .double(let doubleValue):
+            return .double(doubleValue)
+        case .string(let stringValue):
+            return .text(stringValue)
+        case .blob:
+            throw CodecError.unsupportedBlob(column: column)
+        }
+    }
+}

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncRecord.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncRecord.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// A single local row encoded for transport through CloudKit. Mirrors the
+/// `SyncRecord` CloudKit record type (see spec/ios/schemas/sync/schema.ckdb).
+///
+/// The payload is opaque to CloudKit — interpretation is entirely client-side — so
+/// the local SQLite schema can evolve without ever changing the CloudKit schema.
+struct SyncRecord: Equatable, Sendable {
+    /// Source SQLite table name (e.g. "episodes").
+    let tableName: String
+    /// The row's local UUID primary key.
+    let recordId: String
+    /// JSON-encoded row data (see `SyncPayloadCodec`).
+    let payload: String
+    /// SQLite schema version that produced the payload, for migrate-on-read.
+    let schemaVersion: Int
+    /// Last-write time in Unix epoch milliseconds; drives last-write-wins.
+    let updatedAt: Int64
+    /// Soft-delete flag. A tombstone still carries the last known payload.
+    let deleted: Bool
+
+    /// CKRecord.recordName — globally unique across tables, and parseable back to
+    /// its source table. Format: `"{tableName}:{recordId}"`.
+    var recordName: String { "\(tableName):\(recordId)" }
+
+    /// Parse a `recordName` back into its parts. recordIds are UUIDs (no colons),
+    /// so the table name is everything before the first colon. Returns nil if the
+    /// name is not in `"{tableName}:{recordId}"` form.
+    static func parseRecordName(_ recordName: String) -> (tableName: String, recordId: String)? {
+        guard let colon = recordName.firstIndex(of: ":") else { return nil }
+        let tableName = String(recordName[..<colon])
+        let recordId = String(recordName[recordName.index(after: colon)...])
+        guard !tableName.isEmpty, !recordId.isEmpty else { return nil }
+        return (tableName, recordId)
+    }
+}

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncableTable.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncableTable.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// The set of local SQLite tables replicated to iCloud, plus the per-table rules
+/// for turning a row into a sync payload. This is the client-side source of truth
+/// for *what* syncs — CloudKit itself is a dumb pipe (see spec/ios/icloud-sync.md).
+///
+/// Device-local tables are intentionally absent: `scheduled_notifications` and
+/// `medication_reminders` are per-device OS notification bookkeeping, and the
+/// `sync_*` tables are local sync state. Only durable health + configuration data
+/// syncs.
+enum SyncableTable: String, CaseIterable, Sendable {
+    case episodes
+    case intensityReadings = "intensity_readings"
+    case symptomLogs = "symptom_logs"
+    case painLocationLogs = "pain_location_logs"
+    case episodeNotes = "episode_notes"
+    case medications
+    case medicationSchedules = "medication_schedules"
+    case medicationDoses = "medication_doses"
+    case dailyStatusLogs = "daily_status_logs"
+    case calendarOverlays = "calendar_overlays"
+    case categorySafetyRules = "category_safety_rules"
+
+    /// The SQLite table name.
+    var tableName: String { rawValue }
+
+    /// Primary-key column. Every synced table uses a TEXT UUID `id`.
+    var primaryKeyColumn: String { "id" }
+
+    /// Columns excluded from the synced payload because they are device-local and
+    /// meaningless (or harmful) on another device — the receiving device regenerates
+    /// them locally. Currently only `medication_schedules.notification_id`, which
+    /// references a notification registered on the originating device.
+    var deviceLocalColumns: Set<String> {
+        switch self {
+        case .medicationSchedules:
+            return ["notification_id"]
+        default:
+            return []
+        }
+    }
+
+    /// Look up a syncable table by its SQLite name. Returns nil for tables that are
+    /// not synced (device-local or sync-internal).
+    static func named(_ tableName: String) -> SyncableTable? {
+        SyncableTable(rawValue: tableName)
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncPayloadCodecTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncPayloadCodecTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+import GRDB
+@testable import MigraLog
+
+final class SyncPayloadCodecTests: XCTestCase {
+
+    func testEncodeDecodeRoundTripPreservesValues() throws {
+        let row = Row([
+            "id": "e1",
+            "notes": "bad headache",
+            "start_time": Int64(1_700_000_000_000),
+            "severity": 7.5,
+            "end_time": nil,
+        ])
+        let payload = try SyncPayloadCodec.encodePayload(row: row, table: .episodes)
+        let decoded = try SyncPayloadCodec.decodePayload(payload)
+
+        XCTAssertEqual(decoded["id"], .text("e1"))
+        XCTAssertEqual(decoded["notes"], .text("bad headache"))
+        XCTAssertEqual(decoded["start_time"], .int(1_700_000_000_000))
+        XCTAssertEqual(decoded["severity"], .double(7.5))
+        XCTAssertEqual(decoded["end_time"], .null)
+        XCTAssertEqual(decoded.count, 5)
+    }
+
+    func testEncodeStripsDeviceLocalColumns() throws {
+        let row = Row([
+            "id": "sch1",
+            "medication_id": "med1",
+            "time": "08:00",
+            "notification_id": "device-local-xyz",
+        ])
+        let payload = try SyncPayloadCodec.encodePayload(row: row, table: .medicationSchedules)
+        let decoded = try SyncPayloadCodec.decodePayload(payload)
+
+        XCTAssertNil(decoded["notification_id"], "device-local notification_id must not sync")
+        XCTAssertFalse(payload.contains("notification_id"))
+        XCTAssertEqual(decoded["id"], .text("sch1"))
+        XCTAssertEqual(decoded["time"], .text("08:00"))
+    }
+
+    func testEncodeProducesSortedKeys() throws {
+        let row = Row(["zebra": "z", "apple": "a", "mango": "m"])
+        let payload = try SyncPayloadCodec.encodePayload(row: row, table: .episodes)
+        XCTAssertEqual(payload, #"{"apple":"a","mango":"m","zebra":"z"}"#)
+    }
+
+    func testEncodeThrowsOnBlobColumn() throws {
+        let row = Row(["id": "x", "blobby": Data([0xDE, 0xAD])])
+        XCTAssertThrowsError(try SyncPayloadCodec.encodePayload(row: row, table: .episodes)) { error in
+            XCTAssertEqual(error as? SyncPayloadCodec.CodecError, .unsupportedBlob(column: "blobby"))
+        }
+    }
+
+    func testDecodeThrowsOnMalformedPayload() {
+        XCTAssertThrowsError(try SyncPayloadCodec.decodePayload("not json")) { error in
+            XCTAssertEqual(error as? SyncPayloadCodec.CodecError, .malformedPayload)
+        }
+    }
+
+    /// Exercises DatabaseValue handling against a row read from a real GRDB table.
+    func testRoundTripFromActualDatabaseRow() throws {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            try db.execute(sql: """
+                CREATE TABLE episodes (
+                    id TEXT PRIMARY KEY, start_time INTEGER NOT NULL,
+                    notes TEXT, latitude REAL, end_time INTEGER
+                )
+                """)
+            try db.execute(
+                sql: "INSERT INTO episodes (id, start_time, notes, latitude, end_time) VALUES (?, ?, ?, ?, ?)",
+                arguments: ["e9", 1234, "note", 45.5, nil]
+            )
+        }
+        let payload = try queue.read { db -> String in
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM episodes WHERE id = 'e9'")!
+            return try SyncPayloadCodec.encodePayload(row: row, table: .episodes)
+        }
+        let decoded = try SyncPayloadCodec.decodePayload(payload)
+
+        XCTAssertEqual(decoded["id"], .text("e9"))
+        XCTAssertEqual(decoded["start_time"], .int(1234))
+        XCTAssertEqual(decoded["notes"], .text("note"))
+        XCTAssertEqual(decoded["latitude"], .double(45.5))
+        XCTAssertEqual(decoded["end_time"], .null)
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncRecordTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncRecordTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import MigraLog
+
+final class SyncRecordTests: XCTestCase {
+
+    // MARK: - SyncableTable contract
+
+    func testSyncableTablesAreTheExpectedEleven() {
+        let expected: Set<String> = [
+            "episodes", "intensity_readings", "symptom_logs", "pain_location_logs",
+            "episode_notes", "medications", "medication_schedules", "medication_doses",
+            "daily_status_logs", "calendar_overlays", "category_safety_rules",
+        ]
+        XCTAssertEqual(Set(SyncableTable.allCases.map { $0.tableName }), expected)
+        XCTAssertEqual(SyncableTable.allCases.count, 11)
+    }
+
+    func testDeviceLocalAndSyncInternalTablesAreNotSyncable() {
+        for tableName in ["scheduled_notifications", "medication_reminders", "sync_config"] {
+            XCTAssertNil(SyncableTable.named(tableName), "\(tableName) must not be syncable")
+        }
+    }
+
+    func testOnlyMedicationSchedulesStripsADeviceLocalColumn() {
+        for table in SyncableTable.allCases {
+            if table == .medicationSchedules {
+                XCTAssertEqual(table.deviceLocalColumns, ["notification_id"])
+            } else {
+                XCTAssertTrue(table.deviceLocalColumns.isEmpty, "\(table.tableName) should strip nothing")
+            }
+        }
+    }
+
+    func testEverySyncableTableUsesIdPrimaryKey() {
+        for table in SyncableTable.allCases {
+            XCTAssertEqual(table.primaryKeyColumn, "id")
+        }
+    }
+
+    // MARK: - SyncRecord.recordName
+
+    func testRecordNameComposesTableAndId() {
+        let record = SyncRecord(
+            tableName: "episodes", recordId: "ABC-123", payload: "{}",
+            schemaVersion: 29, updatedAt: 1000, deleted: false
+        )
+        XCTAssertEqual(record.recordName, "episodes:ABC-123")
+    }
+
+    func testParseRecordNameRoundTrips() {
+        let parsed = SyncRecord.parseRecordName("medication_doses:11111111-2222-3333")
+        XCTAssertEqual(parsed?.tableName, "medication_doses")
+        XCTAssertEqual(parsed?.recordId, "11111111-2222-3333")
+    }
+
+    func testParseRecordNameRejectsMalformed() {
+        XCTAssertNil(SyncRecord.parseRecordName("no-colon-here"))
+        XCTAssertNil(SyncRecord.parseRecordName(":missing-table"))
+        XCTAssertNil(SyncRecord.parseRecordName("missing-id:"))
+    }
+}


### PR DESCRIPTION
## Summary
First slice of the **SyncService round** for iCloud sync (#434) — the fork-free foundation. No CloudKit wiring, no DB writes; just pure, fully tested building blocks everything else builds on. Independent of #444 (the schema PR) and mergeable on its own.

## What's here
- **`SyncableTable`** — the client-side source of truth for *what* syncs: the 11 durable health/config tables, each table's `id` PK, and the device-local columns stripped from payloads (only `medication_schedules.notification_id`). Device-local tables (`scheduled_notifications`, `medication_reminders`) and `sync_*` state are deliberately excluded.
- **`SyncRecord`** — value type mirroring the CloudKit record type, with the `{tableName}:{recordId}` recordName format + parser.
- **`SyncPayloadCodec`** — generic row ↔ JSON codec (column dictionary, per the signed-off approach — no per-table structs). Preserves SQLite text/int/double/null, strips device-local columns, sorted keys for deterministic output. Decoupled from both the CloudKit schema and the domain models. Never logs payloads (HIPAA).

## Testing
13 unit tests, all passing: the syncable-table contract, recordName compose/parse, codec round-trips (including one from a real GRDB row), device-local stripping, and blob / malformed-payload error paths.

## Roadmap (next slices)
2. Transport protocol + in-memory fake, container + `MigraLogZone` setup, change-token cursor, pending-changes queue (the `sync_*` tables land here).
3. LWW conflict resolution + `sync_conflicts` archive + the delete mechanism (deferred decision).
4. Triggers (foreground/after-write), backup-before-first-sync, settings UI.

The later slices depend on #444 (the v29 `updated_at` columns); this slice does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
