### PR TITLE
feat(ios): backfill existing rows into the sync queue (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncPendingChangesStore.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncPendingChangesStore.swift
@@ -52,6 +52,36 @@ final class SyncPendingChangesStore: Sendable {
         }
     }
 
+    /// Enqueue an `upsert` for every existing row in the synced tables, so the first
+    /// sync after enabling pushes the device's current data (the capture triggers only
+    /// fire on *new* edits, so existing rows would otherwise never sync). Rows already
+    /// queued are left as-is (`ON CONFLICT DO NOTHING`) — a pending delete is not
+    /// downgraded to an upsert — so this is safe to call repeatedly. The queued
+    /// `created_at` is only a fallback; the engine stamps each pushed record with the
+    /// row's real `updated_at` at push time, so backfilled data keeps its true LWW
+    /// timestamp. Returns the number of rows enqueued.
+    @discardableResult
+    func backfillExistingRows(at now: Int64) throws -> Int {
+        try dbManager.dbQueue.write { db in
+            var enqueued = 0
+            for table in SyncableTable.allCases {
+                try db.execute(
+                    sql: """
+                        INSERT INTO sync_pending_changes
+                            (table_name, record_id, change_type, created_at, retry_count, last_error)
+                        SELECT '\(table.tableName)', \(table.primaryKeyColumn), 'upsert', ?, 0, NULL
+                        FROM \(table.tableName)
+                        WHERE true
+                        ON CONFLICT(table_name, record_id) DO NOTHING
+                        """,
+                    arguments: [now]
+                )
+                enqueued += db.changesCount
+            }
+            return enqueued
+        }
+    }
+
     /// Oldest-first batch of pending changes, up to `limit`.
     func fetchBatch(limit: Int) throws -> [SyncPendingChange] {
         try dbManager.dbQueue.read { db in

--- a/mobile-apps/ios/MigraLog/Views/Settings/SyncTestScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/SyncTestScreen.swift
@@ -37,10 +37,11 @@ struct SyncTestScreen: View {
 
             Section("Actions") {
                 Button("Insert test medication") { insertTestMedication() }
+                Button("Backfill existing data") { backfillExistingData() }
                 Button(isSyncing ? "Syncing…" : "Sync now") { Task { await syncNow() } }
                     .disabled(isSyncing)
-                Text("On device A: enable capture, insert a test med, Sync now. "
-                    + "On device B: Sync now, then check Medications.")
+                Text("On device A: enable capture, Backfill existing data, Sync now. "
+                    + "On device B: Sync now, then check your data.")
                     .font(.caption).foregroundStyle(.secondary)
             }
 
@@ -106,6 +107,16 @@ struct SyncTestScreen: View {
             append("inserted \(shortName)")
         } catch {
             append("insert failed: \(error.localizedDescription)")
+        }
+        Task { await refresh() }
+    }
+
+    private func backfillExistingData() {
+        do {
+            let count = try SyncPendingChangesStore(dbManager: db).backfillExistingRows(at: Self.nowMillis())
+            append("backfilled \(count) existing rows")
+        } catch {
+            append("backfill failed: \(error.localizedDescription)")
         }
         Task { await refresh() }
     }

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncPendingChangesStoreTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncPendingChangesStoreTests.swift
@@ -86,4 +86,64 @@ final class SyncPendingChangesStoreTests: XCTestCase {
         XCTAssertEqual(try store.fetchBatch(limit: 3).count, 3)
         XCTAssertEqual(try store.pendingCount(), 5)
     }
+
+    // MARK: - Backfill
+
+    private func insertMedication(_ id: String) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, created_at, updated_at)
+                    VALUES (?, 'Med', 'rescue', 1, 'mg', 1000, 1000)
+                    """,
+                arguments: [id]
+            )
+        }
+    }
+
+    private func insertEpisode(_ id: String) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO episodes
+                        (id, start_time, locations, qualities, symptoms, triggers, created_at, updated_at)
+                    VALUES (?, 1000, '[]', '[]', '[]', '[]', 1000, 1000)
+                    """,
+                arguments: [id]
+            )
+        }
+    }
+
+    func testBackfillEnqueuesAllExistingRows() throws {
+        try insertMedication("m1")
+        try insertMedication("m2")
+        try insertEpisode("e1")
+
+        let count = try store.backfillExistingRows(at: 9000)
+        XCTAssertEqual(count, 3)
+        XCTAssertEqual(try store.pendingCount(), 3)
+        XCTAssertTrue(try store.fetchBatch(limit: 10).allSatisfy { $0.changeType == .upsert })
+    }
+
+    func testBackfillDoesNotDowngradeAPendingDelete() throws {
+        try insertMedication("m1")
+        try insertMedication("m2")
+        // m1 already has a pending delete (it was removed locally before the backfill).
+        try store.enqueue(tableName: "medications", recordId: "m1", changeType: .delete, at: 500)
+
+        let count = try store.backfillExistingRows(at: 9000)
+        XCTAssertEqual(count, 1, "only m2 is newly enqueued; m1 is already queued")
+
+        let pairs = try store.fetchBatch(limit: 10).map { ($0.recordId, $0.changeType) }
+        let byId = Dictionary(uniqueKeysWithValues: pairs)
+        XCTAssertEqual(byId["m1"], .delete, "the pending delete is preserved, not downgraded to upsert")
+        XCTAssertEqual(byId["m2"], .upsert)
+    }
+
+    func testBackfillIsIdempotent() throws {
+        try insertMedication("m1")
+        XCTAssertEqual(try store.backfillExistingRows(at: 9000), 1)
+        XCTAssertEqual(try store.backfillExistingRows(at: 9001), 0, "already-queued rows are not re-enqueued")
+        XCTAssertEqual(try store.pendingCount(), 1)
+    }
 }


### PR DESCRIPTION
## Summary
The missing piece for first-time sync: a **backfill** so a user's existing on-device history actually gets pushed when they turn sync on. The capture triggers (#451) only fire on *new* edits, so without this, enabling sync would only ever carry future changes and leave the entire back-catalogue un-synced.

## What's here
- **`SyncPendingChangesStore.backfillExistingRows(at:)`** — one `INSERT…SELECT` per synced table that enqueues an `upsert` for every existing row.
  - `WHERE true` so SQLite doesn't misparse the trailing `ON CONFLICT` as a join's `ON` clause (it does, otherwise — found via a failing test).
  - `ON CONFLICT(table_name, record_id) DO NOTHING` so a row already queued (e.g. a pending **delete**) is preserved, not downgraded to an upsert.
  - Idempotent; returns the number of rows enqueued.
  - **LWW stays honest:** backfilled records carry each row's real `updated_at` (stamped by `buildRecord` at push time), *not* the backfill timestamp — so backfilled data won't masquerade as "newest" and clobber genuinely-newer data in a future merge.
- **Harness:** a "Backfill existing data" button in Developer Tools → Sync Test, so you can push a populated device's data during TestFlight verification.

## Testing
3 store tests: enqueues every row as `upsert`; preserves a pending delete (no downgrade); idempotent (re-run enqueues 0). Full store suite green (10).

## How it fits
This is the reusable primitive the real first-enable flow (slice 4) will call once — under backup-before-first-sync, gated by `sync_config` so it runs a single time. For now it's exercised manually via the harness.

> Note: `updated_at` isn't yet maintained by all write paths (the v29 columns are still nullable), so backfilled rows fall back to `created_at` for their LWW timestamp where `updated_at` is null — fine for verification; tightening write paths to stamp `updated_at` is a slice-4 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)