### PR TITLE
feat(ios): automatic sync triggers — foreground + after-write (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/App/ContentView.swift
+++ b/mobile-apps/ios/MigraLog/App/ContentView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct ContentView: View {
     @Environment(AppState.self) private var appState
     @Environment(TimezoneChangeService.self) private var timezoneChangeService
+    @Environment(SyncService.self) private var syncService
+    @Environment(\.scenePhase) private var scenePhase
     @State private var selectedTab: TabSection = .dashboard
 
     var body: some View {
@@ -39,6 +41,12 @@ struct ContentView: View {
                 + "a 9:00 PM reminder still fires at 9:00 PM. "
                 + "Review your schedules if you'd like to adjust them."
             )
+        }
+        .task { syncService.startAutoSync() }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active {
+                Task { await syncService.syncIfEnabled() }
+            }
         }
     }
 }

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncService.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 
 /// Coordinates iCloud sync (#434): owns the engine, the on/off config, and the
 /// enable/disable flow. The single surface the app and settings UI talk to. Holds one
@@ -16,6 +17,11 @@ final class SyncService {
     private let configStore: SyncConfigStore
     private let pendingStore: SyncPendingChangesStore
     private let engine: SyncEngine
+
+    @ObservationIgnored private var autoSyncTask: Task<Void, Never>?
+    @ObservationIgnored private var debounceTask: Task<Void, Never>?
+    /// How long after the last local edit to wait before an automatic sync.
+    @ObservationIgnored var afterWriteDebounce: Duration = .seconds(3)
 
     init(
         dbManager: DatabaseManager = .shared,
@@ -79,6 +85,43 @@ final class SyncService {
     func syncIfEnabled() async {
         guard isEnabled else { return }
         try? await syncNow()
+    }
+
+    // MARK: - Automatic triggers
+
+    /// Start watching the pending queue so a local edit triggers an automatic sync.
+    /// When the queue grows (a captured edit), debounce briefly then sync. Idempotent —
+    /// call once on launch. Combine with a foreground trigger calling `syncIfEnabled()`.
+    func startAutoSync() {
+        guard autoSyncTask == nil else { return }
+        let observation = ValueObservation.tracking { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM sync_pending_changes") ?? 0
+        }
+        let dbQueue = dbManager.dbQueue
+        autoSyncTask = Task { [weak self] in
+            var lastCount: Int?
+            do {
+                for try await count in observation.values(in: dbQueue) {
+                    // React only to growth (new local edits), not to the queue draining on push.
+                    if let lastCount, count > lastCount {
+                        self?.scheduleDebouncedSync()
+                    }
+                    lastCount = count
+                }
+            } catch {
+                // Observation ended (teardown) — nothing to do.
+            }
+        }
+    }
+
+    private func scheduleDebouncedSync() {
+        debounceTask?.cancel()
+        let delay = afterWriteDebounce
+        debounceTask = Task { [weak self] in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled else { return }
+            await self?.syncIfEnabled()
+        }
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
**Slice 4c — the final piece: automatic sync.** When sync is enabled, it now runs on its own; no more manual "Sync Now" required (though that still works).

## Triggers
- **Foreground** — `ContentView` calls `syncService.syncIfEnabled()` when the scene becomes `.active`. So opening the app pulls down whatever changed on your other devices.
- **After-write (debounced)** — `SyncService.startAutoSync()` runs a GRDB `ValueObservation` on the pending-queue count. When the queue **grows** (a local edit was captured), it debounces (`afterWriteDebounce`, default 3s) and then syncs. Debouncing means one sync after you finish logging, not one per field. It reacts only to *growth*, so the queue draining on push doesn't re-trigger a loop.

## Deferred
- **Background refresh** (`BGTaskScheduler`) — needs a Background Modes capability + `BGTaskSchedulerPermittedIdentifiers` in Info.plist + the scheduling/handler plumbing. Split out as a follow-up so this slice stays clean. Foreground + after-write already cover the common cases.

## Testing
- **Release build succeeds**; the 4 `SyncService` tests still pass.
- The triggers are lifecycle/observation integration, so behavior is a **local manual check** (not a flaky timing-based unit test). Suggested: enable sync on two devices, log something on A, confirm it appears on B within a few seconds (after-write) and on foreground.

## Slice 4 complete
4a pull-then-push · 4b account/error handling · 4d-i SyncService+config · 4d-ii settings UI · **4c auto-triggers**. iCloud sync is now functionally end-to-end: toggle on → backup + backfill + sync; edits then propagate automatically. Remaining tail: background refresh (above) and the concurrent-edit conflict-detection hardening (documented earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)