### PR TITLE
feat(ios): sync conflict archive — v31 sync_conflicts + store (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -4,7 +4,7 @@ import GRDB
 /// Central database manager. Owns the DatabaseQueue and handles schema creation/migration.
 final class DatabaseManager: Sendable {
     /// The current schema version
-    static let schemaVersion = 30
+    static let schemaVersion = 31
 
     /// Shared singleton for the app's main database
     static let shared = DatabaseManager()
@@ -142,6 +142,13 @@ final class DatabaseManager: Sendable {
         // queue and the per-zone server-change-token cursor. Device-local, never
         // synced. See createSyncStateTables.
         migrator.registerMigration("v30") { db in
+            try DatabaseManager.createSyncStateTables(in: db)
+        }
+
+        // v31: Add the conflict archive (sync_conflicts) for last-write-wins (#434).
+        // createSyncStateTables is idempotent, so this just adds the new table for
+        // installs that already ran v30 without it.
+        migrator.registerMigration("v31") { db in
             try DatabaseManager.createSyncStateTables(in: db)
         }
 
@@ -459,10 +466,9 @@ final class DatabaseManager: Sendable {
     }
 
     /// Create the device-local sync-state tables for iCloud sync (#434): the outbound
-    /// change queue and the per-zone server-change-token cursor. These are NOT synced.
-    /// Idempotent — called from createSchema (fresh installs) and the v30 migration
-    /// (upgrades). Only the tables exercised by current code live here; sync_config
-    /// and sync_conflicts arrive with their consumers (settings UI, conflict archive).
+    /// change queue, the per-zone server-change-token cursor, and the conflict archive.
+    /// These are NOT synced. Idempotent — called from createSchema (fresh installs) and
+    /// the v30/v31 migrations (upgrades). sync_config arrives later with the settings UI.
     static func createSyncStateTables(in db: Database) throws {
         try db.execute(sql: """
             CREATE TABLE IF NOT EXISTS sync_pending_changes (
@@ -486,6 +492,21 @@ final class DatabaseManager: Sendable {
             )
             """)
         try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_sync_pending_created ON sync_pending_changes(created_at)")
+        // Conflict archive (v31): preserves the losing side of last-write-wins for 90 days.
+        try db.execute(sql: """
+            CREATE TABLE IF NOT EXISTS sync_conflicts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                table_name TEXT NOT NULL,
+                record_id TEXT NOT NULL,
+                losing_side TEXT NOT NULL CHECK(losing_side IN ('local', 'remote')),
+                payload TEXT NOT NULL,
+                winning_payload TEXT NOT NULL,
+                resolved_at INTEGER NOT NULL CHECK(resolved_at > 0),
+                expires_at INTEGER NOT NULL CHECK(expires_at > resolved_at)
+            )
+            """)
+        try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_sync_conflicts_expires ON sync_conflicts(expires_at)")
+        try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_sync_conflicts_record ON sync_conflicts(table_name, record_id)")
     }
 
     private static func createIndexes(in db: Database) throws {

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncConflictsStore.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncConflictsStore.swift
@@ -1,0 +1,123 @@
+import Foundation
+import GRDB
+
+/// One archived conflict: the losing side of a last-write-wins resolution, kept so
+/// the user can review and restore it.
+struct SyncConflict: Equatable, Sendable {
+    enum LosingSide: String, Sendable {
+        case local
+        case remote
+    }
+
+    let id: Int64
+    let tableName: String
+    let recordId: String
+    let losingSide: LosingSide
+    /// The payload that lost (the one a user might want to restore).
+    let payload: String
+    /// The payload that won, for context.
+    let winningPayload: String
+    let resolvedAt: Int64
+    let expiresAt: Int64
+}
+
+/// The conflict archive for iCloud sync (#434). When last-write-wins discards a
+/// version of a record, the losing payload is preserved here rather than dropped —
+/// data-loss prevention is a core tenet. Restoring is just writing the payload back to
+/// the local table and re-queuing it (same codepath as a normal edit). Rows are purged
+/// after the retention window so the archive can't grow without bound.
+final class SyncConflictsStore: Sendable {
+    /// How long a losing payload is retained before it can be purged.
+    static let retentionDays = 90
+    private static let retentionMillis = Int64(retentionDays) * 24 * 3_600 * 1_000
+
+    private let dbManager: DatabaseManager
+
+    init(dbManager: DatabaseManager) {
+        self.dbManager = dbManager
+    }
+
+    /// Archive the losing side of a resolved conflict. `payloads` carries both sides
+    /// (the loser, kept for restore, and the winner, for context). `expiresAt` is
+    /// derived from `resolvedAt` plus the retention window.
+    func archive(
+        tableName: String,
+        recordId: String,
+        losingSide: SyncConflict.LosingSide,
+        payloads: (losing: String, winning: String),
+        resolvedAt: Int64
+    ) throws {
+        let expiresAt = resolvedAt + Self.retentionMillis
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO sync_conflicts
+                        (table_name, record_id, losing_side, payload, winning_payload, resolved_at, expires_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                arguments: [
+                    tableName, recordId, losingSide.rawValue,
+                    payloads.losing, payloads.winning, resolvedAt, expiresAt
+                ]
+            )
+        }
+    }
+
+    /// Archived conflicts for one record, newest first.
+    func conflicts(forRecord tableName: String, recordId: String) throws -> [SyncConflict] {
+        try dbManager.dbQueue.read { db in
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT id, table_name, record_id, losing_side, payload, winning_payload, resolved_at, expires_at
+                    FROM sync_conflicts
+                    WHERE table_name = ? AND record_id = ?
+                    ORDER BY resolved_at DESC
+                    """,
+                arguments: [tableName, recordId]
+            )
+            return rows.compactMap { Self.conflictFromRow($0) }
+        }
+    }
+
+    func count() throws -> Int {
+        try dbManager.dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM sync_conflicts") ?? 0
+        }
+    }
+
+    /// Delete conflicts whose retention window has elapsed. Returns the number purged.
+    @discardableResult
+    func purgeExpired(now: Int64) throws -> Int {
+        try dbManager.dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM sync_conflicts WHERE expires_at < ?", arguments: [now])
+            return db.changesCount
+        }
+    }
+
+    // MARK: - Row Mapping
+
+    private static func conflictFromRow(_ row: Row) -> SyncConflict? {
+        guard let id = row["id"] as Int64?,
+              let tableName = row["table_name"] as String?,
+              let recordId = row["record_id"] as String?,
+              let rawSide = row["losing_side"] as String?,
+              let losingSide = SyncConflict.LosingSide(rawValue: rawSide),
+              let payload = row["payload"] as String?,
+              let winningPayload = row["winning_payload"] as String?,
+              let resolvedAt = row["resolved_at"] as Int64?,
+              let expiresAt = row["expires_at"] as Int64? else {
+            return nil
+        }
+        return SyncConflict(
+            id: id,
+            tableName: tableName,
+            recordId: recordId,
+            losingSide: losingSide,
+            payload: payload,
+            winningPayload: winningPayload,
+            resolvedAt: resolvedAt,
+            expiresAt: expiresAt
+        )
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
@@ -56,6 +56,7 @@ final class DatabaseManagerTests: XCTestCase {
             "category_safety_rules",
             "sync_pending_changes",
             "sync_zone_state",
+            "sync_conflicts",
             "grdb_migrations", // GRDB internal table
         ]
 
@@ -185,7 +186,7 @@ final class DatabaseManagerTests: XCTestCase {
     // MARK: - Schema Version
 
     func testSchemaVersionIsTracked() throws {
-        XCTAssertEqual(DatabaseManager.schemaVersion, 30)
+        XCTAssertEqual(DatabaseManager.schemaVersion, 31)
     }
 
     func testMigrationIsRecordedInGRDB() throws {
@@ -232,6 +233,16 @@ final class DatabaseManagerTests: XCTestCase {
             let identifiers = try Row.fetchAll(db, sql: "SELECT identifier FROM grdb_migrations")
                 .map { $0["identifier"] as String }
             XCTAssertTrue(identifiers.contains("v30"), "Migration v30 should be recorded")
+        }
+    }
+
+    /// v31 adds the conflict archive (#434).
+    func testV31CreatesConflictArchive() throws {
+        try dbManager.dbQueue.read { db in
+            XCTAssertTrue(try db.tableExists("sync_conflicts"))
+            let identifiers = try Row.fetchAll(db, sql: "SELECT identifier FROM grdb_migrations")
+                .map { $0["identifier"] as String }
+            XCTAssertTrue(identifiers.contains("v31"), "Migration v31 should be recorded")
         }
     }
 

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncConflictsStoreTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncConflictsStoreTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+import GRDB
+@testable import MigraLog
+
+final class SyncConflictsStoreTests: XCTestCase {
+    var dbManager: DatabaseManager!
+    var store: SyncConflictsStore!
+
+    override func setUpWithError() throws {
+        dbManager = try DatabaseManager(inMemory: true)
+        store = SyncConflictsStore(dbManager: dbManager)
+    }
+
+    override func tearDownWithError() throws {
+        store = nil
+        dbManager = nil
+    }
+
+    func testArchiveAndFetchForRecord() throws {
+        try store.archive(
+            tableName: "episodes", recordId: "e1", losingSide: .local,
+            payloads: (losing: #"{"v":1}"#, winning: #"{"v":2}"#), resolvedAt: 1000
+        )
+        let conflicts = try store.conflicts(forRecord: "episodes", recordId: "e1")
+        XCTAssertEqual(conflicts.count, 1)
+        XCTAssertEqual(conflicts[0].losingSide, .local)
+        XCTAssertEqual(conflicts[0].payload, #"{"v":1}"#)
+        XCTAssertEqual(conflicts[0].winningPayload, #"{"v":2}"#)
+        XCTAssertEqual(conflicts[0].resolvedAt, 1000)
+    }
+
+    func testExpiresAtIsResolvedPlusRetention() throws {
+        try store.archive(
+            tableName: "episodes", recordId: "e1", losingSide: .remote,
+            payloads: (losing: "a", winning: "b"), resolvedAt: 1000
+        )
+        let conflict = try store.conflicts(forRecord: "episodes", recordId: "e1")[0]
+        let retentionMillis = Int64(SyncConflictsStore.retentionDays) * 24 * 3600 * 1000
+        XCTAssertEqual(conflict.expiresAt, 1000 + retentionMillis)
+    }
+
+    func testFetchForRecordNewestFirst() throws {
+        try store.archive(
+            tableName: "episodes", recordId: "e1", losingSide: .local,
+            payloads: (losing: "old", winning: "w"), resolvedAt: 1000
+        )
+        try store.archive(
+            tableName: "episodes", recordId: "e1", losingSide: .remote,
+            payloads: (losing: "new", winning: "w"), resolvedAt: 2000
+        )
+        let conflicts = try store.conflicts(forRecord: "episodes", recordId: "e1")
+        XCTAssertEqual(conflicts.map { $0.payload }, ["new", "old"])
+    }
+
+    func testFetchIsScopedToRecord() throws {
+        try store.archive(
+            tableName: "episodes", recordId: "e1", losingSide: .local,
+            payloads: (losing: "a", winning: "b"), resolvedAt: 1000
+        )
+        try store.archive(
+            tableName: "medications", recordId: "m1", losingSide: .local,
+            payloads: (losing: "c", winning: "d"), resolvedAt: 1000
+        )
+        XCTAssertEqual(try store.conflicts(forRecord: "episodes", recordId: "e1").count, 1)
+        XCTAssertEqual(try store.count(), 2)
+    }
+
+    func testPurgeExpiredRemovesOnlyExpired() throws {
+        let retentionMillis = Int64(SyncConflictsStore.retentionDays) * 24 * 3600 * 1000
+        try store.archive(
+            tableName: "episodes", recordId: "old", losingSide: .local,
+            payloads: (losing: "a", winning: "b"), resolvedAt: 1000
+        )
+        try store.archive(
+            tableName: "episodes", recordId: "new", losingSide: .local,
+            payloads: (losing: "c", winning: "d"), resolvedAt: 5000
+        )
+        // Just past the first conflict's expiry, before the second's.
+        let now = 1000 + retentionMillis + 1
+        let purged = try store.purgeExpired(now: now)
+        XCTAssertEqual(purged, 1)
+        XCTAssertEqual(try store.count(), 1)
+        XCTAssertEqual(try store.conflicts(forRecord: "episodes", recordId: "new").count, 1)
+    }
+}

--- a/spec/schemas/sqlite/schema-v31.sql
+++ b/spec/schemas/sqlite/schema-v31.sql
@@ -1,4 +1,4 @@
--- MigraLog SQLite Schema v30
+-- MigraLog SQLite Schema v31
 -- Canonical schema definition for the migraine tracking database.
 -- Source of truth: mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
 --   (createSchema + registered migrations). This .sql is a formal mirror and
@@ -10,7 +10,9 @@
 --   yet maintained by write paths (SyncService will own that).
 -- v30 (#434, iCloud sync): added the device-local sync-state tables
 --   sync_pending_changes (outbound queue) and sync_zone_state (change-token cursor).
---   These are NOT synced. sync_config + sync_conflicts arrive with their consumers.
+--   These are NOT synced. sync_config arrives with its consumer (settings UI).
+-- v31 (#434, iCloud sync): added sync_conflicts — the last-write-wins conflict
+--   archive (losing payloads, 90-day retention). Device-local, NOT synced.
 --
 -- Conventions:
 --   - All IDs are TEXT (UUIDs)
@@ -281,3 +283,19 @@ CREATE TABLE IF NOT EXISTS sync_zone_state (
 );
 
 CREATE INDEX IF NOT EXISTS idx_sync_pending_created ON sync_pending_changes(created_at);
+
+-- Conflict archive (v31): the losing side of last-write-wins, retained 90 days.
+-- Recovery = write the payload back to the local table and re-queue it.
+CREATE TABLE IF NOT EXISTS sync_conflicts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  table_name TEXT NOT NULL,
+  record_id TEXT NOT NULL,
+  losing_side TEXT NOT NULL CHECK(losing_side IN ('local', 'remote')),
+  payload TEXT NOT NULL,
+  winning_payload TEXT NOT NULL,
+  resolved_at INTEGER NOT NULL CHECK(resolved_at > 0),
+  expires_at INTEGER NOT NULL CHECK(expires_at > resolved_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_conflicts_expires ON sync_conflicts(expires_at);
+CREATE INDEX IF NOT EXISTS idx_sync_conflicts_record ON sync_conflicts(table_name, record_id);


### PR DESCRIPTION
## Summary
**SyncService slice 3b** for iCloud sync (#434): the conflict archive that last-write-wins writes its losers to. Pure SQLite + store, fully unit-tested. Builds on #447 (`LWWResolver`).

## What's here
- **v31 migration** — `sync_conflicts` (losing + winning payloads, `losing_side`, `resolved_at`, `expires_at`) + indexes. Device-local, never synced. Added through the idempotent `createSyncStateTables` helper, so installs that already ran v30 pick it up via v31.
- **`SyncConflictsStore`** — `archive` (expiry = resolved + 90 days), `conflicts(forRecord:)` newest-first, `count`, `purgeExpired` (returns purged count, keeps the archive bounded).
- DDL reconciled to `schema-v31.sql`.

## Why it exists
When two devices edit the same record between syncs, LWW keeps the newer version — but the losing payload is never discarded. It lands here so the user can review/restore it (restoring = write the payload back + re-queue, the same codepath as a normal edit; a later slice wires the UI/restore action). Tombstones in CloudKit + the existing backup system remain the other recovery layers.

## Testing
5 store tests + a v31 migration test: archive + fetch (scoped to record, newest-first), the 90-day expiry derivation, and purge-only-expired. DatabaseManager + conflict suites pass (45 total in the run).

## Roadmap (remaining)
- **3c** — `SyncEngine` orchestration: drain queue → build records → `push`; `fetchChanges` → apply each via `LWWResolver` (upsert/delete local row generically, archive the loser here), persist the new token. Delete-payload capture (hard-delete + queue). Testable against the in-memory fake.
- **3d** — the real `CKContainer`/`MigraLogZone` `CloudKitTransport` (device / `cktool`-verified).
- **4** — triggers (foreground / after-write), backup-before-first-sync, settings UI (`sync_config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
