### PR TITLE
feat(ios): SyncEngine — push/pull orchestration (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
@@ -1,0 +1,129 @@
+import Foundation
+import GRDB
+
+/// Orchestrates one sync cycle for iCloud sync (#434): push the local change queue up,
+/// then pull remote changes down and apply them. It reaches CloudKit only through
+/// `CloudKitTransport`, so the whole flow is testable against an in-memory fake.
+///
+/// An `actor` so overlapping triggers (app foreground, after-write, background refresh)
+/// can't run two syncs at once and double-drain the queue.
+actor SyncEngine {
+    /// The single custom zone all records live in.
+    static let zoneName = "MigraLogZone"
+
+    private let transport: CloudKitTransport
+    private let dbManager: DatabaseManager
+    private let pendingStore: SyncPendingChangesStore
+    private let zoneStore: SyncZoneStateStore
+    private let applier: RemoteChangeApplier
+
+    init(
+        transport: CloudKitTransport,
+        dbManager: DatabaseManager,
+        pendingStore: SyncPendingChangesStore,
+        zoneStore: SyncZoneStateStore,
+        applier: RemoteChangeApplier
+    ) {
+        self.transport = transport
+        self.dbManager = dbManager
+        self.pendingStore = pendingStore
+        self.zoneStore = zoneStore
+        self.applier = applier
+    }
+
+    /// Full cycle: ensure the zone exists, push the outbound queue, then pull and apply
+    /// remote changes. Returns counts for observability and tests.
+    @discardableResult
+    func sync(now: Int64) async throws -> (pushed: Int, applied: Int) {
+        try await transport.ensureZone()
+        let pushed = try await push()
+        let applied = try await pull(now: now)
+        return (pushed, applied)
+    }
+
+    // MARK: - Push
+
+    /// Drain the pending-changes queue in batches, push each, and remove the
+    /// successfully-sent entries. Returns the number of changes pushed.
+    @discardableResult
+    func push(batchSize: Int = 100) async throws -> Int {
+        var total = 0
+        while true {
+            let pending = try pendingStore.fetchBatch(limit: batchSize)
+            if pending.isEmpty { break }
+
+            let records = try pending.compactMap { try buildRecord(for: $0) }
+            if !records.isEmpty {
+                try await transport.push(records)
+            }
+            try pendingStore.remove(ids: pending.map { $0.id })
+            total += pending.count
+
+            if pending.count < batchSize { break }
+        }
+        return total
+    }
+
+    /// Build the record to push for one queued change. An upsert reads the live row and
+    /// encodes it; a row that has vanished since enqueue becomes a tombstone. A delete is
+    /// a tombstone stamped with the enqueue time (≈ delete time) so last-write-wins on
+    /// the other device compares against a real timestamp.
+    private func buildRecord(for change: SyncPendingChange) throws -> SyncRecord? {
+        guard let table = SyncableTable.named(change.tableName) else { return nil }
+        let schemaVersion = DatabaseManager.schemaVersion
+
+        func tombstone() -> SyncRecord {
+            SyncRecord(
+                tableName: table.tableName, recordId: change.recordId, payload: "{}",
+                schemaVersion: schemaVersion, updatedAt: change.createdAt, deleted: true
+            )
+        }
+
+        if change.changeType == .delete {
+            return tombstone()
+        }
+
+        return try dbManager.dbQueue.read { db -> SyncRecord in
+            guard let row = try Row.fetchOne(
+                db,
+                sql: "SELECT * FROM \(table.tableName) WHERE \(table.primaryKeyColumn) = ?",
+                arguments: [change.recordId]
+            ) else {
+                return tombstone()
+            }
+            let payload = try SyncPayloadCodec.encodePayload(row: row, table: table)
+            let updatedAt = (row["updated_at"] as Int64?) ?? (row["created_at"] as Int64?) ?? change.createdAt
+            return SyncRecord(
+                tableName: table.tableName, recordId: change.recordId, payload: payload,
+                schemaVersion: schemaVersion, updatedAt: updatedAt, deleted: false
+            )
+        }
+    }
+
+    // MARK: - Pull
+
+    /// Fetch remote changes since the saved token, apply them parents-first, and persist
+    /// the new token. Returns the number of records applied.
+    @discardableResult
+    func pull(now: Int64) async throws -> Int {
+        var applied = 0
+        var token = try zoneStore.state(zoneName: Self.zoneName)?.serverChangeToken
+
+        while true {
+            let batch = try await transport.fetchChanges(since: token)
+            let ordered = batch.records.sorted { Self.applyRank($0) < Self.applyRank($1) }
+            for record in ordered {
+                _ = try applier.apply(record, now: now)
+                applied += 1
+            }
+            token = batch.newToken
+            try zoneStore.saveChangeToken(token, zoneName: Self.zoneName, syncedAt: now)
+            if !batch.moreComing { break }
+        }
+        return applied
+    }
+
+    private static func applyRank(_ record: SyncRecord) -> Int {
+        SyncableTable.named(record.tableName)?.applyPriority ?? Int.max
+    }
+}

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncableTable.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncableTable.swift
@@ -40,6 +40,18 @@ enum SyncableTable: String, CaseIterable, Sendable {
         }
     }
 
+    /// Relative apply order for pulled records: lower applies first. Parent tables
+    /// (those referenced by a foreign key) must land before their children so inserts
+    /// don't violate FK constraints. `episodes` and `medications` are the only parents.
+    var applyPriority: Int {
+        switch self {
+        case .episodes, .medications:
+            return 0
+        default:
+            return 1
+        }
+    }
+
     /// Look up a syncable table by its SQLite name. Returns nil for tables that are
     /// not synced (device-local or sync-internal).
     static func named(_ tableName: String) -> SyncableTable? {

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+import GRDB
+@testable import MigraLog
+
+final class SyncEngineTests: XCTestCase {
+    var dbManager: DatabaseManager!
+    var transport: InMemoryCloudKitTransport!
+    var pendingStore: SyncPendingChangesStore!
+    var zoneStore: SyncZoneStateStore!
+    var engine: SyncEngine!
+
+    override func setUpWithError() throws {
+        dbManager = try DatabaseManager(inMemory: true)
+        transport = InMemoryCloudKitTransport()
+        pendingStore = SyncPendingChangesStore(dbManager: dbManager)
+        zoneStore = SyncZoneStateStore(dbManager: dbManager)
+        engine = SyncEngine(
+            transport: transport, dbManager: dbManager,
+            pendingStore: pendingStore, zoneStore: zoneStore,
+            applier: RemoteChangeApplier(dbManager: dbManager)
+        )
+    }
+
+    override func tearDownWithError() throws {
+        engine = nil
+        zoneStore = nil
+        pendingStore = nil
+        transport = nil
+        dbManager = nil
+    }
+
+    // MARK: - Helpers
+
+    private func insertMedication(_ id: String, name: String, updatedAt: Int64) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, created_at, updated_at)
+                    VALUES (?, ?, 'rescue', 1, 'mg', 1000, ?)
+                    """,
+                arguments: [id, name, updatedAt]
+            )
+        }
+    }
+
+    private func payload(_ columns: [String: (any DatabaseValueConvertible)?]) -> String {
+        (try? SyncPayloadCodec.encodePayload(row: Row(columns), table: .episodes)) ?? "{}"
+    }
+
+    private func remoteMedication(_ id: String, name: String, updatedAt: Int64) -> SyncRecord {
+        SyncRecord(
+            tableName: "medications", recordId: id,
+            payload: payload([
+                "id": id, "name": name, "type": "rescue", "dosage_amount": 1.0,
+                "dosage_unit": "mg", "active": Int64(1), "created_at": Int64(1000), "updated_at": updatedAt,
+            ]),
+            schemaVersion: 31, updatedAt: updatedAt, deleted: false
+        )
+    }
+
+    private func medicationName(_ id: String) throws -> String? {
+        try dbManager.dbQueue.read { db in
+            try String.fetchOne(db, sql: "SELECT name FROM medications WHERE id = ?", arguments: [id])
+        }
+    }
+
+    // MARK: - Push
+
+    func testPushUpsertSendsEncodedRow() async throws {
+        try insertMedication("m1", name: "Sumatriptan", updatedAt: 1500)
+        try pendingStore.enqueue(tableName: "medications", recordId: "m1", changeType: .upsert, at: 1500)
+
+        let pushed = try await engine.push()
+        XCTAssertEqual(pushed, 1)
+
+        let record = transport.record(named: "medications:m1")
+        XCTAssertNotNil(record)
+        XCTAssertEqual(record?.deleted, false)
+        XCTAssertEqual(record?.updatedAt, 1500)
+        XCTAssertEqual(record?.payload.contains("Sumatriptan"), true)
+        XCTAssertEqual(try pendingStore.pendingCount(), 0, "queue drained after push")
+    }
+
+    func testPushDeleteSendsTombstone() async throws {
+        try pendingStore.enqueue(tableName: "medications", recordId: "gone", changeType: .delete, at: 2000)
+
+        _ = try await engine.push()
+        let record = transport.record(named: "medications:gone")
+        XCTAssertEqual(record?.deleted, true)
+        XCTAssertEqual(record?.updatedAt, 2000)
+        XCTAssertEqual(try pendingStore.pendingCount(), 0)
+    }
+
+    // MARK: - Pull
+
+    func testPullAppliesRemoteRecordAndSavesToken() async throws {
+        try await transport.push([remoteMedication("m9", name: "Remote", updatedAt: 2000)])
+
+        let applied = try await engine.pull(now: 10)
+        XCTAssertEqual(applied, 1)
+        XCTAssertEqual(try medicationName("m9"), "Remote")
+        XCTAssertNotNil(try zoneStore.state(zoneName: SyncEngine.zoneName)?.serverChangeToken)
+    }
+
+    /// The engine must apply parent tables before children, even when the batch arrives
+    /// child-first, or the child's FK insert fails.
+    func testPullAppliesParentsBeforeChildren() async throws {
+        let reading = SyncRecord(
+            tableName: "intensity_readings", recordId: "ir1",
+            payload: payload([
+                "id": "ir1", "episode_id": "e1", "timestamp": Int64(1000), "intensity": 5.0,
+                "created_at": Int64(1000), "updated_at": Int64(1000),
+            ]),
+            schemaVersion: 31, updatedAt: 1000, deleted: false
+        )
+        let episode = SyncRecord(
+            tableName: "episodes", recordId: "e1",
+            payload: payload([
+                "id": "e1", "start_time": Int64(1000), "locations": "[]", "qualities": "[]",
+                "symptoms": "[]", "triggers": "[]", "created_at": Int64(1000), "updated_at": Int64(1000),
+            ]),
+            schemaVersion: 31, updatedAt: 1000, deleted: false
+        )
+        // Child pushed before parent.
+        try await transport.push([reading])
+        try await transport.push([episode])
+
+        let applied = try await engine.pull(now: 10)
+        XCTAssertEqual(applied, 2)
+        let childCount = try await dbManager.dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM intensity_readings WHERE id = 'ir1'")
+        }
+        XCTAssertEqual(childCount, 1, "child applied after parent, no FK error")
+    }
+
+    func testPullIsIncremental() async throws {
+        try await transport.push([remoteMedication("m1", name: "X", updatedAt: 1000)])
+        _ = try await engine.pull(now: 10)
+        let secondApplied = try await engine.pull(now: 20)
+        XCTAssertEqual(secondApplied, 0, "nothing new since the saved token")
+    }
+
+    // MARK: - Full cycle
+
+    func testSyncEnsuresZonePushesAndPulls() async throws {
+        try insertMedication("m1", name: "Local", updatedAt: 1000)
+        try pendingStore.enqueue(tableName: "medications", recordId: "m1", changeType: .upsert, at: 1000)
+
+        let result = try await engine.sync(now: 10)
+        XCTAssertTrue(transport.zoneCreated)
+        XCTAssertEqual(result.pushed, 1)
+        XCTAssertGreaterThanOrEqual(result.applied, 1, "the pushed record echoes back and applies idempotently")
+        XCTAssertEqual(try medicationName("m1"), "Local")
+    }
+}


### PR DESCRIPTION
## Summary
**SyncService slice 3d** for iCloud sync (#434): the `SyncEngine` that drives a sync cycle — push the local queue up, pull remote changes down. Reaches CloudKit only through `CloudKitTransport`, so the entire flow is unit-tested against the in-memory fake. Builds on #445–#449.

## What's here
- **`SyncEngine`** (an `actor`, so overlapping triggers — foreground, after-write, background refresh — can't run two syncs and double-drain the queue):
  - **push** — drain the pending queue in batches; build a `SyncRecord` per change (upsert reads the live row + codec; delete → tombstone stamped with the enqueue time so LWW has a real timestamp; a row that vanished since enqueue → tombstone); push; remove sent entries.
  - **pull** — `fetchChanges` since the saved token, apply records **parents-first**, persist the new token, loop while `moreComing`.
  - **sync** — `ensureZone` + push + pull.
- **`SyncableTable.applyPriority`** — `episodes`/`medications` (the only FK parents) apply before their children, so a child's FK insert never precedes its parent within a batch.

## Testing
6 async tests against the fake transport + in-memory DB: push encodes upserts and sends delete tombstones (queue drained); pull applies + saves the token, orders parents before children (FK-safe), and is incremental (nothing re-applied past the token); full `sync` ensures the zone and round-trips.

## Roadmap (remaining)
- **3e** — change-capture: `AFTER INSERT/UPDATE/DELETE` triggers on the 11 synced tables enqueue to `sync_pending_changes` (DELETE captures the payload), with echo-suppression so the applier's own writes don't re-enqueue. This is what finally *populates* the queue from local edits.
- **3f** — the real `CKContainer`/`MigraLogZone` `CloudKitTransport` (compiles + CI-builds, but needs device / `cktool` to verify the actual round-trip).
- **4** — wire `sync()` to triggers, backup-before-first-sync, settings UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
