### PR TITLE
feat(ios): sync local-state layer — pending queue + zone cursor (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -4,7 +4,7 @@ import GRDB
 /// Central database manager. Owns the DatabaseQueue and handles schema creation/migration.
 final class DatabaseManager: Sendable {
     /// The current schema version
-    static let schemaVersion = 29
+    static let schemaVersion = 30
 
     /// Shared singleton for the app's main database
     static let shared = DatabaseManager()
@@ -136,6 +136,13 @@ final class DatabaseManager: Sendable {
         // sync (#434) to synced tables that lacked them. See addSyncTimestampColumns.
         migrator.registerMigration("v29") { db in
             try DatabaseManager.addSyncTimestampColumns(in: db)
+        }
+
+        // v30: Local sync-state tables for iCloud sync (#434) — the outbound change
+        // queue and the per-zone server-change-token cursor. Device-local, never
+        // synced. See createSyncStateTables.
+        migrator.registerMigration("v30") { db in
+            try DatabaseManager.createSyncStateTables(in: db)
         }
 
         return migrator
@@ -446,6 +453,39 @@ final class DatabaseManager: Sendable {
 
         // Create all indexes
         try DatabaseManager.createIndexes(in: db)
+
+        // Local sync-state tables (#434), device-local.
+        try DatabaseManager.createSyncStateTables(in: db)
+    }
+
+    /// Create the device-local sync-state tables for iCloud sync (#434): the outbound
+    /// change queue and the per-zone server-change-token cursor. These are NOT synced.
+    /// Idempotent — called from createSchema (fresh installs) and the v30 migration
+    /// (upgrades). Only the tables exercised by current code live here; sync_config
+    /// and sync_conflicts arrive with their consumers (settings UI, conflict archive).
+    static func createSyncStateTables(in db: Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE IF NOT EXISTS sync_pending_changes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                table_name TEXT NOT NULL,
+                record_id TEXT NOT NULL,
+                change_type TEXT NOT NULL CHECK(change_type IN ('upsert', 'delete')),
+                created_at INTEGER NOT NULL CHECK(created_at > 0),
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT,
+                UNIQUE(table_name, record_id)
+            )
+            """)
+        try db.execute(sql: """
+            CREATE TABLE IF NOT EXISTS sync_zone_state (
+                zone_name TEXT PRIMARY KEY,
+                server_change_token BLOB,
+                last_sync_at INTEGER CHECK(last_sync_at IS NULL OR last_sync_at > 0),
+                last_error TEXT,
+                last_error_at INTEGER CHECK(last_error_at IS NULL OR last_error_at > 0)
+            )
+            """)
+        try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_sync_pending_created ON sync_pending_changes(created_at)")
     }
 
     private static func createIndexes(in db: Database) throws {

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncPendingChangesStore.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncPendingChangesStore.swift
@@ -1,0 +1,121 @@
+import Foundation
+import GRDB
+
+/// One queued outbound change awaiting push to CloudKit.
+struct SyncPendingChange: Equatable, Sendable {
+    enum ChangeType: String, Sendable {
+        case upsert
+        case delete
+    }
+
+    let id: Int64
+    let tableName: String
+    let recordId: String
+    let changeType: ChangeType
+    /// When the change was queued, Unix epoch milliseconds.
+    let createdAt: Int64
+    let retryCount: Int
+    let lastError: String?
+}
+
+/// The durable outbound queue for iCloud sync (#434). Local writes enqueue a change
+/// here; the sync engine drains the queue, pushes to CloudKit, and removes the
+/// successfully-sent rows. Surviving app restarts is the whole point — an in-memory
+/// queue would lose changes made while offline.
+///
+/// `UNIQUE(table_name, record_id)` collapses repeated edits to the same row into a
+/// single pending entry: the latest change wins and its retry state is reset.
+final class SyncPendingChangesStore: Sendable {
+    private let dbManager: DatabaseManager
+
+    init(dbManager: DatabaseManager) {
+        self.dbManager = dbManager
+    }
+
+    /// Queue a change for a row. If one is already pending for the same row it is
+    /// superseded (newest change type + timestamp, retry state cleared).
+    func enqueue(tableName: String, recordId: String, changeType: SyncPendingChange.ChangeType, at now: Int64) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO sync_pending_changes
+                        (table_name, record_id, change_type, created_at, retry_count, last_error)
+                    VALUES (?, ?, ?, ?, 0, NULL)
+                    ON CONFLICT(table_name, record_id) DO UPDATE SET
+                        change_type = excluded.change_type,
+                        created_at = excluded.created_at,
+                        retry_count = 0,
+                        last_error = NULL
+                    """,
+                arguments: [tableName, recordId, changeType.rawValue, now]
+            )
+        }
+    }
+
+    /// Oldest-first batch of pending changes, up to `limit`.
+    func fetchBatch(limit: Int) throws -> [SyncPendingChange] {
+        try dbManager.dbQueue.read { db in
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT id, table_name, record_id, change_type, created_at, retry_count, last_error
+                    FROM sync_pending_changes
+                    ORDER BY created_at ASC, id ASC
+                    LIMIT ?
+                    """,
+                arguments: [limit]
+            )
+            return rows.compactMap { Self.changeFromRow($0) }
+        }
+    }
+
+    func pendingCount() throws -> Int {
+        try dbManager.dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM sync_pending_changes") ?? 0
+        }
+    }
+
+    /// Remove changes that were successfully pushed.
+    func remove(ids: [Int64]) throws {
+        guard !ids.isEmpty else { return }
+        let placeholders = Array(repeating: "?", count: ids.count).joined(separator: ",")
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: "DELETE FROM sync_pending_changes WHERE id IN (\(placeholders))",
+                arguments: StatementArguments(ids)
+            )
+        }
+    }
+
+    /// Record a failed push attempt: bump the retry count and store the error.
+    func recordFailure(id: Int64, error: String) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE sync_pending_changes SET retry_count = retry_count + 1, last_error = ? WHERE id = ?",
+                arguments: [error, id]
+            )
+        }
+    }
+
+    // MARK: - Row Mapping
+
+    private static func changeFromRow(_ row: Row) -> SyncPendingChange? {
+        guard let id = row["id"] as Int64?,
+              let tableName = row["table_name"] as String?,
+              let recordId = row["record_id"] as String?,
+              let rawType = row["change_type"] as String?,
+              let changeType = SyncPendingChange.ChangeType(rawValue: rawType),
+              let createdAt = row["created_at"] as Int64? else {
+            return nil
+        }
+        return SyncPendingChange(
+            id: id,
+            tableName: tableName,
+            recordId: recordId,
+            changeType: changeType,
+            createdAt: createdAt,
+            retryCount: row["retry_count"] as Int? ?? 0,
+            lastError: row["last_error"] as String?
+        )
+    }
+}

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncZoneStateStore.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncZoneStateStore.swift
@@ -1,0 +1,91 @@
+import Foundation
+import GRDB
+
+/// Persisted sync state for one CloudKit record zone.
+struct SyncZoneState: Equatable, Sendable {
+    let zoneName: String
+    /// Archived `CKServerChangeToken` bytes. Opaque here — the CloudKit layer owns
+    /// archiving/unarchiving; the store only persists the blob so it survives restarts.
+    let serverChangeToken: Data?
+    /// Last successful sync, Unix epoch milliseconds.
+    let lastSyncAt: Int64?
+    let lastError: String?
+    let lastErrorAt: Int64?
+}
+
+/// Persists the incremental-pull cursor (the `CKServerChangeToken`) per zone, plus
+/// last-sync / last-error bookkeeping (#434). The token is what makes pulls
+/// incremental — on each pull CloudKit returns only changes since the stored token,
+/// and we save the new one. It is kept opaque (raw bytes) so this store has no
+/// CloudKit dependency and is fully unit-testable.
+final class SyncZoneStateStore: Sendable {
+    private let dbManager: DatabaseManager
+
+    init(dbManager: DatabaseManager) {
+        self.dbManager = dbManager
+    }
+
+    func state(zoneName: String) throws -> SyncZoneState? {
+        try dbManager.dbQueue.read { db in
+            let row = try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT zone_name, server_change_token, last_sync_at, last_error, last_error_at
+                    FROM sync_zone_state WHERE zone_name = ?
+                    """,
+                arguments: [zoneName]
+            )
+            return row.map { Self.stateFromRow($0) }
+        }
+    }
+
+    /// Persist the change token after a successful pull, stamping `last_sync_at` and
+    /// clearing the error fields.
+    func saveChangeToken(_ token: Data?, zoneName: String, syncedAt: Int64) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO sync_zone_state
+                        (zone_name, server_change_token, last_sync_at, last_error, last_error_at)
+                    VALUES (?, ?, ?, NULL, NULL)
+                    ON CONFLICT(zone_name) DO UPDATE SET
+                        server_change_token = excluded.server_change_token,
+                        last_sync_at = excluded.last_sync_at,
+                        last_error = NULL,
+                        last_error_at = NULL
+                    """,
+                arguments: [zoneName, token, syncedAt]
+            )
+        }
+    }
+
+    /// Record a sync error against the zone without disturbing the change token or
+    /// last-sync timestamp.
+    func recordError(_ error: String, zoneName: String, at now: Int64) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO sync_zone_state
+                        (zone_name, server_change_token, last_sync_at, last_error, last_error_at)
+                    VALUES (?, NULL, NULL, ?, ?)
+                    ON CONFLICT(zone_name) DO UPDATE SET
+                        last_error = excluded.last_error,
+                        last_error_at = excluded.last_error_at
+                    """,
+                arguments: [zoneName, error, now]
+            )
+        }
+    }
+
+    // MARK: - Row Mapping
+
+    private static func stateFromRow(_ row: Row) -> SyncZoneState {
+        SyncZoneState(
+            zoneName: row["zone_name"],
+            serverChangeToken: row["server_change_token"] as Data?,
+            lastSyncAt: row["last_sync_at"] as Int64?,
+            lastError: row["last_error"] as String?,
+            lastErrorAt: row["last_error_at"] as Int64?
+        )
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
@@ -54,6 +54,8 @@ final class DatabaseManagerTests: XCTestCase {
             "calendar_overlays",
             "scheduled_notifications",
             "category_safety_rules",
+            "sync_pending_changes",
+            "sync_zone_state",
             "grdb_migrations", // GRDB internal table
         ]
 
@@ -183,7 +185,7 @@ final class DatabaseManagerTests: XCTestCase {
     // MARK: - Schema Version
 
     func testSchemaVersionIsTracked() throws {
-        XCTAssertEqual(DatabaseManager.schemaVersion, 29)
+        XCTAssertEqual(DatabaseManager.schemaVersion, 30)
     }
 
     func testMigrationIsRecordedInGRDB() throws {
@@ -218,6 +220,18 @@ final class DatabaseManagerTests: XCTestCase {
             let identifiers = try Row.fetchAll(db, sql: "SELECT identifier FROM grdb_migrations")
                 .map { $0["identifier"] as String }
             XCTAssertTrue(identifiers.contains("v29"), "Migration v29 should be recorded")
+        }
+    }
+
+    /// v30 creates the device-local sync-state tables (#434): the outbound queue and
+    /// the per-zone change-token cursor. sync_config / sync_conflicts arrive later.
+    func testV30CreatesSyncStateTables() throws {
+        try dbManager.dbQueue.read { db in
+            XCTAssertTrue(try db.tableExists("sync_pending_changes"))
+            XCTAssertTrue(try db.tableExists("sync_zone_state"))
+            let identifiers = try Row.fetchAll(db, sql: "SELECT identifier FROM grdb_migrations")
+                .map { $0["identifier"] as String }
+            XCTAssertTrue(identifiers.contains("v30"), "Migration v30 should be recorded")
         }
     }
 

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncPendingChangesStoreTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncPendingChangesStoreTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+import GRDB
+@testable import MigraLog
+
+final class SyncPendingChangesStoreTests: XCTestCase {
+    var dbManager: DatabaseManager!
+    var store: SyncPendingChangesStore!
+
+    override func setUpWithError() throws {
+        dbManager = try DatabaseManager(inMemory: true)
+        store = SyncPendingChangesStore(dbManager: dbManager)
+    }
+
+    override func tearDownWithError() throws {
+        store = nil
+        dbManager = nil
+    }
+
+    func testEnqueueAndFetchOldestFirst() throws {
+        try store.enqueue(tableName: "episodes", recordId: "e1", changeType: .upsert, at: 1000)
+        try store.enqueue(tableName: "medications", recordId: "m1", changeType: .delete, at: 2000)
+
+        let batch = try store.fetchBatch(limit: 10)
+        XCTAssertEqual(batch.map { $0.recordId }, ["e1", "m1"])
+        XCTAssertEqual(batch[0].changeType, .upsert)
+        XCTAssertEqual(batch[1].changeType, .delete)
+    }
+
+    func testEnqueueSupersedesSameRecord() throws {
+        try store.enqueue(tableName: "episodes", recordId: "e1", changeType: .upsert, at: 1000)
+        try store.enqueue(tableName: "episodes", recordId: "e1", changeType: .delete, at: 5000)
+
+        let batch = try store.fetchBatch(limit: 10)
+        XCTAssertEqual(batch.count, 1, "the same row collapses to a single pending entry")
+        XCTAssertEqual(batch[0].changeType, .delete, "the latest change wins")
+        XCTAssertEqual(batch[0].createdAt, 5000)
+    }
+
+    func testSupersedeClearsRetryState() throws {
+        try store.enqueue(tableName: "episodes", recordId: "e1", changeType: .upsert, at: 1000)
+        let id = try store.fetchBatch(limit: 1)[0].id
+        try store.recordFailure(id: id, error: "boom")
+        XCTAssertEqual(try store.fetchBatch(limit: 1)[0].retryCount, 1)
+
+        try store.enqueue(tableName: "episodes", recordId: "e1", changeType: .upsert, at: 2000)
+        let reread = try store.fetchBatch(limit: 1)[0]
+        XCTAssertEqual(reread.retryCount, 0, "a superseding enqueue resets retry state")
+        XCTAssertNil(reread.lastError)
+    }
+
+    func testRemove() throws {
+        try store.enqueue(tableName: "episodes", recordId: "e1", changeType: .upsert, at: 1000)
+        try store.enqueue(tableName: "episodes", recordId: "e2", changeType: .upsert, at: 2000)
+
+        let batch = try store.fetchBatch(limit: 10)
+        try store.remove(ids: [batch[0].id])
+
+        XCTAssertEqual(try store.pendingCount(), 1)
+        XCTAssertEqual(try store.fetchBatch(limit: 10).first?.recordId, "e2")
+    }
+
+    func testRemoveEmptyIsNoOp() throws {
+        try store.enqueue(tableName: "episodes", recordId: "e1", changeType: .upsert, at: 1000)
+        try store.remove(ids: [])
+        XCTAssertEqual(try store.pendingCount(), 1)
+    }
+
+    func testRecordFailureIncrementsAndKeepsLatestError() throws {
+        try store.enqueue(tableName: "episodes", recordId: "e1", changeType: .upsert, at: 1000)
+        let id = try store.fetchBatch(limit: 1)[0].id
+        try store.recordFailure(id: id, error: "err1")
+        try store.recordFailure(id: id, error: "err2")
+
+        let change = try store.fetchBatch(limit: 1)[0]
+        XCTAssertEqual(change.retryCount, 2)
+        XCTAssertEqual(change.lastError, "err2")
+    }
+
+    func testFetchBatchRespectsLimit() throws {
+        for index in 0..<5 {
+            try store.enqueue(
+                tableName: "episodes", recordId: "e\(index)",
+                changeType: .upsert, at: Int64(1000 + index)
+            )
+        }
+        XCTAssertEqual(try store.fetchBatch(limit: 3).count, 3)
+        XCTAssertEqual(try store.pendingCount(), 5)
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncZoneStateStoreTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncZoneStateStoreTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+import GRDB
+@testable import MigraLog
+
+final class SyncZoneStateStoreTests: XCTestCase {
+    var dbManager: DatabaseManager!
+    var store: SyncZoneStateStore!
+    let zone = "MigraLogZone"
+
+    override func setUpWithError() throws {
+        dbManager = try DatabaseManager(inMemory: true)
+        store = SyncZoneStateStore(dbManager: dbManager)
+    }
+
+    override func tearDownWithError() throws {
+        store = nil
+        dbManager = nil
+    }
+
+    func testUnknownZoneReturnsNil() throws {
+        XCTAssertNil(try store.state(zoneName: zone))
+    }
+
+    func testSaveAndLoadChangeToken() throws {
+        let token = Data([0x01, 0x02, 0x03])
+        try store.saveChangeToken(token, zoneName: zone, syncedAt: 5000)
+
+        let state = try store.state(zoneName: zone)
+        XCTAssertEqual(state?.serverChangeToken, token)
+        XCTAssertEqual(state?.lastSyncAt, 5000)
+        XCTAssertNil(state?.lastError)
+    }
+
+    func testSaveChangeTokenUpdatesExisting() throws {
+        try store.saveChangeToken(Data([0x01]), zoneName: zone, syncedAt: 1000)
+        try store.saveChangeToken(Data([0x09]), zoneName: zone, syncedAt: 2000)
+
+        let state = try store.state(zoneName: zone)
+        XCTAssertEqual(state?.serverChangeToken, Data([0x09]))
+        XCTAssertEqual(state?.lastSyncAt, 2000)
+    }
+
+    func testRecordErrorDoesNotClobberToken() throws {
+        try store.saveChangeToken(Data([0x07]), zoneName: zone, syncedAt: 1000)
+        try store.recordError("network down", zoneName: zone, at: 3000)
+
+        let state = try store.state(zoneName: zone)
+        XCTAssertEqual(state?.serverChangeToken, Data([0x07]), "an error must not wipe the cursor")
+        XCTAssertEqual(state?.lastSyncAt, 1000)
+        XCTAssertEqual(state?.lastError, "network down")
+        XCTAssertEqual(state?.lastErrorAt, 3000)
+    }
+
+    func testSaveChangeTokenClearsPriorError() throws {
+        try store.recordError("boom", zoneName: zone, at: 1000)
+        try store.saveChangeToken(Data([0x05]), zoneName: zone, syncedAt: 2000)
+
+        let state = try store.state(zoneName: zone)
+        XCTAssertNil(state?.lastError, "a successful sync clears the error")
+        XCTAssertNil(state?.lastErrorAt)
+    }
+
+    func testRecordErrorOnFreshZone() throws {
+        try store.recordError("first failure", zoneName: zone, at: 1000)
+
+        let state = try store.state(zoneName: zone)
+        XCTAssertEqual(state?.lastError, "first failure")
+        XCTAssertNil(state?.serverChangeToken)
+        XCTAssertNil(state?.lastSyncAt)
+    }
+}

--- a/spec/schemas/sqlite/schema-v30.sql
+++ b/spec/schemas/sqlite/schema-v30.sql
@@ -1,4 +1,4 @@
--- MigraLog SQLite Schema v29
+-- MigraLog SQLite Schema v30
 -- Canonical schema definition for the migraine tracking database.
 -- Source of truth: mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
 --   (createSchema + registered migrations). This .sql is a formal mirror and
@@ -8,6 +8,9 @@
 --   category_safety_rules, and `created_at` + `updated_at` to medication_schedules,
 --   as the last-write-wins timestamps for sync. These columns are nullable and not
 --   yet maintained by write paths (SyncService will own that).
+-- v30 (#434, iCloud sync): added the device-local sync-state tables
+--   sync_pending_changes (outbound queue) and sync_zone_state (change-token cursor).
+--   These are NOT synced. sync_config + sync_conflicts arrive with their consumers.
 --
 -- Conventions:
 --   - All IDs are TEXT (UUIDs)
@@ -249,3 +252,32 @@ CREATE INDEX IF NOT EXISTS idx_calendar_overlays_dates ON calendar_overlays(star
 
 -- Category safety rules indexes
 CREATE INDEX IF NOT EXISTS idx_category_safety_rules_category ON category_safety_rules(category);
+
+-- =============================================================================
+-- iCloud sync state (v30, #434) — device-local, NEVER synced.
+-- sync_config + sync_conflicts are added later with their consumers.
+-- =============================================================================
+
+-- Outbound change queue (survives app restart). UNIQUE(table_name, record_id)
+-- collapses repeated edits to a row into one entry: latest change wins.
+CREATE TABLE IF NOT EXISTS sync_pending_changes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  table_name TEXT NOT NULL,
+  record_id TEXT NOT NULL,
+  change_type TEXT NOT NULL CHECK(change_type IN ('upsert', 'delete')),
+  created_at INTEGER NOT NULL CHECK(created_at > 0),
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  UNIQUE(table_name, record_id)
+);
+
+-- Per-zone incremental-pull cursor (CKServerChangeToken) + sync bookkeeping.
+CREATE TABLE IF NOT EXISTS sync_zone_state (
+  zone_name TEXT PRIMARY KEY,
+  server_change_token BLOB,
+  last_sync_at INTEGER CHECK(last_sync_at IS NULL OR last_sync_at > 0),
+  last_error TEXT,
+  last_error_at INTEGER CHECK(last_error_at IS NULL OR last_error_at > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_pending_created ON sync_pending_changes(created_at);


### PR DESCRIPTION
## Summary
**SyncService slice 2** for iCloud sync (#434): the device-local persistence layer the sync engine needs. No CloudKit yet — pure SQLite + stores, fully unit-tested. Builds on #444 (v29) and #445 (codec).

## What's here
- **v30 migration** — creates two device-local, never-synced tables:
  - `sync_pending_changes` — the durable outbound change queue (survives restart). `UNIQUE(table_name, record_id)` collapses repeated edits to a row into a single entry (latest change wins).
  - `sync_zone_state` — the per-zone `CKServerChangeToken` cursor for incremental pulls, plus last-sync / error bookkeeping.
- **`SyncPendingChangesStore`** — enqueue (supersede + reset retry), oldest-first `fetchBatch`, `remove`, `recordFailure`, `pendingCount`.
- **`SyncZoneStateStore`** — save/load the change token (kept as opaque bytes so the store has no CloudKit dependency and is fully testable), record errors without clobbering the cursor, clear errors on a successful sync.
- DDL reconciled to `schema-v30.sql`.

## Scope discipline
Only the two tables this slice's code exercises are created now. `sync_config` (settings, slice 4) and `sync_conflicts` (conflict archive, slice 3) land with their consumers — GRDB migrations are immutable once shipped, so we don't ship a table shape before the code that validates it exists.

## Testing
13 store unit tests + a v30 migration test: queue ordering / supersede / retry-reset, zone token round-trip, and the error semantics (error doesn't wipe the cursor; a successful sync clears the error). DatabaseManager + sync suites pass (52 total in the run).

## Roadmap (next slices)
3. Transport protocol + in-memory fake, real `CKContainer`/`MigraLogZone` transport, push/pull orchestration, LWW conflict resolution + `sync_conflicts` archive + delete mechanism.
4. Triggers (foreground/after-write), backup-before-first-sync, settings UI (`sync_config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
