### PR TITLE
feat(ios): background refresh via BGTaskScheduler (#462)

### DIFF
--- a/mobile-apps/ios/MigraLog/App/ContentView.swift
+++ b/mobile-apps/ios/MigraLog/App/ContentView.swift
@@ -44,8 +44,14 @@ struct ContentView: View {
         }
         .task { syncService.startAutoSync() }
         .onChange(of: scenePhase) { _, phase in
-            if phase == .active {
+            switch phase {
+            case .active:
                 Task { await syncService.syncIfEnabled() }
+            case .background:
+                // Queue a background refresh so changes keep syncing while backgrounded (#462).
+                BackgroundSyncScheduler.schedule()
+            default:
+                break
             }
         }
     }

--- a/mobile-apps/ios/MigraLog/App/Info.plist
+++ b/mobile-apps/ios/MigraLog/App/Info.plist
@@ -56,6 +56,16 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>
+		<!-- `fetch` enables BGAppRefreshTask for lightweight background sync (#462).
+		     Sync is light, so we use a BGAppRefreshTask (fetch) rather than a
+		     BGProcessingTask (processing). See BackgroundSyncScheduler.swift. -->
+		<string>fetch</string>
+	</array>
+	<!-- BGTaskScheduler identifiers must be declared here for the system to permit
+	     scheduling them. Matches BackgroundSyncScheduler.taskIdentifier (#462). -->
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.eff3.migralog.sync.refresh</string>
 	</array>
 </dict>
 </plist>

--- a/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
+++ b/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
@@ -1,8 +1,12 @@
 import SwiftUI
+import UIKit
 import UserNotifications
 
 @main
 struct MigraLogApp: App {
+    /// Owns the shared `SyncService` and registers the background-refresh task before the
+    /// app finishes launching (BGTaskScheduler requires registration at launch — #462).
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var appState = AppState()
 
     /// Notification response handler — must be retained for the lifetime of the app.
@@ -11,7 +15,6 @@ struct MigraLogApp: App {
     private let medicationNotificationService: MedicationNotificationScheduler
     private let dailyCheckinService: DailyCheckinNotificationService
     @State private var timezoneChangeService: TimezoneChangeService
-    @State private var syncService: SyncService
 
     init() {
         SentrySetup.start()
@@ -56,7 +59,6 @@ struct MigraLogApp: App {
         self._timezoneChangeService = State(
             initialValue: TimezoneChangeService(medicationRepo: medicationRepository)
         )
-        self._syncService = State(initialValue: SyncService())
     }
 
     var body: some Scene {
@@ -64,7 +66,7 @@ struct MigraLogApp: App {
             ContentView()
                 .environment(appState)
                 .environment(timezoneChangeService)
-                .environment(syncService)
+                .environment(appDelegate.syncService)
                 .task {
                     await reconciliationService.reconcile()
                     await medicationNotificationService.topUp()
@@ -72,6 +74,23 @@ struct MigraLogApp: App {
                     await timezoneChangeService.checkForChange()
                 }
         }
+    }
+}
+
+/// Owns the single shared `SyncService` and registers the background-refresh task. A
+/// `UIApplicationDelegate` is required because `BGTaskScheduler.register` must run before
+/// `didFinishLaunchingWithOptions` returns — SwiftUI's `App` lifecycle has no equivalent
+/// pre-launch hook (#462).
+@MainActor
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    let syncService = SyncService()
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        BackgroundSyncScheduler.register(syncService: syncService)
+        return true
     }
 }
 

--- a/mobile-apps/ios/MigraLog/Services/Sync/BackgroundSyncScheduler.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/BackgroundSyncScheduler.swift
@@ -1,0 +1,54 @@
+@preconcurrency import BackgroundTasks
+import Foundation
+
+/// Background refresh for iCloud sync (#462). Registers a `BGAppRefreshTask` that runs a
+/// sync while the app is backgrounded, so changes propagate without the app being open.
+/// Complements the existing foreground + after-write auto-sync triggers.
+///
+/// Only the pure scheduling decisions (`nextEarliestBeginDate`) are unit-testable; the
+/// BGTaskScheduler registration/submission glue does nothing in the simulator or CI and
+/// can only be exercised on a real device with the Background Modes capability
+/// provisioned, so it is device-verify-only.
+enum BackgroundSyncScheduler {
+    /// Must match the single `BGTaskSchedulerPermittedIdentifiers` entry in Info.plist.
+    static let taskIdentifier = "com.eff3.migralog.sync.refresh"
+
+    /// How far out to ask the system to schedule the next refresh. This is a lower bound;
+    /// the system picks the actual time based on usage patterns and energy budgets.
+    static let refreshInterval: TimeInterval = 15 * 60
+
+    /// Register the launch handler. Must run before the app finishes launching (from the
+    /// app delegate's `didFinishLaunchingWithOptions`), or BGTaskScheduler raises.
+    @MainActor
+    static func register(syncService: SyncService) {
+        BGTaskScheduler.shared.register(forTaskWithIdentifier: taskIdentifier, using: nil) { task in
+            // The handler is delivered on a system queue. Hop to the main actor to touch the
+            // main-actor-isolated SyncService and to re-schedule, keeping the BGTask alive
+            // until the sync finishes.
+            let work = Task { @MainActor in
+                schedule()
+                await syncService.syncIfEnabled()
+                task.setTaskCompleted(success: true)
+            }
+            task.expirationHandler = { work.cancel() }
+        }
+    }
+
+    /// Ask the system to schedule the next background refresh. Safe to call when sync is
+    /// off — the handler re-checks `isEnabled` via `syncIfEnabled()` before doing any work.
+    /// Submission failures (simulator, missing entitlement, over budget) are swallowed; we
+    /// never log health data (HIPAA).
+    @MainActor
+    static func schedule(now: Date = Date()) {
+        let request = BGAppRefreshTaskRequest(identifier: taskIdentifier)
+        request.earliestBeginDate = nextEarliestBeginDate(from: now)
+        try? BGTaskScheduler.shared.submit(request)
+    }
+
+    // MARK: - Pure helpers (unit-tested)
+
+    /// The earliest time the next refresh should run: `refreshInterval` after `now`.
+    static func nextEarliestBeginDate(from now: Date) -> Date {
+        now.addingTimeInterval(refreshInterval)
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/BackgroundSyncSchedulerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/BackgroundSyncSchedulerTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import MigraLog
+
+/// Covers the pure, testable surface of `BackgroundSyncScheduler` (#462). The live
+/// BGTaskScheduler registration/submission can only be verified on a real device, so it
+/// is not exercised here — `schedule()` is only checked to be a safe no-op when the
+/// scheduler is unavailable (as in the simulator).
+final class BackgroundSyncSchedulerTests: XCTestCase {
+    func testNextEarliestBeginDateIsRefreshIntervalAhead() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let next = BackgroundSyncScheduler.nextEarliestBeginDate(from: now)
+        XCTAssertEqual(next.timeIntervalSince(now), BackgroundSyncScheduler.refreshInterval, accuracy: 0.001)
+        XCTAssertEqual(next, now.addingTimeInterval(15 * 60))
+    }
+
+    func testRefreshIntervalIsFifteenMinutes() {
+        XCTAssertEqual(BackgroundSyncScheduler.refreshInterval, 15 * 60)
+    }
+
+    func testTaskIdentifierMatchesPermittedIdentifierContract() {
+        // Must equal the single BGTaskSchedulerPermittedIdentifiers entry in Info.plist.
+        XCTAssertEqual(BackgroundSyncScheduler.taskIdentifier, "com.eff3.migralog.sync.refresh")
+    }
+
+    @MainActor
+    func testScheduleIsSafeWhenSchedulerUnavailable() {
+        // In the simulator BGTaskScheduler.submit throws; schedule() must swallow it and
+        // not crash.
+        BackgroundSyncScheduler.schedule()
+    }
+}


### PR DESCRIPTION
Closes #462

## What
Sync ran only on app **foreground** and **after a write** (debounced). This adds a `BGAppRefreshTask` so changes keep propagating while the app is backgrounded.

## Changes
- **Info.plist**: `fetch` added to `UIBackgroundModes`; `BGTaskSchedulerPermittedIdentifiers` = `[com.eff3.migralog.sync.refresh]`.
- **`BackgroundSyncScheduler`** (new): registers the task at launch, reschedules ~15 min out, and runs `SyncService.syncIfEnabled()` in the handler. `syncIfEnabled` already gates on `isEnabled`, and `SyncEngine` checks CloudKit account availability, so no work happens when sync is off or signed out. The handler reschedules first (so the chain survives early termination) and sets an `expirationHandler` that cancels the in-flight sync.
- **`AppDelegate`** (via `@UIApplicationDelegateAdaptor`): owns the single shared `SyncService` and calls `BackgroundSyncScheduler.register` in `didFinishLaunchingWithOptions` — `BGTaskScheduler.register` must run before launch completes, which the SwiftUI `App` lifecycle can't express. The **same** `SyncService` instance is injected into the environment, so foreground/after-write/background triggers all share one actor-serialized engine (no duplicate instance with stale state).
- **`ContentView`**: schedules the next refresh on `scenePhase == .background`.

## Tests
`nextEarliestBeginDate` is 15 min ahead; `refreshInterval` + `taskIdentifier` contract; `schedule()` is a safe no-op when the scheduler is unavailable (simulator). Full unit suite green (842 tests, 0 failures) locally.

## ⚠️ Device / provisioning notes
- BGTaskScheduler **cannot** be exercised in CI or the simulator (`submit` throws there, which we swallow) — this is **device-verify-only**.
- The **Background Modes** capability is declared via Info.plist (`UIBackgroundModes`), which needs no separate entitlement, but confirm the App ID / provisioning profile carries Background Modes when building for device/TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)