### PR TITLE
feat(ios): iCloud Sync settings screen (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
+++ b/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
@@ -11,6 +11,7 @@ struct MigraLogApp: App {
     private let medicationNotificationService: MedicationNotificationScheduler
     private let dailyCheckinService: DailyCheckinNotificationService
     @State private var timezoneChangeService: TimezoneChangeService
+    @State private var syncService: SyncService
 
     init() {
         SentrySetup.start()
@@ -55,6 +56,7 @@ struct MigraLogApp: App {
         self._timezoneChangeService = State(
             initialValue: TimezoneChangeService(medicationRepo: medicationRepository)
         )
+        self._syncService = State(initialValue: SyncService())
     }
 
     var body: some Scene {
@@ -62,6 +64,7 @@ struct MigraLogApp: App {
             ContentView()
                 .environment(appState)
                 .environment(timezoneChangeService)
+                .environment(syncService)
                 .task {
                     await reconciliationService.reconcile()
                     await medicationNotificationService.topUp()

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncService.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncService.swift
@@ -4,11 +4,12 @@ import Foundation
 /// enable/disable flow. The single surface the app and settings UI talk to. Holds one
 /// `SyncEngine` (an actor), so overlapping sync triggers serialise rather than racing.
 @MainActor
-final class SyncService: ObservableObject {
-    @Published private(set) var isEnabled: Bool
-    @Published private(set) var isSyncing = false
-    @Published private(set) var lastSyncedAt: Int64?
-    @Published private(set) var lastError: String?
+@Observable
+final class SyncService {
+    private(set) var isEnabled: Bool
+    private(set) var isSyncing = false
+    private(set) var lastSyncedAt: Int64?
+    private(set) var lastError: String?
 
     private let dbManager: DatabaseManager
     private let backupService: BackupServiceProtocol

--- a/mobile-apps/ios/MigraLog/Views/Settings/SettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/SettingsScreen.swift
@@ -46,6 +46,12 @@ struct SettingsScreen: View {
                 } label: {
                     Label("Backup & Export", systemImage: "externaldrive")
                 }
+
+                NavigationLink {
+                    SyncSettingsScreen()
+                } label: {
+                    Label("iCloud Sync", systemImage: "arrow.triangle.2.circlepath.icloud")
+                }
             }
 
             // Developer Tools

--- a/mobile-apps/ios/MigraLog/Views/Settings/SyncSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/SyncSettingsScreen.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// User-facing iCloud Sync settings (#434): turn sync on/off, see last-sync status,
+/// and trigger a manual sync. Backed by `SyncService`.
+struct SyncSettingsScreen: View {
+    @Environment(SyncService.self) private var syncService
+    @State private var isToggling = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        List {
+            Section {
+                Toggle("iCloud Sync", isOn: Binding(
+                    get: { syncService.isEnabled },
+                    set: { on in Task { await setEnabled(on) } }
+                ))
+                .disabled(isToggling || syncService.isSyncing)
+            } footer: {
+                Text("Keep your migraine history in sync across your devices through your "
+                    + "private iCloud account. Turning this on backs up your data first, then uploads it.")
+            }
+
+            if syncService.isEnabled {
+                Section("Status") {
+                    LabeledContent("Last synced", value: lastSyncedText)
+                    if let error = syncService.lastError {
+                        LabeledContent("Last error") {
+                            Text(error).foregroundStyle(.red)
+                        }
+                    }
+                    Button {
+                        Task { await syncNow() }
+                    } label: {
+                        if syncService.isSyncing {
+                            HStack(spacing: 8) {
+                                ProgressView()
+                                Text("Syncing…")
+                            }
+                        } else {
+                            Text("Sync Now")
+                        }
+                    }
+                    .disabled(syncService.isSyncing || isToggling)
+                }
+            }
+        }
+        .navigationTitle("iCloud Sync")
+        .alert("Sync Error", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private var lastSyncedText: String {
+        guard let last = syncService.lastSyncedAt else { return "Never" }
+        return DateFormatting.displayDateTime(TimestampHelper.toDate(last))
+    }
+
+    private func setEnabled(_ on: Bool) async {
+        isToggling = true
+        defer { isToggling = false }
+        do {
+            if on {
+                try await syncService.enable()
+            } else {
+                try syncService.disable()
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func syncNow() async {
+        do {
+            try await syncService.syncNow()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}


### PR DESCRIPTION
## Summary
**Slice 4 — the user-facing UX.** A real **iCloud Sync** settings screen wired to `SyncService`, so sync is a shippable product surface rather than a debug harness.

## What's here
- **`SyncService` → `@Observable`** (was `ObservableObject`) to match the app's Observation pattern, and injected via `.environment(syncService)` from `MigraLogApp` (created alongside the other app services in `init()`).
- **`SyncSettingsScreen`** at **Settings → Data → iCloud Sync**:
  - A **toggle** that runs the real flow — on → `enable()` (back up → backfill existing rows → enable capture → first sync), off → `disable()`.
  - **Status**: last-synced timestamp + last error (when enabled).
  - A manual **Sync Now** with a spinner.
  - Failures surface in an alert (e.g. not signed into iCloud).

## Testing
- **Release build succeeds**; the 4 `SyncService` tests still pass after the `@Observable` conversion.
- The screen is SwiftUI, so behavior is a **local manual check** per our usual rule (UI tests aren't CI-gated). Suggested smoke: toggle on (watch it back up + first-sync), confirm status populates, toggle off, toggle on again.

## Notes
- The debug **Sync Test** harness stays under Developer Tools for now (different audience — raw debugging). It can be retired once you're happy with the real screen.
- **Still manual:** sync runs only when you toggle on or tap Sync Now. **4c** (the final slice) adds automatic triggers — foreground / after-write / background — calling `syncIfEnabled()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)