### PR TITLE
feat(ios): remote-change applier — LWW apply + conflict archive (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/Sync/RemoteChangeApplier.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/RemoteChangeApplier.swift
@@ -1,0 +1,168 @@
+import Foundation
+import GRDB
+
+/// Applies a single remote change (one `SyncRecord` pulled from CloudKit) to the local
+/// database (#434): decode the payload, resolve last-write-wins against the local row,
+/// and upsert or delete accordingly. When the local row also had an unpushed edit (a
+/// genuine conflict), the losing payload is archived to `sync_conflicts` before it is
+/// overwritten — data-loss prevention is a core tenet.
+///
+/// Everything happens in one transaction so the archive and the row change commit
+/// together. Apply is per-record; ordering a batch so parents land before children
+/// (FK constraints) is the sync engine's job — this writes one row.
+final class RemoteChangeApplier: Sendable {
+    enum Outcome: Equatable, Sendable {
+        case skippedUnknownTable
+        case insertedNew
+        case noopTombstone      // a tombstone for a row we don't have
+        case appliedRemoteWin   // remote newer → local upserted or deleted
+        case keptLocalWin       // local newer → remote ignored (engine re-pushes local)
+    }
+
+    private let dbManager: DatabaseManager
+
+    init(dbManager: DatabaseManager) {
+        self.dbManager = dbManager
+    }
+
+    @discardableResult
+    func apply(_ record: SyncRecord, now: Int64) throws -> Outcome {
+        guard let table = SyncableTable.named(record.tableName) else {
+            return .skippedUnknownTable
+        }
+
+        return try dbManager.dbQueue.write { db in
+            let localRow = try Row.fetchOne(
+                db,
+                sql: "SELECT * FROM \(table.tableName) WHERE \(table.primaryKeyColumn) = ?",
+                arguments: [record.recordId]
+            )
+
+            // A record we've never seen: insert it (a tombstone for a missing row is a no-op).
+            guard let localRow else {
+                if record.deleted { return .noopTombstone }
+                try Self.upsert(record, table: table, in: db)
+                return .insertedNew
+            }
+
+            let localPayload = try SyncPayloadCodec.encodePayload(row: localRow, table: table)
+            let winner = LWWResolver.resolve(
+                localUpdatedAt: Self.lwwTimestamp(of: localRow), localPayload: localPayload,
+                remoteUpdatedAt: record.updatedAt, remotePayload: record.payload
+            )
+
+            // It's only a real conflict (worth archiving) if the local row had an edit
+            // that hasn't been pushed yet — otherwise the remote is just an update we
+            // hadn't seen, not a competing version.
+            let isConflict = try Self.hasPendingChange(table: table.tableName, recordId: record.recordId, in: db)
+
+            switch winner {
+            case .remote:
+                if isConflict {
+                    try Self.archiveConflict(
+                        in: db, record: (table.tableName, record.recordId),
+                        losingSide: "local", payloads: (losing: localPayload, winning: record.payload), now: now
+                    )
+                }
+                if record.deleted {
+                    try db.execute(
+                        sql: "DELETE FROM \(table.tableName) WHERE \(table.primaryKeyColumn) = ?",
+                        arguments: [record.recordId]
+                    )
+                } else {
+                    try Self.upsert(record, table: table, in: db)
+                }
+                return .appliedRemoteWin
+
+            case .local:
+                if isConflict {
+                    try Self.archiveConflict(
+                        in: db, record: (table.tableName, record.recordId),
+                        losingSide: "remote", payloads: (losing: record.payload, winning: localPayload), now: now
+                    )
+                }
+                return .keptLocalWin
+            }
+        }
+    }
+
+    // MARK: - Generic row write
+
+    /// Upsert a row from a decoded payload. Uses `ON CONFLICT(id) DO UPDATE` rather than
+    /// `INSERT OR REPLACE` so the existing row is updated in place — REPLACE would delete
+    /// it and cascade-delete any FK children, and would also wipe device-local columns
+    /// that aren't in the payload (e.g. medication_schedules.notification_id, which the
+    /// update set leaves untouched). Columns the local schema doesn't have are dropped
+    /// (forward-compatible migrate-on-read).
+    private static func upsert(_ record: SyncRecord, table: SyncableTable, in db: Database) throws {
+        let decoded = try SyncPayloadCodec.decodePayload(record.payload)
+        let existing = try columnNames(of: table.tableName, in: db)
+        let columns = decoded.keys.filter { existing.contains($0) }.sorted()
+        guard !columns.isEmpty else { return }
+
+        let placeholders = Array(repeating: "?", count: columns.count).joined(separator: ", ")
+        let assignments = columns
+            .filter { $0 != table.primaryKeyColumn }
+            .map { "\($0) = excluded.\($0)" }
+            .joined(separator: ", ")
+        let conflictClause = assignments.isEmpty
+            ? "ON CONFLICT(\(table.primaryKeyColumn)) DO NOTHING"
+            : "ON CONFLICT(\(table.primaryKeyColumn)) DO UPDATE SET \(assignments)"
+
+        let arguments = StatementArguments(columns.map { decoded[$0]!.databaseValue })
+        try db.execute(
+            sql: """
+                INSERT INTO \(table.tableName) (\(columns.joined(separator: ", ")))
+                VALUES (\(placeholders))
+                \(conflictClause)
+                """,
+            arguments: arguments
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func lwwTimestamp(of row: Row) -> Int64 {
+        (row["updated_at"] as Int64?) ?? (row["created_at"] as Int64?) ?? 0
+    }
+
+    private static func hasPendingChange(table: String, recordId: String, in db: Database) throws -> Bool {
+        let found = try Int.fetchOne(
+            db,
+            sql: "SELECT 1 FROM sync_pending_changes WHERE table_name = ? AND record_id = ? LIMIT 1",
+            arguments: [table, recordId]
+        )
+        return found != nil
+    }
+
+    private static func columnNames(of table: String, in db: Database) throws -> Set<String> {
+        let rows = try Row.fetchAll(db, sql: "PRAGMA table_info(\(table))")
+        return Set(rows.map { $0["name"] as String })
+    }
+
+    private static func archiveConflict(
+        in db: Database, record: (table: String, id: String),
+        losingSide: String, payloads: (losing: String, winning: String), now: Int64
+    ) throws {
+        let expiresAt = now + Int64(SyncConflictsStore.retentionDays) * 24 * 3_600 * 1_000
+        try db.execute(
+            sql: """
+                INSERT INTO sync_conflicts
+                    (table_name, record_id, losing_side, payload, winning_payload, resolved_at, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+            arguments: [record.table, record.id, losingSide, payloads.losing, payloads.winning, now, expiresAt]
+        )
+    }
+}
+
+private extension SyncPayloadCodec.Value {
+    var databaseValue: DatabaseValue {
+        switch self {
+        case .text(let value): return value.databaseValue
+        case .int(let value): return value.databaseValue
+        case .double(let value): return value.databaseValue
+        case .null: return .null
+        }
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/RemoteChangeApplierTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/RemoteChangeApplierTests.swift
@@ -1,0 +1,219 @@
+import XCTest
+import GRDB
+@testable import MigraLog
+
+final class RemoteChangeApplierTests: XCTestCase {
+    var dbManager: DatabaseManager!
+    var applier: RemoteChangeApplier!
+
+    override func setUpWithError() throws {
+        dbManager = try DatabaseManager(inMemory: true)
+        applier = RemoteChangeApplier(dbManager: dbManager)
+    }
+
+    override func tearDownWithError() throws {
+        applier = nil
+        dbManager = nil
+    }
+
+    // MARK: - Helpers
+
+    private func makePayload(_ columns: [String: (any DatabaseValueConvertible)?]) -> String {
+        (try? SyncPayloadCodec.encodePayload(row: Row(columns), table: .episodes)) ?? "{}"
+    }
+
+    private func medicationRecord(_ id: String, name: String, updatedAt: Int64, deleted: Bool = false) -> SyncRecord {
+        SyncRecord(
+            tableName: "medications", recordId: id,
+            payload: makePayload([
+                "id": id, "name": name, "type": "rescue", "dosage_amount": 1.0,
+                "dosage_unit": "mg", "active": Int64(1), "created_at": Int64(1000), "updated_at": updatedAt,
+            ]),
+            schemaVersion: 31, updatedAt: updatedAt, deleted: deleted
+        )
+    }
+
+    private func insertMedication(_ id: String, name: String, updatedAt: Int64) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, created_at, updated_at)
+                    VALUES (?, ?, 'rescue', 1, 'mg', 1000, ?)
+                    """,
+                arguments: [id, name, updatedAt]
+            )
+        }
+    }
+
+    private func medicationName(_ id: String) throws -> String? {
+        try dbManager.dbQueue.read { db in
+            try String.fetchOne(db, sql: "SELECT name FROM medications WHERE id = ?", arguments: [id])
+        }
+    }
+
+    private func enqueuePending(table: String, id: String) throws {
+        try SyncPendingChangesStore(dbManager: dbManager)
+            .enqueue(tableName: table, recordId: id, changeType: .upsert, at: 1)
+    }
+
+    private func conflicts() throws -> [(losingSide: String, payload: String)] {
+        try dbManager.dbQueue.read { db in
+            try Row.fetchAll(db, sql: "SELECT losing_side, payload FROM sync_conflicts")
+                .map { (losingSide: $0["losing_side"], payload: $0["payload"]) }
+        }
+    }
+
+    // MARK: - Basic apply
+
+    func testUnknownTableIsSkipped() throws {
+        let record = SyncRecord(
+            tableName: "scheduled_notifications", recordId: "x", payload: "{}",
+            schemaVersion: 31, updatedAt: 1, deleted: false
+        )
+        XCTAssertEqual(try applier.apply(record, now: 10), .skippedUnknownTable)
+    }
+
+    func testInsertsNewRecord() throws {
+        let outcome = try applier.apply(medicationRecord("m1", name: "Sumatriptan", updatedAt: 2000), now: 10)
+        XCTAssertEqual(outcome, .insertedNew)
+        XCTAssertEqual(try medicationName("m1"), "Sumatriptan")
+    }
+
+    func testTombstoneForMissingRowIsNoop() throws {
+        let record = medicationRecord("ghost", name: "x", updatedAt: 2000, deleted: true)
+        XCTAssertEqual(try applier.apply(record, now: 10), .noopTombstone)
+        XCTAssertNil(try medicationName("ghost"))
+    }
+
+    // MARK: - LWW + conflict archiving
+
+    func testRemoteNewerWithoutPendingAppliesWithoutArchiving() throws {
+        try insertMedication("m1", name: "Old", updatedAt: 1000)
+        let outcome = try applier.apply(medicationRecord("m1", name: "New", updatedAt: 2000), now: 10)
+        XCTAssertEqual(outcome, .appliedRemoteWin)
+        XCTAssertEqual(try medicationName("m1"), "New")
+        XCTAssertEqual(try conflicts().count, 0, "no pending local edit → not a conflict")
+    }
+
+    func testRemoteWinsWithPendingArchivesLocalLoser() throws {
+        try insertMedication("m1", name: "LocalEdit", updatedAt: 1500)
+        try enqueuePending(table: "medications", id: "m1")
+
+        let outcome = try applier.apply(medicationRecord("m1", name: "RemoteWins", updatedAt: 2000), now: 99)
+        XCTAssertEqual(outcome, .appliedRemoteWin)
+        XCTAssertEqual(try medicationName("m1"), "RemoteWins")
+
+        let archived = try conflicts()
+        XCTAssertEqual(archived.count, 1)
+        XCTAssertEqual(archived[0].losingSide, "local")
+        XCTAssertTrue(archived[0].payload.contains("LocalEdit"), "the displaced local payload is preserved")
+    }
+
+    func testLocalNewerWithPendingKeepsLocalAndArchivesRemote() throws {
+        try insertMedication("m1", name: "LocalWins", updatedAt: 3000)
+        try enqueuePending(table: "medications", id: "m1")
+
+        let outcome = try applier.apply(medicationRecord("m1", name: "StaleRemote", updatedAt: 2000), now: 99)
+        XCTAssertEqual(outcome, .keptLocalWin)
+        XCTAssertEqual(try medicationName("m1"), "LocalWins", "local is untouched")
+
+        let archived = try conflicts()
+        XCTAssertEqual(archived.count, 1)
+        XCTAssertEqual(archived[0].losingSide, "remote")
+        XCTAssertTrue(archived[0].payload.contains("StaleRemote"))
+    }
+
+    func testRemoteTombstoneDeletesLocalRow() throws {
+        try insertMedication("m1", name: "ToDelete", updatedAt: 1000)
+        let tombstone = medicationRecord("m1", name: "ToDelete", updatedAt: 2000, deleted: true)
+        let outcome = try applier.apply(tombstone, now: 10)
+        XCTAssertEqual(outcome, .appliedRemoteWin)
+        XCTAssertNil(try medicationName("m1"), "row deleted")
+    }
+
+    // MARK: - Correctness guarantees
+
+    /// Updating a parent must NOT delete its children. ON CONFLICT DO UPDATE updates in
+    /// place; INSERT OR REPLACE would cascade-delete the readings.
+    func testUpdatingParentPreservesChildren() throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(sql: """
+                INSERT INTO episodes (id, start_time, locations, qualities, symptoms, triggers, created_at, updated_at)
+                VALUES ('e1', 1000, '[]', '[]', '[]', '[]', 1000, 1000)
+                """)
+            try db.execute(sql: """
+                INSERT INTO intensity_readings (id, episode_id, timestamp, intensity, created_at, updated_at)
+                VALUES ('ir1', 'e1', 1000, 5, 1000, 1000)
+                """)
+        }
+
+        let remote = SyncRecord(
+            tableName: "episodes", recordId: "e1",
+            payload: makePayload([
+                "id": "e1", "start_time": Int64(1000), "locations": "[]", "qualities": "[]",
+                "symptoms": "[]", "triggers": "[]", "notes": "updated",
+                "created_at": Int64(1000), "updated_at": Int64(2000),
+            ]),
+            schemaVersion: 31, updatedAt: 2000, deleted: false
+        )
+        XCTAssertEqual(try applier.apply(remote, now: 10), .appliedRemoteWin)
+
+        try dbManager.dbQueue.read { db in
+            XCTAssertEqual(try String.fetchOne(db, sql: "SELECT notes FROM episodes WHERE id = 'e1'"), "updated")
+            let childCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM intensity_readings WHERE id = 'ir1'")
+            XCTAssertEqual(childCount, 1, "the child reading must survive a parent update")
+        }
+    }
+
+    /// A device-local column (medication_schedules.notification_id) is absent from the
+    /// payload and must be preserved across a remote update, not nulled.
+    func testDeviceLocalColumnPreservedOnUpdate() throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(sql: """
+                INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, created_at, updated_at)
+                VALUES ('med1', 'Med', 'preventative', 1, 'mg', 1000, 1000)
+                """)
+            try db.execute(sql: """
+                INSERT INTO medication_schedules
+                    (id, medication_id, time, timezone, notification_id, created_at, updated_at)
+                VALUES ('sch1', 'med1', '08:00', 'UTC', 'local-notif', 1000, 1000)
+                """)
+        }
+
+        let remote = SyncRecord(
+            tableName: "medication_schedules", recordId: "sch1",
+            payload: makePayload([
+                "id": "sch1", "medication_id": "med1", "time": "09:00", "timezone": "UTC",
+                "dosage": 1.0, "enabled": Int64(1), "reminder_enabled": Int64(1),
+                "created_at": Int64(1000), "updated_at": Int64(2000),
+            ]),
+            schemaVersion: 31, updatedAt: 2000, deleted: false
+        )
+        XCTAssertEqual(try applier.apply(remote, now: 10), .appliedRemoteWin)
+
+        try dbManager.dbQueue.read { db in
+            let time = try String.fetchOne(db, sql: "SELECT time FROM medication_schedules WHERE id = 'sch1'")
+            XCTAssertEqual(time, "09:00")
+            let notif = try String.fetchOne(
+                db, sql: "SELECT notification_id FROM medication_schedules WHERE id = 'sch1'"
+            )
+            XCTAssertEqual(notif, "local-notif", "device-local notification_id must be preserved")
+        }
+    }
+
+    /// A payload column the local schema doesn't have (newer remote schema) is dropped,
+    /// not an error — basic forward-compatible migrate-on-read.
+    func testUnknownPayloadColumnIsDropped() throws {
+        let record = SyncRecord(
+            tableName: "medications", recordId: "m1",
+            payload: makePayload([
+                "id": "m1", "name": "Future", "type": "rescue", "dosage_amount": 1.0,
+                "dosage_unit": "mg", "created_at": Int64(1000), "updated_at": Int64(2000),
+                "future_column": "ignored",
+            ]),
+            schemaVersion: 99, updatedAt: 2000, deleted: false
+        )
+        XCTAssertEqual(try applier.apply(record, now: 10), .insertedNew)
+        XCTAssertEqual(try medicationName("m1"), "Future")
+    }
+}


### PR DESCRIPTION
## Summary
**SyncService slice 3c** for iCloud sync (#434): the pull-side applier. Given one remote `SyncRecord`, it decodes the payload, resolves last-write-wins against the local row, and upserts/deletes — archiving the loser on a genuine conflict. Fully unit-tested against an in-memory DB. Builds on #445/#446/#447/#448.

## What's here
- **`RemoteChangeApplier.apply(record:now:)`** — new row → insert; existing row → `LWWResolver` decides. Remote wins → upsert (or delete, for a tombstone); local wins → keep local (the engine re-pushes it). The losing payload is archived to `sync_conflicts` **only when the local row had an unpushed edit** — i.e. a real concurrent conflict — so ordinary "receive an update" applies don't flood the archive.

## Two correctness guarantees (and why)
- **Parent updates don't delete children.** The generic upsert uses `INSERT … ON CONFLICT(id) DO UPDATE`, *not* `INSERT OR REPLACE`. REPLACE deletes the existing row, which would cascade-delete FK children (an episode's intensity readings) — and would also wipe device-local columns. ON CONFLICT updates in place. Tested: `testUpdatingParentPreservesChildren`.
- **Device-local columns survive.** `medication_schedules.notification_id` isn't in the payload, and the update set leaves it untouched. Tested: `testDeviceLocalColumnPreservedOnUpdate`.

Unknown remote columns (newer schema) are dropped rather than erroring — basic forward-compatible migrate-on-read. The archive + row change commit in one transaction.

## Known limitation (follow-up)
Conflict resolution keys on the primary key `id`. Tables with a secondary unique constraint (`daily_status_logs.date`, `category_safety_rules(category,type)`) can collide across devices on that natural key with different ids; the applier currently surfaces the constraint error rather than merging. The engine (3d) will quarantine/log; natural-key merge is a later refinement.

## Testing
10 applier tests: insert/skip/noop, LWW both directions, conflict archiving (local & remote losers), tombstone delete, cascade-preservation, device-local preservation, unknown-column drop.

## Roadmap (remaining)
- **3d** — `SyncEngine`: drain the pending queue → build records → `push`; `fetchChanges` → order batch (parents first) → `apply` each → persist token. Delete-payload capture (hard-delete + queue). Testable against the in-memory fake.
- **3e** — real `CKContainer`/`MigraLogZone` transport (device / `cktool`-verified).
- **4** — triggers, backup-before-first-sync, settings UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
