### PR TITLE
fix(ios): stamp updated_at on all synced UPDATE paths (#460)

### DIFF
--- a/mobile-apps/ios/MigraLog/Models/DomainModels.swift
+++ b/mobile-apps/ios/MigraLog/Models/DomainModels.swift
@@ -59,6 +59,7 @@ struct SymptomLog: Identifiable, Equatable, Sendable {
     var resolutionTime: Int64?
     var severity: Double?
     let createdAt: Int64
+    var updatedAt: Int64
 }
 
 // MARK: - Pain Location Log
@@ -80,6 +81,7 @@ struct EpisodeNote: Identifiable, Equatable, Sendable {
     var timestamp: Int64
     var note: String
     let createdAt: Int64
+    var updatedAt: Int64
 
     var date: Date {
         Date(timeIntervalSince1970: Double(timestamp) / 1000.0)
@@ -116,6 +118,8 @@ struct MedicationSchedule: Identifiable, Equatable, Sendable {
     var enabled: Bool
     var notificationId: String?
     var reminderEnabled: Bool
+    var createdAt: Int64? = nil
+    var updatedAt: Int64? = nil
 
     var timeComponents: (hour: Int, minute: Int)? {
         let parts = time.split(separator: ":")

--- a/mobile-apps/ios/MigraLog/Repositories/CategorySafetyRuleRepository.swift
+++ b/mobile-apps/ios/MigraLog/Repositories/CategorySafetyRuleRepository.swift
@@ -22,6 +22,7 @@ struct CategorySafetyRule: Identifiable, Equatable, Sendable {
     let periodHours: Double
     let maxCount: Int?
     let createdAt: Date
+    var updatedAt: Date?
 
     /// Window length in whole days, for period_limit rules. Rounds to nearest
     /// integer day because the UI only exposes day-granularity.
@@ -41,7 +42,7 @@ final class CategorySafetyRuleRepository: CategorySafetyRuleRepositoryProtocol {
         try dbManager.dbQueue.read { db in
             let rows = try Row.fetchAll(
                 db,
-                sql: "SELECT id, category, type, period_hours, max_count, created_at FROM category_safety_rules"
+                sql: "SELECT id, category, type, period_hours, max_count, created_at, updated_at FROM category_safety_rules"
             )
             return rows.compactMap { Self.ruleFromRow($0) }
         }
@@ -51,7 +52,7 @@ final class CategorySafetyRuleRepository: CategorySafetyRuleRepositoryProtocol {
         try dbManager.dbQueue.read { db in
             let rows = try Row.fetchAll(
                 db,
-                sql: "SELECT id, category, type, period_hours, max_count, created_at FROM category_safety_rules WHERE category = ?",
+                sql: "SELECT id, category, type, period_hours, max_count, created_at, updated_at FROM category_safety_rules WHERE category = ?",
                 arguments: [category.rawValue]
             )
             return rows.compactMap { Self.ruleFromRow($0) }
@@ -63,7 +64,7 @@ final class CategorySafetyRuleRepository: CategorySafetyRuleRepositoryProtocol {
             let row = try Row.fetchOne(
                 db,
                 sql: """
-                    SELECT id, category, type, period_hours, max_count, created_at
+                    SELECT id, category, type, period_hours, max_count, created_at, updated_at
                     FROM category_safety_rules
                     WHERE category = ? AND type = ?
                     """,
@@ -74,15 +75,17 @@ final class CategorySafetyRuleRepository: CategorySafetyRuleRepositoryProtocol {
     }
 
     func upsert(_ rule: CategorySafetyRule) throws {
+        let now = TimestampHelper.now
         try dbManager.dbQueue.write { db in
             try db.execute(
                 sql: """
                     INSERT INTO category_safety_rules
-                        (id, category, type, period_hours, max_count, created_at)
-                    VALUES (?, ?, ?, ?, ?, ?)
+                        (id, category, type, period_hours, max_count, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(category, type) DO UPDATE SET
                         period_hours = excluded.period_hours,
-                        max_count = excluded.max_count
+                        max_count = excluded.max_count,
+                        updated_at = excluded.updated_at
                     """,
                 arguments: [
                     rule.id,
@@ -90,7 +93,8 @@ final class CategorySafetyRuleRepository: CategorySafetyRuleRepositoryProtocol {
                     rule.type.rawValue,
                     rule.periodHours,
                     rule.maxCount,
-                    Int64(rule.createdAt.timeIntervalSince1970 * 1000)
+                    Int64(rule.createdAt.timeIntervalSince1970 * 1000),
+                    now
                 ]
             )
         }
@@ -139,13 +143,16 @@ final class CategorySafetyRuleRepository: CategorySafetyRuleRepositoryProtocol {
               let createdAtMillis = row["created_at"] as Int64? else {
             return nil
         }
+        let updatedAt: Date? = (row["updated_at"] as Int64?)
+            .map { Date(timeIntervalSince1970: TimeInterval($0) / 1000.0) }
         return CategorySafetyRule(
             id: id,
             category: category,
             type: type,
             periodHours: periodHours,
             maxCount: row["max_count"] as Int?,
-            createdAt: Date(timeIntervalSince1970: TimeInterval(createdAtMillis) / 1000.0)
+            createdAt: Date(timeIntervalSince1970: TimeInterval(createdAtMillis) / 1000.0),
+            updatedAt: updatedAt
         )
     }
 }

--- a/mobile-apps/ios/MigraLog/Repositories/EpisodeRepository.swift
+++ b/mobile-apps/ios/MigraLog/Repositories/EpisodeRepository.swift
@@ -251,8 +251,8 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
         try dbManager.dbQueue.write { db in
             try db.execute(
                 sql: """
-                    INSERT INTO symptom_logs (id, episode_id, symptom, onset_time, resolution_time, severity, created_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    INSERT INTO symptom_logs (id, episode_id, symptom, onset_time, resolution_time, severity, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                 arguments: [
                     log.id,
@@ -261,7 +261,8 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
                     log.onsetTime,
                     log.resolutionTime,
                     log.severity,
-                    log.createdAt
+                    log.createdAt,
+                    log.updatedAt
                 ]
             )
         }
@@ -280,23 +281,27 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
     }
 
     func updateSymptomLog(_ log: SymptomLog) throws -> SymptomLog {
+        let now = TimestampHelper.now
+        var updated = log
+        updated.updatedAt = now
         try dbManager.dbQueue.write { db in
             try db.execute(
                 sql: """
                     UPDATE symptom_logs SET
-                        symptom = ?, onset_time = ?, resolution_time = ?, severity = ?
+                        symptom = ?, onset_time = ?, resolution_time = ?, severity = ?, updated_at = ?
                     WHERE id = ?
                     """,
                 arguments: [
-                    log.symptom.rawValue,
-                    log.onsetTime,
-                    log.resolutionTime,
-                    log.severity,
-                    log.id
+                    updated.symptom.rawValue,
+                    updated.onsetTime,
+                    updated.resolutionTime,
+                    updated.severity,
+                    updated.updatedAt,
+                    updated.id
                 ]
             )
         }
-        return log
+        return updated
     }
 
     func deleteSymptomLog(_ id: String) throws {
@@ -372,15 +377,16 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
         try dbManager.dbQueue.write { db in
             try db.execute(
                 sql: """
-                    INSERT INTO episode_notes (id, episode_id, timestamp, note, created_at)
-                    VALUES (?, ?, ?, ?, ?)
+                    INSERT INTO episode_notes (id, episode_id, timestamp, note, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
                     """,
                 arguments: [
                     note.id,
                     note.episodeId,
                     note.timestamp,
                     note.note,
-                    note.createdAt
+                    note.createdAt,
+                    note.updatedAt
                 ]
             )
         }
@@ -399,17 +405,20 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
     }
 
     func updateEpisodeNote(_ note: EpisodeNote) throws -> EpisodeNote {
+        let now = TimestampHelper.now
+        var updated = note
+        updated.updatedAt = now
         try dbManager.dbQueue.write { db in
             try db.execute(
                 sql: """
                     UPDATE episode_notes SET
-                        timestamp = ?, note = ?
+                        timestamp = ?, note = ?, updated_at = ?
                     WHERE id = ?
                     """,
-                arguments: [note.timestamp, note.note, note.id]
+                arguments: [updated.timestamp, updated.note, updated.updatedAt, updated.id]
             )
         }
-        return note
+        return updated
     }
 
     func updateNoteTimestamps(episodeId: String, offset: Int64) throws {
@@ -417,10 +426,10 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
             try db.execute(
                 sql: """
                     UPDATE episode_notes SET
-                        timestamp = timestamp + ?
+                        timestamp = timestamp + ?, updated_at = ?
                     WHERE episode_id = ?
                     """,
-                arguments: [offset, episodeId]
+                arguments: [offset, TimestampHelper.now, episodeId]
             )
         }
     }
@@ -475,7 +484,8 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
             onsetTime: row["onset_time"],
             resolutionTime: row["resolution_time"],
             severity: row["severity"],
-            createdAt: row["created_at"]
+            createdAt: row["created_at"],
+            updatedAt: row["updated_at"] ?? row["created_at"]
         )
     }
 
@@ -497,7 +507,8 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
             episodeId: row["episode_id"],
             timestamp: row["timestamp"],
             note: row["note"],
-            createdAt: row["created_at"]
+            createdAt: row["created_at"],
+            updatedAt: row["updated_at"] ?? row["created_at"]
         )
     }
 }

--- a/mobile-apps/ios/MigraLog/Repositories/MedicationRepository.swift
+++ b/mobile-apps/ios/MigraLog/Repositories/MedicationRepository.swift
@@ -351,26 +351,32 @@ final class MedicationRepository: MedicationRepositoryProtocol {
     // MARK: - Schedule CRUD
 
     func createSchedule(_ schedule: MedicationSchedule) throws -> MedicationSchedule {
+        let now = TimestampHelper.now
+        var created = schedule
+        if created.createdAt == nil { created.createdAt = now }
+        if created.updatedAt == nil { created.updatedAt = now }
         try dbManager.dbQueue.write { db in
             try db.execute(
                 sql: """
                     INSERT INTO medication_schedules (id, medication_id, time, timezone, dosage,
-                        enabled, notification_id, reminder_enabled)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        enabled, notification_id, reminder_enabled, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                 arguments: [
-                    schedule.id,
-                    schedule.medicationId,
-                    schedule.time,
-                    schedule.timezone,
-                    schedule.dosage,
-                    schedule.enabled ? 1 : 0,
-                    schedule.notificationId,
-                    schedule.reminderEnabled ? 1 : 0
+                    created.id,
+                    created.medicationId,
+                    created.time,
+                    created.timezone,
+                    created.dosage,
+                    created.enabled ? 1 : 0,
+                    created.notificationId,
+                    created.reminderEnabled ? 1 : 0,
+                    created.createdAt,
+                    created.updatedAt
                 ]
             )
         }
-        return schedule
+        return created
     }
 
     func getSchedulesByMedicationId(_ medicationId: String) throws -> [MedicationSchedule] {
@@ -403,26 +409,30 @@ final class MedicationRepository: MedicationRepositoryProtocol {
     }
 
     func updateSchedule(_ schedule: MedicationSchedule) throws -> MedicationSchedule {
+        let now = TimestampHelper.now
+        var updated = schedule
+        updated.updatedAt = now
         try dbManager.dbQueue.write { db in
             try db.execute(
                 sql: """
                     UPDATE medication_schedules SET
                         time = ?, timezone = ?, dosage = ?, enabled = ?,
-                        notification_id = ?, reminder_enabled = ?
+                        notification_id = ?, reminder_enabled = ?, updated_at = ?
                     WHERE id = ?
                     """,
                 arguments: [
-                    schedule.time,
-                    schedule.timezone,
-                    schedule.dosage,
-                    schedule.enabled ? 1 : 0,
-                    schedule.notificationId,
-                    schedule.reminderEnabled ? 1 : 0,
-                    schedule.id
+                    updated.time,
+                    updated.timezone,
+                    updated.dosage,
+                    updated.enabled ? 1 : 0,
+                    updated.notificationId,
+                    updated.reminderEnabled ? 1 : 0,
+                    updated.updatedAt,
+                    updated.id
                 ]
             )
         }
-        return schedule
+        return updated
     }
 
     func deleteSchedule(_ id: String) throws {
@@ -491,7 +501,9 @@ final class MedicationRepository: MedicationRepositoryProtocol {
             dosage: row["dosage"],
             enabled: (row["enabled"] as Int) != 0,
             notificationId: row["notification_id"],
-            reminderEnabled: (row["reminder_enabled"] as Int) != 0
+            reminderEnabled: (row["reminder_enabled"] as Int) != 0,
+            createdAt: row["created_at"],
+            updatedAt: row["updated_at"]
         )
     }
 }

--- a/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
@@ -267,7 +267,8 @@ final class EpisodeDetailViewModel {
             onsetTime: timestamp ?? now,
             resolutionTime: nil,
             severity: severity,
-            createdAt: now
+            createdAt: now,
+            updatedAt: now
         )
         do {
             let saved = try await episodeRepository.createSymptomLog(log)
@@ -312,7 +313,8 @@ final class EpisodeDetailViewModel {
             episodeId: episodeId,
             timestamp: timestamp ?? now,
             note: note,
-            createdAt: now
+            createdAt: now,
+            updatedAt: now
         )
         do {
             let saved = try await episodeRepository.createEpisodeNote(episodeNote)

--- a/mobile-apps/ios/MigraLogTests/Repositories/CategorySafetyRuleRepositoryTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Repositories/CategorySafetyRuleRepositoryTests.swift
@@ -49,6 +49,29 @@ final class CategorySafetyRuleRepositoryTests: XCTestCase {
         XCTAssertEqual(all[0].periodHours, 6.0)
     }
 
+    func test_upsert_stamps_updated_at_for_LWW() throws {
+        // #460: every upsert must stamp updated_at so last-write-wins compares
+        // last-modified time, not creation time.
+        let rule = CategorySafetyRule(
+            id: "a", category: .nsaid, type: .cooldown,
+            periodHours: 4.0, maxCount: nil, createdAt: Date()
+        )
+        try repo.upsert(rule)
+        let first = try repo.getRule(category: .nsaid, type: .cooldown)?.updatedAt
+        XCTAssertNotNil(first)
+
+        Thread.sleep(forTimeInterval: 0.005)
+
+        let changed = CategorySafetyRule(
+            id: rule.id, category: .nsaid, type: .cooldown,
+            periodHours: 6.0, maxCount: nil, createdAt: rule.createdAt
+        )
+        try repo.upsert(changed)
+        let second = try repo.getRule(category: .nsaid, type: .cooldown)?.updatedAt
+        XCTAssertNotNil(second)
+        XCTAssertGreaterThan(second!, first!)
+    }
+
     func test_can_store_cooldown_and_period_limit_for_same_category() throws {
         let cooldown = CategorySafetyRule(
             id: "c", category: .nsaid, type: .cooldown,

--- a/mobile-apps/ios/MigraLogTests/Repositories/EpisodeRepositoryTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Repositories/EpisodeRepositoryTests.swift
@@ -76,7 +76,8 @@ final class EpisodeRepositoryTests: XCTestCase {
             onsetTime: onsetTime,
             resolutionTime: nil,
             severity: 5.0,
-            createdAt: TimestampHelper.now
+            createdAt: TimestampHelper.now,
+            updatedAt: TimestampHelper.now
         )
     }
 
@@ -108,7 +109,8 @@ final class EpisodeRepositoryTests: XCTestCase {
             episodeId: episodeId,
             timestamp: timestamp,
             note: note,
-            createdAt: TimestampHelper.now
+            createdAt: TimestampHelper.now,
+            updatedAt: TimestampHelper.now
         )
     }
 
@@ -367,6 +369,9 @@ final class EpisodeRepositoryTests: XCTestCase {
         let log = makeSymptomLog(episodeId: episode.id, symptom: .nausea)
         try repo.createSymptomLog(log)
 
+        let before = try repo.getSymptomLogsByEpisodeId(episode.id).first!.updatedAt
+        Thread.sleep(forTimeInterval: 0.005)  // guarantee the millis clock advances
+
         var toUpdate = log
         toUpdate.symptom = .dizziness
         let updated = try repo.updateSymptomLog(toUpdate)
@@ -374,6 +379,9 @@ final class EpisodeRepositoryTests: XCTestCase {
 
         let fetched = try repo.getSymptomLogsByEpisodeId(episode.id)
         XCTAssertEqual(fetched.first?.symptom, .dizziness)
+        // #460: editing a synced row must bump updated_at for LWW.
+        XCTAssertGreaterThan(fetched.first!.updatedAt, before)
+        XCTAssertEqual(updated.updatedAt, fetched.first!.updatedAt)
     }
 
     func testDeleteSymptomLog() throws {
@@ -467,12 +475,17 @@ final class EpisodeRepositoryTests: XCTestCase {
         let note = makeNote(episodeId: episode.id, note: "Original")
         try repo.createEpisodeNote(note)
 
+        let before = try repo.getNotesByEpisodeId(episode.id).first!.updatedAt
+        Thread.sleep(forTimeInterval: 0.005)
+
         var toUpdate = note
         toUpdate.note = "Updated text"
         try repo.updateEpisodeNote(toUpdate)
 
         let fetched = try repo.getNotesByEpisodeId(episode.id)
         XCTAssertEqual(fetched.first?.note, "Updated text")
+        // #460: editing a synced row must bump updated_at for LWW.
+        XCTAssertGreaterThan(fetched.first!.updatedAt, before)
     }
 
     func testUpdateNoteTimestamps() throws {
@@ -481,11 +494,16 @@ final class EpisodeRepositoryTests: XCTestCase {
         let note = makeNote(episodeId: episode.id, timestamp: 1_700_000_000_000)
         try repo.createEpisodeNote(note)
 
+        let before = try repo.getNotesByEpisodeId(episode.id).first!.updatedAt
+        Thread.sleep(forTimeInterval: 0.005)
+
         let offset: Int64 = 3_600_000
         try repo.updateNoteTimestamps(episodeId: episode.id, offset: offset)
 
         let notes = try repo.getNotesByEpisodeId(episode.id)
         XCTAssertEqual(notes.first?.timestamp, 1_700_000_000_000 + offset)
+        // #460: bulk timestamp shift must also bump updated_at.
+        XCTAssertGreaterThan(notes.first!.updatedAt, before)
     }
 
     func testDeleteEpisodeNote() throws {

--- a/mobile-apps/ios/MigraLogTests/Repositories/MedicationRepositoryTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Repositories/MedicationRepositoryTests.swift
@@ -373,12 +373,18 @@ final class MedicationRepositoryTests: XCTestCase {
         let schedule = makeSchedule(medicationId: med.id, time: "08:00")
         try repo.createSchedule(schedule)
 
+        let before = try repo.getSchedulesByMedicationId(med.id).first!.updatedAt
+        Thread.sleep(forTimeInterval: 0.005)
+
         var toUpdate = schedule
         toUpdate.time = "09:30"
         try repo.updateSchedule(toUpdate)
 
         let fetched = try repo.getSchedulesByMedicationId(med.id)
         XCTAssertEqual(fetched.first?.time, "09:30")
+        // #460: editing a synced row must bump updated_at for LWW.
+        XCTAssertNotNil(fetched.first?.updatedAt)
+        XCTAssertGreaterThan(fetched.first!.updatedAt!, before ?? 0)
     }
 
     func testDeleteSchedule() throws {

--- a/mobile-apps/ios/MigraLogTests/ViewModels/EpisodeDetailViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/EpisodeDetailViewModelTests.swift
@@ -159,7 +159,7 @@ final class EpisodeDetailViewModelTests: XCTestCase {
         let log = SymptomLog(
             id: "sl-1", episodeId: "ep-1", symptom: .aura,
             onsetTime: TimestampHelper.now, resolutionTime: nil,
-            severity: nil, createdAt: TimestampHelper.now
+            severity: nil, createdAt: TimestampHelper.now, updatedAt: TimestampHelper.now
         )
         mockRepo.symptomLogs = [log]
         await sut.loadEpisode()
@@ -186,7 +186,7 @@ final class EpisodeDetailViewModelTests: XCTestCase {
         let note = EpisodeNote(
             id: "n-1", episodeId: "ep-1",
             timestamp: TimestampHelper.now,
-            note: "Test note", createdAt: TimestampHelper.now
+            note: "Test note", createdAt: TimestampHelper.now, updatedAt: TimestampHelper.now
         )
         mockRepo.episodeNotes = [note]
         await sut.loadEpisode()


### PR DESCRIPTION
Closes #460

## Problem
Last-write-wins sync (`LWWResolver` / `RemoteChangeApplier` / `SyncEngine.buildRecord`) compares `updated_at`. Several repository write paths never stamped it, so a row's `updated_at` could stay at creation time and LWW would pick the wrong winner during concurrent multi-device edits.

## Fix
Carry `updatedAt` on the domain models and stamp `updated_at = TimestampHelper.now` on every synced INSERT/UPDATE:

- **Models**: `SymptomLog`, `EpisodeNote`, `MedicationSchedule`, `CategorySafetyRule` gain `updatedAt`.
- **EpisodeRepository**: `updateSymptomLog`, `updateEpisodeNote`, `updateNoteTimestamps` now stamp `updated_at`; `symptom_logs` / `episode_notes` INSERTs persist it; row mappers read `updated_at` (falling back to `created_at`).
- **MedicationRepository**: `createSchedule` / `updateSchedule` stamp + persist `updated_at`.
- **CategorySafetyRuleRepository**: `upsert` stamps `updated_at` (INSERT + `ON CONFLICT`), and `getAllRules` / `getRules` / `getRule` now `SELECT updated_at` so it round-trips — previously the column was dropped from the SELECT, leaving `updatedAt` always nil (a latent LWW bug for safety rules).

Audited **every** repository UPDATE on a synced table — all 14 now set `updated_at`. No DB migration: the `updated_at` columns already exist (v29); this is app-side stamping only.

## Tests
Repository tests assert `updated_at` strictly increases on edit: symptom log, episode note, note-timestamp shift, medication schedule, and category-rule upsert. Full unit suite green (839 tests, 0 failures) locally.

## Acceptance (#460)
- ✅ Editing any synced row updates its `updated_at`.
- Two-device LWW (newer edit wins) follows from the timestamp now being maintained on every write path; the CloudKit round-trip remains device-verify-only (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)