### PR TITLE
fix(ios): sync pull-then-push + drop superseded pending changes (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
@@ -31,13 +31,17 @@ actor SyncEngine {
         self.applier = applier
     }
 
-    /// Full cycle: ensure the zone exists, push the outbound queue, then pull and apply
-    /// remote changes. Returns counts for observability and tests.
+    /// Full cycle: ensure the zone exists, pull and apply remote changes, then push the
+    /// outbound queue. Returns counts for observability and tests.
     @discardableResult
     func sync(now: Int64) async throws -> (pushed: Int, applied: Int) {
         try await transport.ensureZone()
-        let pushed = try await push()
+        // Pull before push: apply remote changes (LWW) first, so a locally-queued edit
+        // that lost to a newer remote version is dropped during pull rather than pushed
+        // and clobbering the winner. Push-then-pull would force-overwrite the newer
+        // remote record with our stale local one.
         let applied = try await pull(now: now)
+        let pushed = try await push()
         return (pushed, applied)
     }
 
@@ -113,7 +117,13 @@ actor SyncEngine {
             let batch = try await transport.fetchChanges(since: token)
             let ordered = batch.records.sorted { Self.applyRank($0) < Self.applyRank($1) }
             for record in ordered {
-                _ = try applier.apply(record, now: now)
+                let outcome = try applier.apply(record, now: now)
+                // A remote change that won last-write-wins supersedes any locally-queued
+                // edit for the same row — drop it so push doesn't send the now-stale local
+                // version back and clobber the winner.
+                if outcome == .appliedRemoteWin {
+                    try pendingStore.removePending(tableName: record.tableName, recordId: record.recordId)
+                }
                 applied += 1
             }
             token = batch.newToken

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncPendingChangesStore.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncPendingChangesStore.swift
@@ -105,6 +105,17 @@ final class SyncPendingChangesStore: Sendable {
         }
     }
 
+    /// Remove any pending change for a specific row. Used when an incoming remote change
+    /// supersedes a locally-queued edit, so the now-stale local version isn't pushed.
+    func removePending(tableName: String, recordId: String) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: "DELETE FROM sync_pending_changes WHERE table_name = ? AND record_id = ?",
+                arguments: [tableName, recordId]
+            )
+        }
+    }
+
     /// Remove changes that were successfully pushed.
     func remove(ids: [Int64]) throws {
         guard !ids.isEmpty else { return }

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
@@ -149,7 +149,40 @@ final class SyncEngineTests: XCTestCase {
         let result = try await engine.sync(now: 10)
         XCTAssertTrue(transport.zoneCreated)
         XCTAssertEqual(result.pushed, 1)
-        XCTAssertGreaterThanOrEqual(result.applied, 1, "the pushed record echoes back and applies idempotently")
+        XCTAssertEqual(result.applied, 0, "pull runs before push, so our own push isn't echoed back this cycle")
         XCTAssertEqual(try medicationName("m1"), "Local")
+        XCTAssertNotNil(transport.record(named: "medications:m1"), "local change was pushed")
+    }
+
+    /// Pull-then-push: a locally-queued edit that lost to a newer remote version must be
+    /// dropped during pull, not pushed back over the winner.
+    func testSyncDoesNotClobberNewerRemoteWithStaleLocalEdit() async throws {
+        try insertMedication("m1", name: "Local", updatedAt: 1000)
+        try pendingStore.enqueue(tableName: "medications", recordId: "m1", changeType: .upsert, at: 1000)
+        try await transport.push([remoteMedication("m1", name: "Remote", updatedAt: 2000)])
+
+        _ = try await engine.sync(now: 10)
+
+        XCTAssertEqual(try medicationName("m1"), "Remote", "newer remote applied locally")
+        let stored = transport.record(named: "medications:m1")
+        XCTAssertEqual(stored?.updatedAt, 2000, "remote winner not overwritten by the stale local push")
+        XCTAssertEqual(stored?.payload.contains("Remote"), true)
+        XCTAssertEqual(try pendingStore.pendingCount(), 0, "superseded local edit was dropped")
+    }
+
+    /// The mirror case: a locally-queued edit that beats the remote version is kept and
+    /// pushed over it.
+    func testSyncPushesLocalWinnerOverOlderRemote() async throws {
+        try insertMedication("m1", name: "Local", updatedAt: 2000)
+        try pendingStore.enqueue(tableName: "medications", recordId: "m1", changeType: .upsert, at: 2000)
+        try await transport.push([remoteMedication("m1", name: "Remote", updatedAt: 1000)])
+
+        _ = try await engine.sync(now: 10)
+
+        XCTAssertEqual(try medicationName("m1"), "Local", "local winner kept")
+        let stored = transport.record(named: "medications:m1")
+        XCTAssertEqual(stored?.updatedAt, 2000, "local winner pushed over the older remote")
+        XCTAssertEqual(stored?.payload.contains("Local"), true)
+        XCTAssertEqual(try pendingStore.pendingCount(), 0, "queue drained after push")
     }
 }

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncPendingChangesStoreTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncPendingChangesStoreTests.swift
@@ -87,6 +87,15 @@ final class SyncPendingChangesStoreTests: XCTestCase {
         XCTAssertEqual(try store.pendingCount(), 5)
     }
 
+    func testRemovePendingDeletesOnlyThatRow() throws {
+        try store.enqueue(tableName: "medications", recordId: "m1", changeType: .upsert, at: 1000)
+        try store.enqueue(tableName: "episodes", recordId: "e1", changeType: .upsert, at: 1000)
+
+        try store.removePending(tableName: "medications", recordId: "m1")
+
+        XCTAssertEqual(try store.fetchBatch(limit: 10).map { $0.recordId }, ["e1"])
+    }
+
     // MARK: - Backfill
 
     private func insertMedication(_ id: String) throws {


### PR DESCRIPTION
## Summary
**Slice 4 — correctness hardening (part 1 of the data-loss-sensitive items)**, now that the round-trip is device-verified. Fixes the clobber risk I flagged when the real transport landed.

The engine pushed *before* pulling. Combined with force-overwrite push (`.allKeys`), a locally-queued edit could overwrite a **newer** remote version the device hadn't pulled yet → lost data.

## Changes
- **`SyncEngine.sync()` now pulls before pushing.** Remote changes are applied (LWW) first, so anything that lost to a newer remote version is reconciled before we push.
- **Drop superseded pending changes.** During pull, when a remote change wins LWW (`appliedRemoteWin`), the engine removes any pending change for that row — so push doesn't send the now-stale local version back and clobber the winner (which the force-overwrite push would otherwise do, even across a concurrent edit).
- **`SyncPendingChangesStore.removePending(tableName:recordId:)`.**

## Testing
- `testSyncDoesNotClobberNewerRemoteWithStaleLocalEdit` — stale local edit no longer overwrites a newer remote record; its pending entry is dropped.
- `testSyncPushesLocalWinnerOverOlderRemote` — mirror case: a local winner is still kept and pushed over an older remote.
- `testRemovePendingDeletesOnlyThatRow` + updated full-cycle test (pull-then-push means our own push no longer echoes back the same cycle).
- Engine + store suites green (19).

## Still to harden (next sub-slices)
- `CKAccountStatus` precondition + CKError handling (zone-not-found recreate, change-token-expired reset + full re-pull) — mostly in the real transport.
- Residual concurrent-edit-during-sync race: full fix needs server-side conflict detection (`.ifServerRecordUnchanged` + merge) rather than force-overwrite. Documented for a later pass.

Then: auto-wiring (foreground / after-write / background) + the iCloud Sync settings UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)