### PR TITLE
feat(ios): real CloudKit transport — UNVERIFIED, needs device (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/Sync/CloudKitSyncTransport.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/CloudKitSyncTransport.swift
@@ -1,0 +1,103 @@
+import CloudKit
+import Foundation
+
+/// The real `CloudKitTransport` over the user's private CloudKit database (#434).
+/// A dumb pipe: it maps `SyncRecord` ↔ `CKRecord`, force-overwrites on push (the
+/// client has already resolved last-write-wins), and pages changes via the zone's
+/// server change token. All record interpretation stays client-side.
+///
+/// ⚠️ UNVERIFIED: this compiles and CI builds it, but the actual CloudKit round-trip
+/// cannot be exercised in CI or the simulator — it needs a device signed into iCloud
+/// with the schema deployed. Device-verify before enabling sync. See the PR for the
+/// data-loss-sensitive items to confirm (push/pull ordering, superseded pending
+/// changes, partial-failure handling).
+final class CloudKitSyncTransport: CloudKitTransport, @unchecked Sendable {
+    static let recordType = "SyncRecord"
+
+    private let database: CKDatabase
+    private let zoneID: CKRecordZone.ID
+
+    init(containerIdentifier: String = "iCloud.com.eff3.migralog") {
+        let container = CKContainer(identifier: containerIdentifier)
+        self.database = container.privateCloudDatabase
+        self.zoneID = CKRecordZone.ID(zoneName: SyncEngine.zoneName, ownerName: CKCurrentUserDefaultName)
+    }
+
+    /// Create the custom zone if it doesn't exist. Saving an existing zone is a no-op,
+    /// so this is idempotent.
+    func ensureZone() async throws {
+        let zone = CKRecordZone(zoneID: zoneID)
+        _ = try await database.modifyRecordZones(saving: [zone], deleting: [])
+    }
+
+    /// Save records (upserts and tombstones) to the zone. Uses `.allKeys` so our
+    /// already-resolved version overwrites the server's regardless of change tag, and
+    /// `atomically: true` so a partial failure throws (the engine keeps the queue and
+    /// retries) rather than silently dropping changes.
+    func push(_ records: [SyncRecord]) async throws {
+        guard !records.isEmpty else { return }
+        let ckRecords = records.map { makeCKRecord(from: $0) }
+        _ = try await database.modifyRecords(
+            saving: ckRecords, deleting: [], savePolicy: .allKeys, atomically: true
+        )
+    }
+
+    /// Fetch changes since `token` (nil for a first full sync), mapping each changed
+    /// `CKRecord` back to a `SyncRecord`. Deletions of CKRecords are ignored — our model
+    /// propagates deletes as tombstone records, not by removing CKRecords.
+    func fetchChanges(since token: Data?) async throws -> SyncChangeBatch {
+        let changeToken = try Self.decodeToken(token)
+        let change = try await database.recordZoneChanges(inZoneWith: zoneID, since: changeToken)
+
+        let records: [SyncRecord] = change.modificationResultsByID.values.compactMap { result in
+            guard case .success(let modification) = result else { return nil }
+            return Self.makeSyncRecord(from: modification.record)
+        }
+        return SyncChangeBatch(
+            records: records,
+            newToken: try Self.encodeToken(change.changeToken),
+            moreComing: change.moreComing
+        )
+    }
+
+    // MARK: - Record mapping
+
+    private func makeCKRecord(from record: SyncRecord) -> CKRecord {
+        let recordID = CKRecord.ID(recordName: record.recordName, zoneID: zoneID)
+        let ckRecord = CKRecord(recordType: Self.recordType, recordID: recordID)
+        ckRecord["tableName"] = record.tableName
+        ckRecord["recordId"] = record.recordId
+        ckRecord["payload"] = record.payload
+        ckRecord["schemaVersion"] = Int64(record.schemaVersion)
+        ckRecord["updatedAt"] = record.updatedAt
+        ckRecord["deleted"] = Int64(record.deleted ? 1 : 0)
+        return ckRecord
+    }
+
+    private static func makeSyncRecord(from ckRecord: CKRecord) -> SyncRecord? {
+        guard let tableName = ckRecord["tableName"] as? String,
+              let recordId = ckRecord["recordId"] as? String,
+              let payload = ckRecord["payload"] as? String,
+              let schemaVersion = ckRecord["schemaVersion"] as? Int64,
+              let updatedAt = ckRecord["updatedAt"] as? Int64 else {
+            return nil
+        }
+        let deleted = (ckRecord["deleted"] as? Int64 ?? 0) == 1
+        return SyncRecord(
+            tableName: tableName, recordId: recordId, payload: payload,
+            schemaVersion: Int(schemaVersion), updatedAt: updatedAt, deleted: deleted
+        )
+    }
+
+    // MARK: - Change token (NSSecureCoding ↔ Data)
+
+    private static func encodeToken(_ token: CKServerChangeToken?) throws -> Data? {
+        guard let token else { return nil }
+        return try NSKeyedArchiver.archivedData(withRootObject: token, requiringSecureCoding: true)
+    }
+
+    private static func decodeToken(_ data: Data?) throws -> CKServerChangeToken? {
+        guard let data else { return nil }
+        return try NSKeyedUnarchiver.unarchivedObject(ofClass: CKServerChangeToken.self, from: data)
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Settings/DeveloperToolsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DeveloperToolsScreen.swift
@@ -36,6 +36,16 @@ struct DeveloperToolsScreen: View {
                 }
             }
 
+            #if DEBUG
+            Section("iCloud Sync (#434)") {
+                NavigationLink {
+                    SyncTestScreen()
+                } label: {
+                    Label("Sync Test", systemImage: "arrow.triangle.2.circlepath.icloud")
+                }
+            }
+            #endif
+
             Section("Onboarding") {
                 Button("Reset Onboarding") {
                     appState.resetOnboarding()
@@ -79,4 +89,3 @@ struct ErrorLogsScreen: View {
         .navigationTitle("Error Logs")
     }
 }
-

--- a/mobile-apps/ios/MigraLog/Views/Settings/DeveloperToolsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DeveloperToolsScreen.swift
@@ -36,7 +36,6 @@ struct DeveloperToolsScreen: View {
                 }
             }
 
-            #if DEBUG
             Section("iCloud Sync (#434)") {
                 NavigationLink {
                     SyncTestScreen()
@@ -44,7 +43,6 @@ struct DeveloperToolsScreen: View {
                     Label("Sync Test", systemImage: "arrow.triangle.2.circlepath.icloud")
                 }
             }
-            #endif
 
             Section("Onboarding") {
                 Button("Reset Onboarding") {

--- a/mobile-apps/ios/MigraLog/Views/Settings/SyncTestScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/SyncTestScreen.swift
@@ -1,0 +1,152 @@
+#if DEBUG
+import CloudKit
+import GRDB
+import SwiftUI
+
+/// DEBUG-only manual harness for exercising the real CloudKit transport (#434) on a
+/// device, before sync is wired into the app. Lets you enable change-capture, make a
+/// test edit, and run a full sync cycle by hand, then watch the result. Runs against
+/// CloudKit's Development environment (local Xcode builds) — isolated from the
+/// Production data a TestFlight build uses. Never compiled into release builds.
+struct SyncTestScreen: View {
+    @State private var captureEnabled = false
+    @State private var accountStatus = "—"
+    @State private var pendingCount = 0
+    @State private var isSyncing = false
+    @State private var log: [String] = []
+
+    private let db = DatabaseManager.shared
+    private let containerID = "iCloud.com.eff3.migralog"
+
+    var body: some View {
+        List {
+            Section("CloudKit") {
+                LabeledContent("Account", value: accountStatus)
+                LabeledContent("Pending changes", value: "\(pendingCount)")
+                Button("Refresh") { Task { await refresh() } }
+            }
+
+            Section("Capture") {
+                Toggle("Capture local edits", isOn: $captureEnabled)
+                    .onChange(of: captureEnabled) { _, on in setCapture(on) }
+                Text("Off by default. Turn on so edits get queued into sync_pending_changes.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
+            Section("Actions") {
+                Button("Insert test medication") { insertTestMedication() }
+                Button(isSyncing ? "Syncing…" : "Sync now") { Task { await syncNow() } }
+                    .disabled(isSyncing)
+                Text("On device A: enable capture, insert a test med, Sync now. "
+                    + "On device B: Sync now, then check Medications.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
+            Section("Log") {
+                if log.isEmpty {
+                    Text("No activity yet").foregroundStyle(.secondary)
+                } else {
+                    ForEach(Array(log.enumerated()), id: \.offset) { _, line in
+                        Text(line).font(.caption.monospaced())
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Sync Test")
+        .task { await refresh() }
+    }
+
+    // MARK: - Status
+
+    private func refresh() async {
+        do {
+            let status = try await CKContainer(identifier: containerID).accountStatus()
+            accountStatus = Self.describe(status)
+        } catch {
+            accountStatus = "error: \(error.localizedDescription)"
+        }
+        pendingCount = (try? await db.dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM sync_pending_changes") ?? 0
+        }) ?? -1
+        captureEnabled = ((try? await db.dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT enabled FROM sync_capture_state WHERE id = 1")
+        }) ?? 0) == 1
+    }
+
+    // MARK: - Actions
+
+    private func setCapture(_ on: Bool) {
+        do {
+            try db.dbQueue.write { db in
+                try db.execute(sql: "UPDATE sync_capture_state SET enabled = ? WHERE id = 1", arguments: [on ? 1 : 0])
+            }
+            append("capture \(on ? "enabled" : "disabled")")
+        } catch {
+            append("capture toggle failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func insertTestMedication() {
+        let id = UUID().uuidString
+        let shortName = "SyncTest-\(id.prefix(8))"
+        let now = Self.nowMillis()
+        do {
+            try db.dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                        INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, created_at, updated_at)
+                        VALUES (?, ?, 'rescue', 1, 'mg', ?, ?)
+                        """,
+                    arguments: [id, shortName, now, now]
+                )
+            }
+            append("inserted \(shortName)")
+        } catch {
+            append("insert failed: \(error.localizedDescription)")
+        }
+        Task { await refresh() }
+    }
+
+    private func syncNow() async {
+        isSyncing = true
+        defer { isSyncing = false }
+        let engine = SyncEngine(
+            transport: CloudKitSyncTransport(containerIdentifier: containerID),
+            dbManager: db,
+            pendingStore: SyncPendingChangesStore(dbManager: db),
+            zoneStore: SyncZoneStateStore(dbManager: db),
+            applier: RemoteChangeApplier(dbManager: db)
+        )
+        do {
+            let result = try await engine.sync(now: Self.nowMillis())
+            append("sync ok — pushed \(result.pushed), applied \(result.applied)")
+        } catch {
+            append("sync failed: \(error.localizedDescription)")
+        }
+        await refresh()
+    }
+
+    // MARK: - Helpers
+
+    private func append(_ line: String) {
+        log.insert(line, at: 0)
+        if log.count > 50 { log.removeLast() }
+    }
+
+    private static func nowMillis() -> Int64 {
+        Int64(Date().timeIntervalSince1970 * 1000)
+    }
+
+    private static func describe(_ status: CKAccountStatus) -> String {
+        switch status {
+        case .available: return "available"
+        case .noAccount: return "no iCloud account"
+        case .restricted: return "restricted"
+        case .couldNotDetermine: return "could not determine"
+        case .temporarilyUnavailable: return "temporarily unavailable"
+        @unknown default: return "unknown"
+        }
+    }
+}
+#endif

--- a/mobile-apps/ios/MigraLog/Views/Settings/SyncTestScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/SyncTestScreen.swift
@@ -1,13 +1,15 @@
-#if DEBUG
 import CloudKit
 import GRDB
 import SwiftUI
 
-/// DEBUG-only manual harness for exercising the real CloudKit transport (#434) on a
-/// device, before sync is wired into the app. Lets you enable change-capture, make a
-/// test edit, and run a full sync cycle by hand, then watch the result. Runs against
-/// CloudKit's Development environment (local Xcode builds) — isolated from the
-/// Production data a TestFlight build uses. Never compiled into release builds.
+/// Manual harness for exercising the real CloudKit transport (#434) on-device before
+/// sync is wired into the app. Lets you enable change-capture, make a test edit, and
+/// run a full sync cycle by hand, then watch the result. Lives under Developer Tools.
+///
+/// Included in Release (not `#if DEBUG`) so sync can be verified on TestFlight, which
+/// uses the CloudKit Production environment — Production schema must be deployed first.
+/// Local Xcode builds use the Development environment instead. Remove or gate this once
+/// real auto-sync ships.
 struct SyncTestScreen: View {
     @State private var captureEnabled = false
     @State private var accountStatus = "—"
@@ -149,4 +151,3 @@ struct SyncTestScreen: View {
         }
     }
 }
-#endif


### PR DESCRIPTION
## Summary
The production **`CloudKitTransport`** over the user's private CloudKit database (#434) — a dumb pipe that maps `SyncRecord` ↔ `CKRecord`, force-overwrites on push, and pages changes via the zone server change token. This is the end of the autonomously-buildable road.

## ⚠️ Status: COMPILE-VERIFIED ONLY
This **compiles and CI builds it**, but the actual CloudKit round-trip **cannot be exercised in CI or the simulator** — it needs a device signed into iCloud with the schema deployed. **Do not enable sync until this is device-verified.** The transport code is a straightforward dumb pipe; the risk is in the *system* correctness below, which is data-loss-sensitive and untestable here.

## What's here
- `ensureZone` — `modifyRecordZones(saving:)`, idempotent.
- `push` — `modifyRecords(savePolicy: .allKeys, atomically: true)`. `.allKeys` because the client already resolved LWW, so our version overwrites; `atomically` so a partial failure throws and the engine keeps the queue and retries (rather than silently dropping).
- `fetchChanges` — `recordZoneChanges(inZoneWith:since:)`, maps changed records back to `SyncRecord`, returns the new token + `moreComing`.
- `SyncRecord` ↔ `CKRecord` mapping and `CKServerChangeToken` ↔ `Data` archiving.

## 🔴 Must resolve during device verification (data-loss-sensitive)
1. **Push/pull ordering.** `SyncEngine.sync()` currently does **push-then-pull**. With force-overwrite push, pushing a local edit *before* pulling can overwrite a newer remote version we haven't seen → data loss. **Recommend switching to pull-then-push.**
2. **Drop superseded pending changes.** When a pull applies a remote version that beats a locally-*pending* edit (`appliedRemoteWin` with a queued change), that pending entry must be removed — otherwise the next push sends the stale local version and clobbers the winner. Not yet wired.
3. **Account-state precondition.** Check `CKAccountStatus`/availability before syncing; handle "not signed in" / account-changed gracefully.
4. **CKError handling.** Zone-not-found (recreate), quota, throttling/retry-after, change-token-expired (reset + full re-pull). The atomic push throws on partial failure — decide the retry policy.

## Testing
Compile + link only (`BUILD SUCCEEDED`), SwiftLint clean. No unit tests — the type can't be meaningfully exercised without iCloud. Everything *behind* this seam is unit-tested via the in-memory fake (#447–#451).

## Remaining (all needs you)
- Device-verify this transport + resolve the 🔴 items above.
- Deploy schema to **Production** (irreversible) for a sync-enabled TestFlight build.
- Slice 4: wire `SyncEngine.sync()` to foreground/after-write/background-refresh, flip the `enabled` capture flag, backup-before-first-sync, settings UI (+ local UI tests).
- Deferred refinement: delete-payload capture (tombstones currently `{}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
