### PR TITLE
feat(ios): sync account precondition + recoverable CKError handling (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/Sync/CloudKitSyncTransport.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/CloudKitSyncTransport.swift
@@ -14,20 +14,29 @@ import Foundation
 final class CloudKitSyncTransport: CloudKitTransport, @unchecked Sendable {
     static let recordType = "SyncRecord"
 
+    private let container: CKContainer
     private let database: CKDatabase
     private let zoneID: CKRecordZone.ID
 
     init(containerIdentifier: String = "iCloud.com.eff3.migralog") {
-        let container = CKContainer(identifier: containerIdentifier)
+        self.container = CKContainer(identifier: containerIdentifier)
         self.database = container.privateCloudDatabase
         self.zoneID = CKRecordZone.ID(zoneName: SyncEngine.zoneName, ownerName: CKCurrentUserDefaultName)
+    }
+
+    func accountAvailable() async throws -> Bool {
+        try await container.accountStatus() == .available
     }
 
     /// Create the custom zone if it doesn't exist. Saving an existing zone is a no-op,
     /// so this is idempotent.
     func ensureZone() async throws {
         let zone = CKRecordZone(zoneID: zoneID)
-        _ = try await database.modifyRecordZones(saving: [zone], deleting: [])
+        do {
+            _ = try await database.modifyRecordZones(saving: [zone], deleting: [])
+        } catch {
+            throw Self.mapError(error)
+        }
     }
 
     /// Save records (upserts and tombstones) to the zone. Uses `.allKeys` so our
@@ -37,9 +46,13 @@ final class CloudKitSyncTransport: CloudKitTransport, @unchecked Sendable {
     func push(_ records: [SyncRecord]) async throws {
         guard !records.isEmpty else { return }
         let ckRecords = records.map { makeCKRecord(from: $0) }
-        _ = try await database.modifyRecords(
-            saving: ckRecords, deleting: [], savePolicy: .allKeys, atomically: true
-        )
+        do {
+            _ = try await database.modifyRecords(
+                saving: ckRecords, deleting: [], savePolicy: .allKeys, atomically: true
+            )
+        } catch {
+            throw Self.mapError(error)
+        }
     }
 
     /// Fetch changes since `token` (nil for a first full sync), mapping each changed
@@ -47,17 +60,44 @@ final class CloudKitSyncTransport: CloudKitTransport, @unchecked Sendable {
     /// propagates deletes as tombstone records, not by removing CKRecords.
     func fetchChanges(since token: Data?) async throws -> SyncChangeBatch {
         let changeToken = try Self.decodeToken(token)
-        let change = try await database.recordZoneChanges(inZoneWith: zoneID, since: changeToken)
-
-        let records: [SyncRecord] = change.modificationResultsByID.values.compactMap { result in
-            guard case .success(let modification) = result else { return nil }
-            return Self.makeSyncRecord(from: modification.record)
+        do {
+            let change = try await database.recordZoneChanges(inZoneWith: zoneID, since: changeToken)
+            let records: [SyncRecord] = change.modificationResultsByID.values.compactMap { result in
+                guard case .success(let modification) = result else { return nil }
+                return Self.makeSyncRecord(from: modification.record)
+            }
+            return SyncChangeBatch(
+                records: records,
+                newToken: try Self.encodeToken(change.changeToken),
+                moreComing: change.moreComing
+            )
+        } catch {
+            throw Self.mapError(error)
         }
-        return SyncChangeBatch(
-            records: records,
-            newToken: try Self.encodeToken(change.changeToken),
-            moreComing: change.moreComing
-        )
+    }
+
+    // MARK: - Error mapping
+
+    /// Map CloudKit errors onto the engine-facing recoverable errors. Anything not
+    /// specifically recoverable propagates unchanged so the engine surfaces it.
+    private static func mapError(_ error: Error) -> Error {
+        guard let ckError = error as? CKError else { return error }
+        switch ckError.code {
+        case .zoneNotFound, .userDeletedZone:
+            return SyncTransportError.zoneNotFound
+        case .changeTokenExpired:
+            return SyncTransportError.changeTokenExpired
+        case .notAuthenticated:
+            return SyncTransportError.accountUnavailable
+        case .partialFailure:
+            let partials = ckError.partialErrorsByItemID?.values.compactMap { $0 as? CKError } ?? []
+            if partials.contains(where: { $0.code == .zoneNotFound || $0.code == .userDeletedZone }) {
+                return SyncTransportError.zoneNotFound
+            }
+            return error
+        default:
+            return error
+        }
     }
 
     // MARK: - Record mapping

--- a/mobile-apps/ios/MigraLog/Services/Sync/CloudKitTransport.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/CloudKitTransport.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+/// Recoverable conditions a transport can signal so the engine can react — retry,
+/// reset, or skip — instead of failing the whole sync. Implementations map their
+/// backend errors (e.g. `CKError`) onto these; the engine handles them generically.
+enum SyncTransportError: Error, Equatable {
+    /// No iCloud account is available — skip syncing.
+    case accountUnavailable
+    /// The custom zone is missing (e.g. the user deleted iCloud data) — recreate and retry.
+    case zoneNotFound
+    /// The saved server change token is no longer valid — discard it and re-pull fully.
+    case changeTokenExpired
+}
+
 /// A page of remote changes pulled from a CloudKit zone.
 struct SyncChangeBatch: Equatable, Sendable {
     /// Changed/created records since the supplied token, including tombstones
@@ -20,6 +32,10 @@ struct SyncChangeBatch: Equatable, Sendable {
 /// Implementations must be safe to call from a single sync task at a time; the engine
 /// serialises sync runs.
 protocol CloudKitTransport: Sendable {
+    /// Whether an iCloud account is currently available to sync with. The engine skips
+    /// syncing when this is false rather than failing on every CloudKit call.
+    func accountAvailable() async throws -> Bool
+
     /// Create the custom record zone if it does not already exist. Idempotent.
     func ensureZone() async throws
 

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
@@ -35,6 +35,9 @@ actor SyncEngine {
     /// outbound queue. Returns counts for observability and tests.
     @discardableResult
     func sync(now: Int64) async throws -> (pushed: Int, applied: Int) {
+        guard try await transport.accountAvailable() else {
+            throw SyncTransportError.accountUnavailable
+        }
         try await transport.ensureZone()
         // Pull before push: apply remote changes (LWW) first, so a locally-queued edit
         // that lost to a newer remote version is dropped during pull rather than pushed
@@ -58,7 +61,13 @@ actor SyncEngine {
 
             let records = try pending.compactMap { try buildRecord(for: $0) }
             if !records.isEmpty {
-                try await transport.push(records)
+                do {
+                    try await transport.push(records)
+                } catch SyncTransportError.zoneNotFound {
+                    // Zone vanished (e.g. user deleted iCloud data) — recreate and retry once.
+                    try await transport.ensureZone()
+                    try await transport.push(records)
+                }
             }
             try pendingStore.remove(ids: pending.map { $0.id })
             total += pending.count
@@ -112,9 +121,20 @@ actor SyncEngine {
     func pull(now: Int64) async throws -> Int {
         var applied = 0
         var token = try zoneStore.state(zoneName: Self.zoneName)?.serverChangeToken
+        var didResetToken = false
 
         while true {
-            let batch = try await transport.fetchChanges(since: token)
+            let batch: SyncChangeBatch
+            do {
+                batch = try await transport.fetchChanges(since: token)
+            } catch SyncTransportError.changeTokenExpired where !didResetToken {
+                // The saved token is stale (e.g. the zone was reset server-side). Discard
+                // it and re-pull from the beginning. Guarded so we reset at most once.
+                didResetToken = true
+                token = nil
+                try zoneStore.saveChangeToken(nil, zoneName: Self.zoneName, syncedAt: now)
+                continue
+            }
             let ordered = batch.records.sorted { Self.applyRank($0) < Self.applyRank($1) }
             for record in ordered {
                 let outcome = try applier.apply(record, now: now)

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/InMemoryCloudKitTransport.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/InMemoryCloudKitTransport.swift
@@ -16,6 +16,15 @@ final class InMemoryCloudKitTransport: CloudKitTransport, @unchecked Sendable {
 
     /// When set, the next `push` throws this and clears it (for error-path tests).
     var failNextPush: Error?
+    /// When set, the next `fetchChanges` throws this and clears it (for error-path tests).
+    var failNextFetch: Error?
+    /// Controls `accountAvailable()` for precondition tests.
+    var accountIsAvailable = true
+
+    func accountAvailable() async throws -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return accountIsAvailable
+    }
 
     func ensureZone() async throws {
         lock.lock(); defer { lock.unlock() }
@@ -38,6 +47,10 @@ final class InMemoryCloudKitTransport: CloudKitTransport, @unchecked Sendable {
 
     func fetchChanges(since token: Data?) async throws -> SyncChangeBatch {
         lock.lock(); defer { lock.unlock() }
+        if let error = failNextFetch {
+            failNextFetch = nil
+            throw error
+        }
         let sinceSeq = token
             .flatMap { String(bytes: $0, encoding: .utf8) }
             .flatMap { Int($0) } ?? 0

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
@@ -185,4 +185,37 @@ final class SyncEngineTests: XCTestCase {
         XCTAssertEqual(stored?.payload.contains("Local"), true)
         XCTAssertEqual(try pendingStore.pendingCount(), 0, "queue drained after push")
     }
+
+    // MARK: - Recoverable errors
+
+    func testSyncThrowsWhenAccountUnavailable() async throws {
+        transport.accountIsAvailable = false
+        do {
+            _ = try await engine.sync(now: 10)
+            XCTFail("expected accountUnavailable")
+        } catch SyncTransportError.accountUnavailable {
+            // expected
+        }
+        XCTAssertFalse(transport.zoneCreated, "no sync work attempted without an account")
+    }
+
+    func testPullRecoversFromExpiredToken() async throws {
+        try await transport.push([remoteMedication("m1", name: "Remote", updatedAt: 2000)])
+        transport.failNextFetch = SyncTransportError.changeTokenExpired
+
+        let applied = try await engine.pull(now: 10)
+        XCTAssertEqual(applied, 1, "token reset + retry, then the change applies")
+        XCTAssertEqual(try medicationName("m1"), "Remote")
+    }
+
+    func testPushRecreatesZoneOnZoneNotFound() async throws {
+        try insertMedication("m1", name: "Local", updatedAt: 1000)
+        try pendingStore.enqueue(tableName: "medications", recordId: "m1", changeType: .upsert, at: 1000)
+        transport.failNextPush = SyncTransportError.zoneNotFound
+
+        let pushed = try await engine.push()
+        XCTAssertEqual(pushed, 1)
+        XCTAssertTrue(transport.zoneCreated, "zone recreated after zoneNotFound")
+        XCTAssertNotNil(transport.record(named: "medications:m1"), "record pushed on retry")
+    }
 }


### PR DESCRIPTION
## Summary
**Slice 4 — correctness hardening (part 2).** Adds a transport seam for recoverable conditions so the engine reacts (retry / reset / skip) instead of failing the entire sync — and so the engine-side logic is testable against the fake rather than being untestable real-transport glue.

## Changes
- **`CloudKitTransport.accountAvailable()`** + **`SyncTransportError`** `{ accountUnavailable, zoneNotFound, changeTokenExpired }`.
- **`SyncEngine`**:
  - `sync()` skips (throws `accountUnavailable`) when there's no iCloud account — no half-attempted work.
  - `pull()` recovers from `changeTokenExpired`: discard the stale token and re-pull from scratch (guarded to reset at most once).
  - `push()` recovers from `zoneNotFound`: recreate the zone and retry once (e.g. user deleted iCloud data).
- **`CloudKitSyncTransport`**: `accountStatus() == .available`; maps `CKError` `zoneNotFound` / `userDeletedZone` / `changeTokenExpired` / `notAuthenticated` (including the `partialFailure` wrapper) onto `SyncTransportError`.

## Testing
3 engine tests through the in-memory fake (which now models account state + injectable fetch/push errors):
- account unavailable → `sync()` throws and does no work;
- expired token → pull resets + retries, then applies;
- zone-not-found on push → zone recreated + push retried.

11 engine tests green; Release build clean. The `CKError`→`SyncTransportError` mapping itself is real-CloudKit glue (untestable in CI), but it's a thin switch; all the *behavior* it drives is tested.

## Next
4c — auto-wiring (`sync()` on foreground / after-write / background refresh), then 4d — the iCloud Sync settings UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)