### PR TITLE
feat(ios): capture delete payloads for recoverable tombstones (#463)

### DIFF
--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -4,7 +4,7 @@ import GRDB
 /// Central database manager. Owns the DatabaseQueue and handles schema creation/migration.
 final class DatabaseManager: Sendable {
     /// The current schema version
-    static let schemaVersion = 33
+    static let schemaVersion = 34
 
     /// Shared singleton for the app's main database
     static let shared = DatabaseManager()
@@ -154,13 +154,26 @@ final class DatabaseManager: Sendable {
 
         // v32: Change-capture triggers that enqueue local edits to sync_pending_changes,
         // plus the sync_capture_state control flags (enabled / suppressed). See #434.
+        // includePayload: false — at v32 the `payload` column does not yet exist (it is
+        // added in v34), so the triggers must NOT reference it. Preserves historical
+        // behavior for fresh installs, which run v32 before v34.
         migrator.registerMigration("v32") { db in
-            try DatabaseManager.createSyncCaptureTriggers(in: db)
+            try DatabaseManager.createSyncCaptureTriggers(in: db, includePayload: false)
         }
 
         // v33: sync_config — the on/off switch + last-sync status for iCloud sync (#434).
         migrator.registerMigration("v33") { db in
             try DatabaseManager.createSyncConfig(in: db)
+        }
+
+        // v34: Capture delete payloads for recoverable tombstones (#463). Add the nullable
+        // `payload` column to sync_pending_changes, then DROP and re-create every
+        // sync_capture_* trigger so the DELETE triggers record the deleted row's synced
+        // columns as JSON. Existing installs already ran v32 with the old (payload-free)
+        // triggers, so they must be replaced here. Now that the column exists,
+        // includePayload: true.
+        migrator.registerMigration("v34") { db in
+            try DatabaseManager.addSyncPayloadColumn(in: db)
         }
 
         return migrator
@@ -537,14 +550,41 @@ final class DatabaseManager: Sendable {
         try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_sync_conflicts_record ON sync_conflicts(table_name, record_id)")
     }
 
+    /// v34 (#463): add the nullable `payload` column to sync_pending_changes and rebuild
+    /// the capture triggers so DELETEs retain the deleted row's data for recoverable
+    /// tombstones. Existing installs already created the old payload-free triggers in v32,
+    /// so they are dropped and re-created here with `includePayload: true`. Idempotent: the
+    /// column is added only when missing, and the triggers are dropped before re-creation.
+    static func addSyncPayloadColumn(in db: Database) throws {
+        let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(sync_pending_changes)")
+        let hasPayload = columns.contains { (row: Row) in (row["name"] as String?) == "payload" }
+        if !hasPayload {
+            try db.execute(sql: "ALTER TABLE sync_pending_changes ADD COLUMN payload TEXT")
+        }
+
+        // Drop the old (payload-free) capture triggers so they can be re-created with the
+        // delete-payload variant. Each synced table has insert/update/delete triggers.
+        for table in SyncableTable.allCases {
+            for suffix in ["insert", "update", "delete"] {
+                try db.execute(sql: "DROP TRIGGER IF EXISTS sync_capture_\(table.tableName)_\(suffix)")
+            }
+        }
+        try DatabaseManager.createSyncCaptureTriggers(in: db, includePayload: true)
+    }
+
     /// Create the change-capture machinery for iCloud sync (#434): the sync_capture_state
     /// control row plus one AFTER INSERT/UPDATE/DELETE trigger per synced table. Each
     /// trigger enqueues the row into sync_pending_changes — but only while capture is
     /// `enabled` (off until sync is switched on, so the queue can't grow unbounded) and
     /// not `suppressed` (the applier suppresses its own writes to avoid an echo loop).
-    /// Device-local; idempotent. Called only by the v32 migration — it must run after
-    /// every synced table exists (notably category_safety_rules, added in v28).
-    static func createSyncCaptureTriggers(in db: Database) throws {
+    /// Device-local; idempotent.
+    ///
+    /// `includePayload` controls whether the DELETE triggers capture the deleted row's
+    /// synced columns as a JSON `payload` for recoverable tombstones (#463). It MUST be
+    /// false at v32 (the `payload` column does not exist until v34) and true from v34 on,
+    /// once the column has been added. INSERT/UPDATE (upsert) triggers always set
+    /// `payload = NULL` — the live row is re-read at push time.
+    static func createSyncCaptureTriggers(in db: Database, includePayload: Bool) throws {
         try db.execute(sql: """
             CREATE TABLE IF NOT EXISTS sync_capture_state (
                 id INTEGER PRIMARY KEY CHECK(id = 1),
@@ -563,25 +603,43 @@ final class DatabaseManager: Sendable {
 
         for table in SyncableTable.allCases {
             let name = table.tableName
+            // The DELETE trigger snapshots the deleted row's synced columns as JSON so the
+            // tombstone is recoverable. Built only when includePayload is true (the column
+            // exists from v34 on). OLD.<col> references the about-to-be-deleted row.
+            let deletePayloadExpr = "json_object(" + table.syncedColumns
+                .map { "'\($0)', OLD.\($0)" }
+                .joined(separator: ", ") + ")"
+
             let events: [(suffix: String, timing: String, idRef: String, change: String)] = [
                 ("insert", "AFTER INSERT", "NEW.id", "upsert"),
                 ("update", "AFTER UPDATE", "NEW.id", "upsert"),
                 ("delete", "AFTER DELETE", "OLD.id", "delete"),
             ]
             for event in events {
+                // Only the DELETE trigger captures a payload; upserts re-read the live row at push time.
+                let payloadExpr = event.change == "delete" ? deletePayloadExpr : "NULL"
+                let columnList = includePayload
+                    ? "(table_name, record_id, change_type, created_at, retry_count, last_error, payload)"
+                    : "(table_name, record_id, change_type, created_at, retry_count, last_error)"
+                let valuesList = includePayload
+                    ? "('\(name)', \(event.idRef), '\(event.change)', \(nowMillis), 0, NULL, \(payloadExpr))"
+                    : "('\(name)', \(event.idRef), '\(event.change)', \(nowMillis), 0, NULL)"
+                let payloadConflictAssignment = includePayload
+                    ? ",\n                            payload = \(payloadExpr)"
+                    : ""
                 try db.execute(sql: """
                     CREATE TRIGGER IF NOT EXISTS sync_capture_\(name)_\(event.suffix)
                     \(event.timing) ON \(name)
                     \(guardClause)
                     BEGIN
                         INSERT INTO sync_pending_changes
-                            (table_name, record_id, change_type, created_at, retry_count, last_error)
-                        VALUES ('\(name)', \(event.idRef), '\(event.change)', \(nowMillis), 0, NULL)
+                            \(columnList)
+                        VALUES \(valuesList)
                         ON CONFLICT(table_name, record_id) DO UPDATE SET
                             change_type = '\(event.change)',
                             created_at = \(nowMillis),
                             retry_count = 0,
-                            last_error = NULL;
+                            last_error = NULL\(payloadConflictAssignment);
                     END
                     """)
             }

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
@@ -85,9 +85,13 @@ actor SyncEngine {
         guard let table = SyncableTable.named(change.tableName) else { return nil }
         let schemaVersion = DatabaseManager.schemaVersion
 
+        // For a delete, the AFTER DELETE trigger captured the deleted row's synced
+        // columns into `change.payload` (#463), so the tombstone carries recoverable
+        // data instead of an empty `{}`. A vanished-upsert fallback has no captured
+        // payload (nil), so it stays `{}`.
         func tombstone() -> SyncRecord {
             SyncRecord(
-                tableName: table.tableName, recordId: change.recordId, payload: "{}",
+                tableName: table.tableName, recordId: change.recordId, payload: change.payload ?? "{}",
                 schemaVersion: schemaVersion, updatedAt: change.createdAt, deleted: true
             )
         }

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncPendingChangesStore.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncPendingChangesStore.swift
@@ -16,6 +16,11 @@ struct SyncPendingChange: Equatable, Sendable {
     let createdAt: Int64
     let retryCount: Int
     let lastError: String?
+    /// For `delete` changes, a JSON snapshot of the deleted row's synced columns,
+    /// captured by the AFTER DELETE trigger so the tombstone is recoverable (#463).
+    /// `nil` for upserts (the live row is re-read at push time) and for deletes queued
+    /// before the v34 migration.
+    let payload: String?
 }
 
 /// The durable outbound queue for iCloud sync (#434). Local writes enqueue a change
@@ -88,7 +93,7 @@ final class SyncPendingChangesStore: Sendable {
             let rows = try Row.fetchAll(
                 db,
                 sql: """
-                    SELECT id, table_name, record_id, change_type, created_at, retry_count, last_error
+                    SELECT id, table_name, record_id, change_type, created_at, retry_count, last_error, payload
                     FROM sync_pending_changes
                     ORDER BY created_at ASC, id ASC
                     LIMIT ?
@@ -156,7 +161,8 @@ final class SyncPendingChangesStore: Sendable {
             changeType: changeType,
             createdAt: createdAt,
             retryCount: row["retry_count"] as Int? ?? 0,
-            lastError: row["last_error"] as String?
+            lastError: row["last_error"] as String?,
+            payload: row["payload"] as String?
         )
     }
 }

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncableTable.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncableTable.swift
@@ -52,6 +52,58 @@ enum SyncableTable: String, CaseIterable, Sendable {
         }
     }
 
+    /// The synced columns for this table, in a fixed order. This MUST equal the live
+    /// table's columns (`PRAGMA table_info`) minus `deviceLocalColumns`, matching exactly
+    /// what `SyncPayloadCodec.encodePayload` emits.
+    ///
+    /// Why this is enumerated by hand: the DELETE capture triggers build the recoverable
+    /// tombstone payload with a SQL `json_object('col', OLD.col, …)`, and a trigger cannot
+    /// read `PRAGMA table_info` to discover columns — it needs literal column names baked in
+    /// at CREATE TRIGGER time. So this list is the authoritative column inventory the
+    /// triggers iterate over.
+    ///
+    /// DRIFT RISK (#463): if a future migration adds/removes a column on one of these
+    /// tables, this list must be updated in lockstep or the captured tombstone payload will
+    /// silently miss (or wrongly include) a column. `SyncableTableSyncedColumnsTests`
+    /// asserts this list matches the live schema for every table to catch that drift.
+    var syncedColumns: [String] {
+        switch self {
+        case .episodes:
+            return ["id", "start_time", "end_time", "locations", "qualities", "symptoms",
+                    "triggers", "notes", "latitude", "longitude", "location_accuracy",
+                    "location_timestamp", "created_at", "updated_at"]
+        case .intensityReadings:
+            return ["id", "episode_id", "timestamp", "intensity", "created_at", "updated_at"]
+        case .symptomLogs:
+            return ["id", "episode_id", "symptom", "onset_time", "resolution_time",
+                    "severity", "created_at", "updated_at"]
+        case .painLocationLogs:
+            return ["id", "episode_id", "timestamp", "pain_locations", "created_at", "updated_at"]
+        case .episodeNotes:
+            return ["id", "episode_id", "timestamp", "note", "created_at", "updated_at"]
+        case .medications:
+            return ["id", "name", "type", "dosage_amount", "dosage_unit", "default_quantity",
+                    "schedule_frequency", "photo_uri", "active", "notes", "category",
+                    "created_at", "updated_at", "min_interval_hours"]
+        case .medicationSchedules:
+            // notification_id is excluded (deviceLocalColumns).
+            return ["id", "medication_id", "time", "timezone", "dosage", "enabled",
+                    "reminder_enabled", "created_at", "updated_at"]
+        case .medicationDoses:
+            return ["id", "medication_id", "timestamp", "quantity", "dosage_amount",
+                    "dosage_unit", "status", "episode_id", "effectiveness_rating",
+                    "time_to_relief", "side_effects", "notes", "created_at", "updated_at"]
+        case .dailyStatusLogs:
+            return ["id", "date", "status", "status_type", "notes", "prompted",
+                    "created_at", "updated_at"]
+        case .calendarOverlays:
+            return ["id", "start_date", "end_date", "label", "notes", "exclude_from_stats",
+                    "created_at", "updated_at"]
+        case .categorySafetyRules:
+            return ["id", "category", "type", "period_hours", "max_count", "created_at", "updated_at"]
+        }
+    }
+
     /// Look up a syncable table by its SQLite name. Returns nil for tables that are
     /// not synced (device-local or sync-internal).
     static func named(_ tableName: String) -> SyncableTable? {

--- a/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
@@ -188,7 +188,7 @@ final class DatabaseManagerTests: XCTestCase {
     // MARK: - Schema Version
 
     func testSchemaVersionIsTracked() throws {
-        XCTAssertEqual(DatabaseManager.schemaVersion, 33)
+        XCTAssertEqual(DatabaseManager.schemaVersion, 34)
     }
 
     func testMigrationIsRecordedInGRDB() throws {

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncCaptureTriggerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncCaptureTriggerTests.swift
@@ -90,6 +90,73 @@ final class SyncCaptureTriggerTests: XCTestCase {
         XCTAssertEqual(queued[0].type, "delete", "a delete supersedes the pending upsert")
     }
 
+    // MARK: - Delete payload capture (#463)
+
+    private func pendingPayload(table: String, recordId: String) throws -> String? {
+        try dbManager.dbQueue.read { db in
+            try String.fetchOne(
+                db,
+                sql: "SELECT payload FROM sync_pending_changes WHERE table_name = ? AND record_id = ?",
+                arguments: [table, recordId]
+            )
+        }
+    }
+
+    func testDeleteCapturesRowPayload() throws {
+        try enableCapture()
+        try insertMedication("m1")
+        try dbManager.dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM medications WHERE id = 'm1'")
+        }
+
+        let queued = try pending()
+        XCTAssertEqual(queued.count, 1)
+        XCTAssertEqual(queued[0].type, "delete")
+
+        // The AFTER DELETE trigger snapshots the deleted row's synced columns as JSON.
+        let payload = try pendingPayload(table: "medications", recordId: "m1")
+        let json = try XCTUnwrap(payload, "delete tombstone must carry the captured row payload")
+        let obj = try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        let keys = Set(try XCTUnwrap(obj).keys)
+
+        // Captured keys must be exactly the synced columns for the table.
+        XCTAssertEqual(keys, Set(SyncableTable.medications.syncedColumns))
+        XCTAssertEqual(obj?["id"] as? String, "m1")
+        XCTAssertEqual(obj?["name"] as? String, "Med")
+    }
+
+    func testDeletePayloadExcludesDeviceLocalColumns() throws {
+        try enableCapture()
+        // medication_schedules.notification_id is device-local and must not be captured.
+        try insertMedication("m1")
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO medication_schedules
+                        (id, medication_id, time, timezone, dosage, enabled, notification_id,
+                         reminder_enabled, created_at, updated_at)
+                    VALUES ('s1', 'm1', '08:00', 'America/New_York', 1.0, 1, 'notif-xyz', 1, 1000, 1000)
+                    """
+            )
+            try db.execute(sql: "DELETE FROM medication_schedules WHERE id = 's1'")
+        }
+
+        let payload = try XCTUnwrap(try pendingPayload(table: "medication_schedules", recordId: "s1"))
+        let obj = try JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any]
+        let keys = Set(try XCTUnwrap(obj).keys)
+        XCTAssertEqual(keys, Set(SyncableTable.medicationSchedules.syncedColumns))
+        XCTAssertFalse(keys.contains("notification_id"), "device-local column must not be captured")
+    }
+
+    func testUpsertHasNoPayload() throws {
+        try enableCapture()
+        try insertMedication("m1")
+        XCTAssertNil(
+            try pendingPayload(table: "medications", recordId: "m1"),
+            "upserts carry no payload — the live row is re-read at push time"
+        )
+    }
+
     // MARK: - Echo suppression
 
     func testApplierWritesAreNotCaptured() throws {

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
@@ -91,6 +91,28 @@ final class SyncEngineTests: XCTestCase {
         XCTAssertEqual(try pendingStore.pendingCount(), 0)
     }
 
+    func testPushDeleteCarriesCapturedPayload() async throws {
+        // The AFTER DELETE trigger captures the deleted row's synced columns as JSON into
+        // sync_pending_changes.payload (#463). buildRecord must put that payload on the
+        // tombstone for recoverability, instead of an empty `{}`.
+        let captured = #"{"id":"gone","name":"Removed Med","type":"rescue"}"#
+        try await dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO sync_pending_changes
+                        (table_name, record_id, change_type, created_at, retry_count, last_error, payload)
+                    VALUES ('medications', 'gone', 'delete', 2000, 0, NULL, ?)
+                    """,
+                arguments: [captured]
+            )
+        }
+
+        _ = try await engine.push()
+        let record = transport.record(named: "medications:gone")
+        XCTAssertEqual(record?.deleted, true)
+        XCTAssertEqual(record?.payload, captured, "tombstone must carry the captured delete payload, not {}")
+    }
+
     // MARK: - Pull
 
     func testPullAppliesRemoteRecordAndSavesToken() async throws {

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncableTableSyncedColumnsTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncableTableSyncedColumnsTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import GRDB
+@testable import MigraLog
+
+/// Guards the hand-maintained `SyncableTable.syncedColumns` lists against schema drift
+/// (#463). The DELETE capture triggers bake these column names into a SQL `json_object`,
+/// so if a migration adds/removes a column on a synced table without updating
+/// `syncedColumns`, the recoverable tombstone would silently miss (or wrongly include) a
+/// column. This asserts, for every synced table, that `syncedColumns` equals the live
+/// table's columns minus `deviceLocalColumns`.
+final class SyncableTableSyncedColumnsTests: XCTestCase {
+    var dbManager: DatabaseManager!
+
+    override func setUpWithError() throws {
+        dbManager = try DatabaseManager(inMemory: true)
+    }
+
+    override func tearDownWithError() throws {
+        dbManager = nil
+    }
+
+    func testSyncedColumnsMatchLiveSchemaForEveryTable() throws {
+        try dbManager.dbQueue.read { db in
+            for table in SyncableTable.allCases {
+                let liveColumns = try Row
+                    .fetchAll(db, sql: "PRAGMA table_info(\(table.tableName))")
+                    .compactMap { $0["name"] as String? }
+                let expected = Set(liveColumns).subtracting(table.deviceLocalColumns)
+                let declared = Set(table.syncedColumns)
+
+                XCTAssertFalse(liveColumns.isEmpty, "\(table.tableName) has no columns — wrong table name?")
+                XCTAssertEqual(
+                    declared, expected,
+                    """
+                    syncedColumns drift for \(table.tableName):
+                      missing from syncedColumns: \(expected.subtracting(declared).sorted())
+                      extra in syncedColumns:      \(declared.subtracting(expected).sorted())
+                    """
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #463

## Problem
The AFTER DELETE capture triggers enqueued a `delete` with no payload, so the CloudKit tombstone (`SyncEngine.buildRecord`) carried `{}`. Delete propagation worked, but the deleted row's data was lost — defeating the original hard-delete+queue intent of keeping deletes recoverable.

## Changes
- **Migration v34** (`schemaVersion` 33 → 34): adds a nullable `payload` column to `sync_pending_changes`, then DROPs and re-creates every `sync_capture_*` trigger so DELETEs snapshot the deleted row.
- **`createSyncCaptureTriggers(includePayload:)`** is parameterized. v32 calls it with `false` (on a fresh install v32 runs *before* the column exists, so its triggers must not reference `payload`); v34 adds the column then re-creates with `true`. Both the fresh (v25→v34) and existing (v33→v34) install paths were traced.
- **DELETE triggers** build the payload as `json_object('col', OLD.col, …)` over each table's synced columns. INSERT/UPDATE triggers keep `payload` NULL — the live row is re-read at push time.
- **`SyncableTable.syncedColumns`**: the authoritative per-table column inventory the triggers iterate (a trigger can't read `PRAGMA`, so column names are baked in). A **drift-guard test** asserts this equals the live schema (`PRAGMA table_info` minus `deviceLocalColumns`) for every synced table, so a future column add/remove that forgets this list fails loudly.
- **`SyncPendingChange`** / store carry `payload`; **`SyncEngine.buildRecord`** uses it for delete tombstones (falls back to `{}` for the vanished-upsert case).

## Tests
- Deleting a row captures its synced columns as JSON in `sync_pending_changes.payload`.
- Device-local columns (`medication_schedules.notification_id`) are excluded from the payload.
- Upserts carry no payload.
- A pushed delete tombstone now carries the captured payload, not `{}`.
- Schema-drift guard across all 11 synced tables.

Full unit suite green (843 tests, 0 failures) locally. The live CloudKit round-trip remains device-verify-only (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)