### PR TITLE
feat(ios): SyncService + sync_config — enable/disable + status (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -4,7 +4,7 @@ import GRDB
 /// Central database manager. Owns the DatabaseQueue and handles schema creation/migration.
 final class DatabaseManager: Sendable {
     /// The current schema version
-    static let schemaVersion = 32
+    static let schemaVersion = 33
 
     /// Shared singleton for the app's main database
     static let shared = DatabaseManager()
@@ -156,6 +156,11 @@ final class DatabaseManager: Sendable {
         // plus the sync_capture_state control flags (enabled / suppressed). See #434.
         migrator.registerMigration("v32") { db in
             try DatabaseManager.createSyncCaptureTriggers(in: db)
+        }
+
+        // v33: sync_config — the on/off switch + last-sync status for iCloud sync (#434).
+        migrator.registerMigration("v33") { db in
+            try DatabaseManager.createSyncConfig(in: db)
         }
 
         return migrator
@@ -471,6 +476,21 @@ final class DatabaseManager: Sendable {
         // NOT created here — they reference category_safety_rules (created in v28), so
         // they're created by the v32 migration once every synced table exists.
         try DatabaseManager.createSyncStateTables(in: db)
+        try DatabaseManager.createSyncConfig(in: db)
+    }
+
+    /// Create `sync_config` (#434): the device-local on/off switch for iCloud sync plus
+    /// last-sync status. Idempotent — called from createSchema and the v33 migration.
+    static func createSyncConfig(in db: Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE IF NOT EXISTS sync_config (
+                id INTEGER PRIMARY KEY CHECK(id = 1),
+                enabled INTEGER NOT NULL DEFAULT 0 CHECK(enabled IN (0, 1)),
+                last_synced_at INTEGER,
+                last_error TEXT
+            )
+            """)
+        try db.execute(sql: "INSERT OR IGNORE INTO sync_config (id, enabled) VALUES (1, 0)")
     }
 
     /// Create the device-local sync-state tables for iCloud sync (#434): the outbound

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncConfigStore.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncConfigStore.swift
@@ -1,0 +1,56 @@
+import Foundation
+import GRDB
+
+/// The device-local on/off switch and last-sync status for iCloud sync (#434).
+struct SyncConfig: Equatable, Sendable {
+    let enabled: Bool
+    let lastSyncedAt: Int64?
+    let lastError: String?
+}
+
+/// Reads and writes the single `sync_config` row.
+final class SyncConfigStore: Sendable {
+    private let dbManager: DatabaseManager
+
+    init(dbManager: DatabaseManager) {
+        self.dbManager = dbManager
+    }
+
+    func config() throws -> SyncConfig {
+        try dbManager.dbQueue.read { db in
+            guard let row = try Row.fetchOne(
+                db, sql: "SELECT enabled, last_synced_at, last_error FROM sync_config WHERE id = 1"
+            ) else {
+                return SyncConfig(enabled: false, lastSyncedAt: nil, lastError: nil)
+            }
+            return SyncConfig(
+                enabled: (row["enabled"] as Int64? ?? 0) == 1,
+                lastSyncedAt: row["last_synced_at"] as Int64?,
+                lastError: row["last_error"] as String?
+            )
+        }
+    }
+
+    func setEnabled(_ enabled: Bool) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(sql: "UPDATE sync_config SET enabled = ? WHERE id = 1", arguments: [enabled ? 1 : 0])
+        }
+    }
+
+    /// Record a successful sync: stamp the time and clear any prior error.
+    func recordSuccess(at now: Int64) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE sync_config SET last_synced_at = ?, last_error = NULL WHERE id = 1",
+                arguments: [now]
+            )
+        }
+    }
+
+    /// Record a sync failure message (leaves last_synced_at untouched).
+    func recordFailure(_ message: String) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(sql: "UPDATE sync_config SET last_error = ? WHERE id = 1", arguments: [message])
+        }
+    }
+}

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncService.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncService.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Coordinates iCloud sync (#434): owns the engine, the on/off config, and the
+/// enable/disable flow. The single surface the app and settings UI talk to. Holds one
+/// `SyncEngine` (an actor), so overlapping sync triggers serialise rather than racing.
+@MainActor
+final class SyncService: ObservableObject {
+    @Published private(set) var isEnabled: Bool
+    @Published private(set) var isSyncing = false
+    @Published private(set) var lastSyncedAt: Int64?
+    @Published private(set) var lastError: String?
+
+    private let dbManager: DatabaseManager
+    private let backupService: BackupServiceProtocol
+    private let configStore: SyncConfigStore
+    private let pendingStore: SyncPendingChangesStore
+    private let engine: SyncEngine
+
+    init(
+        dbManager: DatabaseManager = .shared,
+        transport: CloudKitTransport = CloudKitSyncTransport(),
+        backupService: BackupServiceProtocol = BackupService()
+    ) {
+        self.dbManager = dbManager
+        self.backupService = backupService
+        self.configStore = SyncConfigStore(dbManager: dbManager)
+        self.pendingStore = SyncPendingChangesStore(dbManager: dbManager)
+        self.engine = SyncEngine(
+            transport: transport, dbManager: dbManager,
+            pendingStore: pendingStore, zoneStore: SyncZoneStateStore(dbManager: dbManager),
+            applier: RemoteChangeApplier(dbManager: dbManager)
+        )
+
+        let config = (try? configStore.config()) ?? SyncConfig(enabled: false, lastSyncedAt: nil, lastError: nil)
+        self.isEnabled = config.enabled
+        self.lastSyncedAt = config.lastSyncedAt
+        self.lastError = config.lastError
+    }
+
+    /// Turn sync on: back up first, enqueue all existing rows, start capturing new edits,
+    /// persist the flag, then run a first sync.
+    func enable() async throws {
+        try backUp()
+        try pendingStore.backfillExistingRows(at: TimestampHelper.now)
+        try setCaptureEnabled(true)
+        try configStore.setEnabled(true)
+        isEnabled = true
+        try await syncNow()
+    }
+
+    /// Turn sync off: stop capturing new edits and clear the flag. Queued and already-
+    /// synced data are left as-is.
+    func disable() throws {
+        try setCaptureEnabled(false)
+        try configStore.setEnabled(false)
+        isEnabled = false
+    }
+
+    /// Run a sync cycle now, recording success/failure. Throws on failure (after recording).
+    func syncNow() async throws {
+        isSyncing = true
+        defer { isSyncing = false }
+        let now = TimestampHelper.now
+        do {
+            _ = try await engine.sync(now: now)
+            try configStore.recordSuccess(at: now)
+            lastSyncedAt = now
+            lastError = nil
+        } catch {
+            let message = error.localizedDescription
+            try? configStore.recordFailure(message)
+            lastError = message
+            throw error
+        }
+    }
+
+    /// Sync only if enabled — the entry point for automatic triggers (foreground, etc.).
+    func syncIfEnabled() async {
+        guard isEnabled else { return }
+        try? await syncNow()
+    }
+
+    // MARK: - Helpers
+
+    private func backUp() throws {
+        let counts = try dbManager.dbQueue.read { db in
+            (episodes: try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM episodes") ?? 0,
+             medications: try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM medications") ?? 0)
+        }
+        _ = try backupService.createBackup(
+            dbManager: dbManager, episodeCount: counts.episodes, medicationCount: counts.medications
+        )
+    }
+
+    private func setCaptureEnabled(_ enabled: Bool) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE sync_capture_state SET enabled = ? WHERE id = 1", arguments: [enabled ? 1 : 0]
+            )
+        }
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
@@ -58,6 +58,7 @@ final class DatabaseManagerTests: XCTestCase {
             "sync_zone_state",
             "sync_conflicts",
             "sync_capture_state",
+            "sync_config",
             "grdb_migrations", // GRDB internal table
         ]
 
@@ -187,7 +188,7 @@ final class DatabaseManagerTests: XCTestCase {
     // MARK: - Schema Version
 
     func testSchemaVersionIsTracked() throws {
-        XCTAssertEqual(DatabaseManager.schemaVersion, 32)
+        XCTAssertEqual(DatabaseManager.schemaVersion, 33)
     }
 
     func testMigrationIsRecordedInGRDB() throws {
@@ -258,6 +259,18 @@ final class DatabaseManagerTests: XCTestCase {
             let identifiers = try Row.fetchAll(db, sql: "SELECT identifier FROM grdb_migrations")
                 .map { $0["identifier"] as String }
             XCTAssertTrue(identifiers.contains("v32"), "Migration v32 should be recorded")
+        }
+    }
+
+    /// v33 adds sync_config — the on/off switch for iCloud sync (#434).
+    func testV33CreatesSyncConfig() throws {
+        try dbManager.dbQueue.read { db in
+            XCTAssertTrue(try db.tableExists("sync_config"))
+            let enabled = try Int.fetchOne(db, sql: "SELECT enabled FROM sync_config WHERE id = 1")
+            XCTAssertEqual(enabled, 0, "sync is off by default")
+            let identifiers = try Row.fetchAll(db, sql: "SELECT identifier FROM grdb_migrations")
+                .map { $0["identifier"] as String }
+            XCTAssertTrue(identifiers.contains("v33"), "Migration v33 should be recorded")
         }
     }
 

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncConfigStoreTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncConfigStoreTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import GRDB
+@testable import MigraLog
+
+final class SyncConfigStoreTests: XCTestCase {
+    var dbManager: DatabaseManager!
+    var store: SyncConfigStore!
+
+    override func setUpWithError() throws {
+        dbManager = try DatabaseManager(inMemory: true)
+        store = SyncConfigStore(dbManager: dbManager)
+    }
+
+    override func tearDownWithError() throws {
+        store = nil
+        dbManager = nil
+    }
+
+    func testDefaultsToDisabled() throws {
+        let config = try store.config()
+        XCTAssertFalse(config.enabled)
+        XCTAssertNil(config.lastSyncedAt)
+        XCTAssertNil(config.lastError)
+    }
+
+    func testSetEnabledRoundTrips() throws {
+        try store.setEnabled(true)
+        XCTAssertTrue(try store.config().enabled)
+        try store.setEnabled(false)
+        XCTAssertFalse(try store.config().enabled)
+    }
+
+    func testRecordSuccessStampsTimeAndClearsError() throws {
+        try store.recordFailure("boom")
+        try store.recordSuccess(at: 5000)
+        let config = try store.config()
+        XCTAssertEqual(config.lastSyncedAt, 5000)
+        XCTAssertNil(config.lastError)
+    }
+
+    func testRecordFailureStoresMessage() throws {
+        try store.recordFailure("network down")
+        XCTAssertEqual(try store.config().lastError, "network down")
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncServiceTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncServiceTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+import GRDB
+@testable import MigraLog
+
+@MainActor
+final class SyncServiceTests: XCTestCase {
+
+    private func insertMedication(_ db: DatabaseManager, _ id: String) throws {
+        try db.dbQueue.write {
+            try $0.execute(
+                sql: """
+                    INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, created_at, updated_at)
+                    VALUES (?, 'Med', 'rescue', 1, 'mg', 1000, 1000)
+                    """,
+                arguments: [id]
+            )
+        }
+    }
+
+    private func captureEnabled(_ db: DatabaseManager) throws -> Bool {
+        (try db.dbQueue.read { try Int.fetchOne($0, sql: "SELECT enabled FROM sync_capture_state WHERE id = 1") }) == 1
+    }
+
+    func testEnableBacksUpBackfillsCapturesAndSyncs() async throws {
+        let db = try DatabaseManager(inMemory: true)
+        try insertMedication(db, "m1")
+        let transport = InMemoryCloudKitTransport()
+        let backup = SpyBackupService()
+        let service = SyncService(dbManager: db, transport: transport, backupService: backup)
+
+        try await service.enable()
+
+        XCTAssertTrue(service.isEnabled)
+        XCTAssertTrue(backup.createBackupCalled, "backed up before first sync")
+        XCTAssertTrue(try captureEnabled(db), "capture turned on")
+        XCTAssertNotNil(transport.record(named: "medications:m1"), "existing row backfilled and pushed")
+        XCTAssertNotNil(service.lastSyncedAt)
+        XCTAssertNil(service.lastError)
+    }
+
+    func testDisableTurnsOffCaptureAndFlag() async throws {
+        let db = try DatabaseManager(inMemory: true)
+        let service = SyncService(
+            dbManager: db, transport: InMemoryCloudKitTransport(), backupService: SpyBackupService()
+        )
+        try await service.enable()
+
+        try service.disable()
+
+        XCTAssertFalse(service.isEnabled)
+        XCTAssertFalse(try captureEnabled(db))
+    }
+
+    func testSyncIfEnabledSkipsWhenDisabled() async throws {
+        let db = try DatabaseManager(inMemory: true)
+        let transport = InMemoryCloudKitTransport()
+        let service = SyncService(dbManager: db, transport: transport, backupService: SpyBackupService())
+
+        await service.syncIfEnabled()
+
+        XCTAssertFalse(transport.zoneCreated, "no sync work when disabled")
+    }
+
+    func testSyncNowRecordsFailure() async throws {
+        let db = try DatabaseManager(inMemory: true)
+        let transport = InMemoryCloudKitTransport()
+        transport.accountIsAvailable = false
+        let service = SyncService(dbManager: db, transport: transport, backupService: SpyBackupService())
+
+        do {
+            try await service.syncNow()
+            XCTFail("expected sync to throw")
+        } catch {
+            // expected
+        }
+        XCTAssertNotNil(service.lastError, "failure recorded for the UI")
+    }
+}
+
+private final class SpyBackupService: BackupServiceProtocol {
+    private(set) var createBackupCalled = false
+
+    func createBackup(dbManager: DatabaseManager, episodeCount: Int, medicationCount: Int) throws -> BackupMetadata {
+        createBackupCalled = true
+        return BackupMetadata(
+            id: "test", timestamp: 0, version: "test", schemaVersion: 0,
+            episodeCount: episodeCount, medicationCount: medicationCount
+        )
+    }
+
+    func listBackups() throws -> [BackupMetadata] { [] }
+    func deleteBackup(id: String) throws {}
+    func restoreFromBackup(path: String, dbManager: DatabaseManager) throws {}
+    func validateBackup(path: String) -> Bool { true }
+}

--- a/spec/schemas/sqlite/schema-v33.sql
+++ b/spec/schemas/sqlite/schema-v33.sql
@@ -1,4 +1,4 @@
--- MigraLog SQLite Schema v32
+-- MigraLog SQLite Schema v33
 -- Canonical schema definition for the migraine tracking database.
 -- Source of truth: mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
 --   (createSchema + registered migrations). This .sql is a formal mirror and
@@ -16,6 +16,8 @@
 -- v32 (#434, iCloud sync): added sync_capture_state (control flags) + AFTER
 --   INSERT/UPDATE/DELETE triggers on each synced table that enqueue local edits to
 --   sync_pending_changes. Device-local. See createSyncCaptureTriggers.
+-- v33 (#434, iCloud sync): added sync_config — the on/off switch + last-sync status.
+--   Device-local, NOT synced.
 --
 -- Conventions:
 --   - All IDs are TEXT (UUIDs)
@@ -329,3 +331,12 @@ INSERT OR IGNORE INTO sync_capture_state (id, enabled, suppressed) VALUES (1, 0,
 --         change_type = 'upsert', created_at = excluded.created_at,
 --         retry_count = 0, last_error = NULL;
 --   END;
+
+-- iCloud sync on/off switch + last-sync status (v33). Device-local, NOT synced.
+CREATE TABLE IF NOT EXISTS sync_config (
+  id INTEGER PRIMARY KEY CHECK(id = 1),
+  enabled INTEGER NOT NULL DEFAULT 0 CHECK(enabled IN (0, 1)),
+  last_synced_at INTEGER,
+  last_error TEXT
+);
+INSERT OR IGNORE INTO sync_config (id, enabled) VALUES (1, 0);


### PR DESCRIPTION
## Summary
**Slice 4 — UX core (logic, no UI yet).** The `SyncService` coordinator + `sync_config` table that the app and the forthcoming settings screen talk to. Everything here is unit-tested against the fake transport; the settings UI (4d-ii) just drives it.

## What's here
- **v33 migration: `sync_config`** — the device-local on/off switch + `last_synced_at` / `last_error` status. Off by default.
- **`SyncConfigStore`** — `config()`, `setEnabled`, `recordSuccess(at:)`, `recordFailure(_:)`.
- **`SyncService`** (`@MainActor ObservableObject`, holds **one** `SyncEngine` so overlapping triggers serialise on the actor rather than racing):
  - **`enable()`** — the proper first-time flow: **back up → backfill existing rows → enable capture → set the flag → first sync**. This is the safe on-switch.
  - **`disable()`** — stop capturing new edits + clear the flag (queued/synced data left as-is).
  - **`syncNow()`** — run a cycle, recording success/failure for the UI to show.
  - **`syncIfEnabled()`** — the entry point the automatic triggers (4c) will call.
  - Transport + `BackupServiceProtocol` are injected, so the flow is testable.

## Testing
- 4 `SyncConfigStore` tests (defaults off; setEnabled round-trips; success stamps time + clears error; failure stored).
- 4 `SyncService` tests via the fake + a spy backup service: `enable()` backs up, backfills, turns capture on, and pushes existing data; `disable()` turns capture + flag off; `syncIfEnabled()` skips when disabled; a failed sync records `lastError`.
- v33 migration test. **Full unit suite: 838, 0 failures.**

## Notes
- `SyncService` isn't instantiated in the app yet (no `static let shared`) — that's intentional; **4d-ii** wires one instance through the app/environment and builds the iCloud Sync settings screen on top of it, then retires the debug harness. **4c** adds the automatic triggers calling `syncIfEnabled()`.
- DDL mirrored to `schema-v33.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)