### PR TITLE
feat(ios): sync transport seam + LWW resolver (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/Sync/CloudKitTransport.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/CloudKitTransport.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A page of remote changes pulled from a CloudKit zone.
+struct SyncChangeBatch: Equatable, Sendable {
+    /// Changed/created records since the supplied token, including tombstones
+    /// (records with `deleted == true`). Deletes propagate as tombstones, not as
+    /// CKRecord deletions, so they arrive here like any other change.
+    let records: [SyncRecord]
+    /// The updated server change token to persist for the next incremental pull.
+    let newToken: Data?
+    /// True when the server has more pages to deliver; the caller should fetch again.
+    let moreComing: Bool
+}
+
+/// The seam between the sync engine and CloudKit. The engine talks only to this
+/// protocol so its logic (queue draining, last-write-wins, conflict archiving) can be
+/// unit-tested against an in-memory fake — the real CloudKit round-trip needs a device
+/// / iCloud account and is verified separately (#434).
+///
+/// Implementations must be safe to call from a single sync task at a time; the engine
+/// serialises sync runs.
+protocol CloudKitTransport: Sendable {
+    /// Create the custom record zone if it does not already exist. Idempotent.
+    func ensureZone() async throws
+
+    /// Save the given records (upserts and tombstones) to the zone. Throws if any
+    /// record fails to save.
+    func push(_ records: [SyncRecord]) async throws
+
+    /// Fetch changes since `token` (nil for a first full sync). Returns the changed
+    /// records, the new token to persist, and whether more pages remain.
+    func fetchChanges(since token: Data?) async throws -> SyncChangeBatch
+}

--- a/mobile-apps/ios/MigraLog/Services/Sync/LWWResolver.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/LWWResolver.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Which side of a sync conflict survives.
+enum SyncWinner: Equatable, Sendable {
+    case local
+    case remote
+}
+
+/// Last-write-wins conflict resolution for iCloud sync (#434).
+///
+/// When the same record was modified on two devices between syncs, the version with
+/// the higher local `updated_at` wins. CloudKit's own `modificationDate` reflects
+/// upload time, not edit time, so we never use it — we carry our own `updatedAt`.
+///
+/// `deleted` gets no special treatment: a tombstone is just a version with its own
+/// `updatedAt`, so a later edit resurrects a deleted row and a later delete wins over
+/// an older edit. The losing payload is archived by the caller, never discarded.
+enum LWWResolver {
+    /// Decide which version of a record survives.
+    ///
+    /// Higher `updatedAt` wins. On an exact timestamp tie we break deterministically on
+    /// the payload bytes (lexicographic) so every device converges on the *same* winner
+    /// without consulting any server-assigned metadata. Identical payloads are not a
+    /// real conflict, so local is kept.
+    static func resolve(
+        localUpdatedAt: Int64, localPayload: String,
+        remoteUpdatedAt: Int64, remotePayload: String
+    ) -> SyncWinner {
+        if remoteUpdatedAt != localUpdatedAt {
+            return remoteUpdatedAt > localUpdatedAt ? .remote : .local
+        }
+        if remotePayload != localPayload {
+            return remotePayload > localPayload ? .remote : .local
+        }
+        return .local
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/InMemoryCloudKitTransport.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/InMemoryCloudKitTransport.swift
@@ -1,0 +1,58 @@
+import Foundation
+@testable import MigraLog
+
+/// In-memory `CloudKitTransport` for unit tests. Models a single zone as a
+/// record store plus a monotonic change log, so incremental `fetchChanges` behaves
+/// like the real zone-token mechanism: a token is just the sequence number of the
+/// last change the caller has seen.
+final class InMemoryCloudKitTransport: CloudKitTransport, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: SyncRecord] = [:]
+    /// recordName → sequence number of its latest change.
+    private var changeSeq: [String: Int] = [:]
+    private var seq = 0
+    private(set) var zoneCreated = false
+    private(set) var pushCount = 0
+
+    /// When set, the next `push` throws this and clears it (for error-path tests).
+    var failNextPush: Error?
+
+    func ensureZone() async throws {
+        lock.lock(); defer { lock.unlock() }
+        zoneCreated = true
+    }
+
+    func push(_ records: [SyncRecord]) async throws {
+        lock.lock(); defer { lock.unlock() }
+        if let error = failNextPush {
+            failNextPush = nil
+            throw error
+        }
+        pushCount += 1
+        for record in records {
+            seq += 1
+            storage[record.recordName] = record
+            changeSeq[record.recordName] = seq
+        }
+    }
+
+    func fetchChanges(since token: Data?) async throws -> SyncChangeBatch {
+        lock.lock(); defer { lock.unlock() }
+        let sinceSeq = token
+            .flatMap { String(bytes: $0, encoding: .utf8) }
+            .flatMap { Int($0) } ?? 0
+        let changedNames = changeSeq
+            .filter { $0.value > sinceSeq }
+            .sorted { $0.value < $1.value }
+            .map { $0.key }
+        let records = changedNames.compactMap { storage[$0] }
+        let newSeq = changeSeq.values.max() ?? sinceSeq
+        return SyncChangeBatch(records: records, newToken: Data(String(newSeq).utf8), moreComing: false)
+    }
+
+    /// Test helper: the current stored record for a recordName, if any.
+    func record(named recordName: String) -> SyncRecord? {
+        lock.lock(); defer { lock.unlock() }
+        return storage[recordName]
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/InMemoryCloudKitTransportTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/InMemoryCloudKitTransportTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import MigraLog
+
+final class InMemoryCloudKitTransportTests: XCTestCase {
+
+    private func rec(
+        _ table: String, _ id: String,
+        updatedAt: Int64 = 1, deleted: Bool = false, payload: String = "{}"
+    ) -> SyncRecord {
+        SyncRecord(
+            tableName: table, recordId: id, payload: payload,
+            schemaVersion: 30, updatedAt: updatedAt, deleted: deleted
+        )
+    }
+
+    func testEnsureZone() async throws {
+        let transport = InMemoryCloudKitTransport()
+        XCTAssertFalse(transport.zoneCreated)
+        try await transport.ensureZone()
+        XCTAssertTrue(transport.zoneCreated)
+    }
+
+    func testPushThenFetchAllFromNilToken() async throws {
+        let transport = InMemoryCloudKitTransport()
+        try await transport.push([rec("episodes", "e1"), rec("medications", "m1")])
+
+        let batch = try await transport.fetchChanges(since: nil)
+        XCTAssertEqual(Set(batch.records.map { $0.recordName }), ["episodes:e1", "medications:m1"])
+        XCTAssertNotNil(batch.newToken)
+        XCTAssertFalse(batch.moreComing)
+    }
+
+    func testFetchIsIncremental() async throws {
+        let transport = InMemoryCloudKitTransport()
+        try await transport.push([rec("episodes", "e1")])
+        let first = try await transport.fetchChanges(since: nil)
+
+        let nothingNew = try await transport.fetchChanges(since: first.newToken)
+        XCTAssertTrue(nothingNew.records.isEmpty, "nothing changed since the first token")
+
+        try await transport.push([rec("episodes", "e2")])
+        let second = try await transport.fetchChanges(since: first.newToken)
+        XCTAssertEqual(second.records.map { $0.recordName }, ["episodes:e2"], "only the new record returns")
+    }
+
+    func testPushUpdatesExistingRecord() async throws {
+        let transport = InMemoryCloudKitTransport()
+        try await transport.push([rec("episodes", "e1", updatedAt: 1)])
+        try await transport.push([rec("episodes", "e1", updatedAt: 2)])
+
+        XCTAssertEqual(transport.record(named: "episodes:e1")?.updatedAt, 2)
+        let batch = try await transport.fetchChanges(since: nil)
+        XCTAssertEqual(batch.records.count, 1, "the same record name stays a single record")
+    }
+
+    func testTombstonePropagatesAsRecord() async throws {
+        let transport = InMemoryCloudKitTransport()
+        try await transport.push([rec("episodes", "e1", updatedAt: 5, deleted: true)])
+
+        let batch = try await transport.fetchChanges(since: nil)
+        XCTAssertEqual(batch.records.first?.deleted, true)
+    }
+
+    func testFailNextPushThrowsOnce() async throws {
+        struct Boom: Error {}
+        let transport = InMemoryCloudKitTransport()
+        transport.failNextPush = Boom()
+
+        do {
+            try await transport.push([rec("episodes", "e1")])
+            XCTFail("expected push to throw")
+        } catch is Boom {
+            // expected
+        }
+
+        try await transport.push([rec("episodes", "e1")])
+        XCTAssertEqual(transport.pushCount, 1, "only the successful push counts")
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/LWWResolverTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/LWWResolverTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import MigraLog
+
+final class LWWResolverTests: XCTestCase {
+
+    func testRemoteNewerWins() {
+        XCTAssertEqual(
+            LWWResolver.resolve(localUpdatedAt: 100, localPayload: "a", remoteUpdatedAt: 200, remotePayload: "b"),
+            .remote
+        )
+    }
+
+    func testLocalNewerWins() {
+        XCTAssertEqual(
+            LWWResolver.resolve(localUpdatedAt: 300, localPayload: "a", remoteUpdatedAt: 200, remotePayload: "b"),
+            .local
+        )
+    }
+
+    func testTimestampTieBreaksOnHigherPayload() {
+        XCTAssertEqual(
+            LWWResolver.resolve(localUpdatedAt: 100, localPayload: "aaa", remoteUpdatedAt: 100, remotePayload: "bbb"),
+            .remote
+        )
+        XCTAssertEqual(
+            LWWResolver.resolve(localUpdatedAt: 100, localPayload: "zzz", remoteUpdatedAt: 100, remotePayload: "aaa"),
+            .local
+        )
+    }
+
+    func testIdenticalVersionsKeepLocal() {
+        XCTAssertEqual(
+            LWWResolver.resolve(localUpdatedAt: 100, localPayload: "same", remoteUpdatedAt: 100, remotePayload: "same"),
+            .local
+        )
+    }
+
+    /// Both devices see the same two versions (mirrored local/remote) and must converge
+    /// on the same surviving payload — here, "y".
+    func testTiebreakConvergesAcrossDevices() {
+        let deviceA = LWWResolver.resolve(localUpdatedAt: 5, localPayload: "x", remoteUpdatedAt: 5, remotePayload: "y")
+        let deviceB = LWWResolver.resolve(localUpdatedAt: 5, localPayload: "y", remoteUpdatedAt: 5, remotePayload: "x")
+        XCTAssertEqual(deviceA, .remote, "device A keeps remote 'y'")
+        XCTAssertEqual(deviceB, .local, "device B keeps local 'y'")
+    }
+}


### PR DESCRIPTION
## Summary
**SyncService slice 3a** for iCloud sync (#434): the CloudKit seam and the conflict-resolution logic the sync engine builds on. Fork-free and fully unit-tested against an in-memory fake — no real CloudKit yet. Builds on #444/#445/#446.

## What's here
- **`CloudKitTransport`** protocol — `ensureZone` / `push` / `fetchChanges(since:)`, with `SyncChangeBatch` (changed records incl. tombstones, the new token, `moreComing`). The engine talks only to this seam, so its push/pull/conflict logic is testable without a device — the real `CKContainer` round-trip is verified separately (device / `cktool`).
- **`InMemoryCloudKitTransport`** (test fake) — models one zone as a record store + a monotonic change log, so `fetchChanges` is genuinely incremental (token = last sequence seen) and push failures are injectable.
- **`LWWResolver`** — last-write-wins on `updated_at`; exact-timestamp ties break on payload bytes (lexicographic) so two devices converge on the *same* winner without server metadata. `deleted` gets no special case: a later edit resurrects a deleted row, a later delete wins over an older edit.

## Conflict-resolution contract (for review)
These behavioral defaults are baked in and worth a glance:
- **Tiebreaker:** payload-lexicographic on exact `updated_at` ties (recordId can't tiebreak — both sides share it). Test `testTiebreakConvergesAcrossDevices` demonstrates convergence.
- **Delete vs edit:** pure LWW — later wins, so an edit after a delete resurrects (favours no-data-loss).

## Testing
11 unit tests: resolver (newer-wins both directions, payload tiebreak, identical-keeps-local, cross-device convergence) and the fake (incremental fetch, update-in-place, tombstone propagation, one-shot push failure).

## Roadmap (remaining)
3b. Real `CKContainer`/`MigraLogZone` transport + the `SyncEngine` orchestration (drain queue → push; fetch → apply with `LWWResolver`), `sync_conflicts` table + archive, delete-payload capture (hard-delete + queue, per the chosen mechanism).
4. Triggers (foreground/after-write), backup-before-first-sync, settings UI (`sync_config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
