### PR TITLE
feat(ios): server-side conflict detection on push (#461)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/Sync/CloudKitSyncTransport.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/CloudKitSyncTransport.swift
@@ -39,19 +39,102 @@ final class CloudKitSyncTransport: CloudKitTransport, @unchecked Sendable {
         }
     }
 
-    /// Save records (upserts and tombstones) to the zone. Uses `.allKeys` so our
-    /// already-resolved version overwrites the server's regardless of change tag, and
-    /// `atomically: true` so a partial failure throws (the engine keeps the queue and
-    /// retries) rather than silently dropping changes.
-    func push(_ records: [SyncRecord]) async throws {
-        guard !records.isEmpty else { return }
-        let ckRecords = records.map { makeCKRecord(from: $0) }
+    /// Maximum optimistic-concurrency passes before falling back to a force-save, so a
+    /// pathologically hot record can't loop forever.
+    private static let maxPushAttempts = 5
+
+    /// Save records (upserts and tombstones), resolving server-side conflicts by
+    /// last-write-wins (#461). Each record is saved with `.ifServerRecordUnchanged`
+    /// (`atomically: false`), so the server rejects a save when it already holds a version
+    /// different from the one we based ours on. For each rejected record we compare our
+    /// version against the server's by `updatedAt` (LWW): if ours is newer we re-save into
+    /// the *server* record — which carries the current change tag — and retry; if the
+    /// server's is newer we drop ours and return it so the engine applies it locally and
+    /// converges. This closes the residual pull→push race where another device wrote a
+    /// newer version into the zone during our sync window. Returns the server records that
+    /// won (empty in the common no-conflict case).
+    ///
+    /// ⚠️ Device-verify-only: the CloudKit conflict path cannot run in CI or the
+    /// simulator. The contract (LWW at push, return the server winners) is exercised
+    /// against the in-memory fake in tests.
+    @discardableResult
+    func push(_ records: [SyncRecord]) async throws -> [SyncRecord] {
+        guard !records.isEmpty else { return [] }
+        var desired: [CKRecord.ID: SyncRecord] = [:]
+        var toSave: [CKRecord] = records.map { record in
+            let ck = makeCKRecord(from: record)
+            desired[ck.recordID] = record
+            return ck
+        }
+        var serverWon: [SyncRecord] = []
+
+        for _ in 0..<Self.maxPushAttempts {
+            let conflicts = try await saveResolvingConflicts(toSave)
+            if conflicts.isEmpty { return serverWon }
+
+            var retry: [CKRecord] = []
+            for (recordID, serverRecord) in conflicts {
+                guard let want = desired[recordID] else { continue }
+                let server = Self.makeSyncRecord(from: serverRecord)
+                let winner = server.map {
+                    LWWResolver.resolve(
+                        localUpdatedAt: want.updatedAt, localPayload: want.payload,
+                        remoteUpdatedAt: $0.updatedAt, remotePayload: $0.payload
+                    )
+                } ?? .local
+                if winner == .remote, let server {
+                    serverWon.append(server)        // server is newer — keep it, converge locally.
+                    desired[recordID] = nil
+                } else {
+                    // We win: write our fields into the server record so the save carries
+                    // the current change tag and passes the .ifServerRecordUnchanged check.
+                    writeFields(of: want, into: serverRecord)
+                    retry.append(serverRecord)
+                }
+            }
+            toSave = retry
+            if toSave.isEmpty { return serverWon }
+        }
+
+        // Last resort after repeated conflicts on the same hot record: force-save what
+        // remains so our edit isn't silently lost. Bounded by maxPushAttempts above.
+        if !toSave.isEmpty {
+            do {
+                _ = try await database.modifyRecords(
+                    saving: toSave, deleting: [], savePolicy: .allKeys, atomically: false
+                )
+            } catch {
+                throw Self.mapError(error)
+            }
+        }
+        return serverWon
+    }
+
+    /// One optimistic-concurrency save pass. Returns the records the server rejected
+    /// because it holds a changed version, paired with that server record. Throws (mapped)
+    /// for any other failure so the engine keeps the queue and retries.
+    private func saveResolvingConflicts(_ ckRecords: [CKRecord]) async throws -> [(CKRecord.ID, CKRecord)] {
         do {
             _ = try await database.modifyRecords(
-                saving: ckRecords, deleting: [], savePolicy: .allKeys, atomically: true
+                saving: ckRecords, deleting: [], savePolicy: .ifServerRecordUnchanged, atomically: false
             )
+            return []
         } catch {
-            throw Self.mapError(error)
+            guard let ckError = error as? CKError, ckError.code == .partialFailure,
+                  let perItem = ckError.partialErrorsByItemID else {
+                throw Self.mapError(error)
+            }
+            var conflicts: [(CKRecord.ID, CKRecord)] = []
+            for (key, itemError) in perItem {
+                guard let itemCK = itemError as? CKError, itemCK.code == .serverRecordChanged else {
+                    // A non-conflict per-item failure (zone gone, quota, …) — surface it.
+                    throw Self.mapError(error)
+                }
+                if let id = key as? CKRecord.ID, let server = itemCK.serverRecord {
+                    conflicts.append((id, server))
+                }
+            }
+            return conflicts
         }
     }
 
@@ -105,13 +188,19 @@ final class CloudKitSyncTransport: CloudKitTransport, @unchecked Sendable {
     private func makeCKRecord(from record: SyncRecord) -> CKRecord {
         let recordID = CKRecord.ID(recordName: record.recordName, zoneID: zoneID)
         let ckRecord = CKRecord(recordType: Self.recordType, recordID: recordID)
+        writeFields(of: record, into: ckRecord)
+        return ckRecord
+    }
+
+    /// Copy a `SyncRecord`'s fields onto a `CKRecord`. Used both to build a fresh record
+    /// and to re-stamp a fetched server record (preserving its change tag) on conflict.
+    private func writeFields(of record: SyncRecord, into ckRecord: CKRecord) {
         ckRecord["tableName"] = record.tableName
         ckRecord["recordId"] = record.recordId
         ckRecord["payload"] = record.payload
         ckRecord["schemaVersion"] = Int64(record.schemaVersion)
         ckRecord["updatedAt"] = record.updatedAt
         ckRecord["deleted"] = Int64(record.deleted ? 1 : 0)
-        return ckRecord
     }
 
     private static func makeSyncRecord(from ckRecord: CKRecord) -> SyncRecord? {

--- a/mobile-apps/ios/MigraLog/Services/Sync/CloudKitTransport.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/CloudKitTransport.swift
@@ -39,9 +39,15 @@ protocol CloudKitTransport: Sendable {
     /// Create the custom record zone if it does not already exist. Idempotent.
     func ensureZone() async throws
 
-    /// Save the given records (upserts and tombstones) to the zone. Throws if any
-    /// record fails to save.
-    func push(_ records: [SyncRecord]) async throws
+    /// Save the given records (upserts and tombstones) to the zone, resolving any
+    /// server-side conflict by last-write-wins (#461). A record is only overwritten when
+    /// our version wins LWW against whatever the server currently holds; when the server
+    /// holds a *newer* version, ours is dropped and the server's is returned so the engine
+    /// can apply it locally and converge. Returns the server records that won (empty in the
+    /// common no-conflict case). Throws if any record fails to save for a non-conflict
+    /// reason (the engine keeps the queue and retries).
+    @discardableResult
+    func push(_ records: [SyncRecord]) async throws -> [SyncRecord]
 
     /// Fetch changes since `token` (nil for a first full sync). Returns the changed
     /// records, the new token to persist, and whether more pages remain.

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
@@ -44,30 +44,39 @@ actor SyncEngine {
         // and clobbering the winner. Push-then-pull would force-overwrite the newer
         // remote record with our stale local one.
         let applied = try await pull(now: now)
-        let pushed = try await push()
+        let pushed = try await push(now: now)
         return (pushed, applied)
     }
 
     // MARK: - Push
 
-    /// Drain the pending-changes queue in batches, push each, and remove the
-    /// successfully-sent entries. Returns the number of changes pushed.
+    /// Drain the pending-changes queue in batches, push each, and remove the drained
+    /// entries. The transport resolves any server-side conflict by last-write-wins (#461);
+    /// when the server holds a newer version it is returned here and applied locally so the
+    /// database converges (and the losing local edit is archived as a conflict). Returns the
+    /// number of queued changes drained.
     @discardableResult
-    func push(batchSize: Int = 100) async throws -> Int {
+    func push(batchSize: Int = 100, now: Int64 = TimestampHelper.now) async throws -> Int {
         var total = 0
         while true {
             let pending = try pendingStore.fetchBatch(limit: batchSize)
             if pending.isEmpty { break }
 
             let records = try pending.compactMap { try buildRecord(for: $0) }
+            var serverWon: [SyncRecord] = []
             if !records.isEmpty {
                 do {
-                    try await transport.push(records)
+                    serverWon = try await transport.push(records)
                 } catch SyncTransportError.zoneNotFound {
                     // Zone vanished (e.g. user deleted iCloud data) — recreate and retry once.
                     try await transport.ensureZone()
-                    try await transport.push(records)
+                    serverWon = try await transport.push(records)
                 }
+            }
+            // Apply records the server held a newer version of, before clearing the queue,
+            // so the applier still sees the (losing) pending edit and archives it.
+            for record in serverWon {
+                try applier.apply(record, now: now)
             }
             try pendingStore.remove(ids: pending.map { $0.id })
             total += pending.count

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/InMemoryCloudKitTransport.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/InMemoryCloudKitTransport.swift
@@ -31,18 +31,43 @@ final class InMemoryCloudKitTransport: CloudKitTransport, @unchecked Sendable {
         zoneCreated = true
     }
 
-    func push(_ records: [SyncRecord]) async throws {
+    @discardableResult
+    func push(_ records: [SyncRecord]) async throws -> [SyncRecord] {
         lock.lock(); defer { lock.unlock() }
         if let error = failNextPush {
             failNextPush = nil
             throw error
         }
         pushCount += 1
+        var serverWon: [SyncRecord] = []
         for record in records {
+            // Optimistic concurrency: only overwrite when our version wins LWW against
+            // whatever the zone currently holds (#461). A newer server version is kept and
+            // returned so the engine can converge locally.
+            if let existing = storage[record.recordName] {
+                let winner = LWWResolver.resolve(
+                    localUpdatedAt: record.updatedAt, localPayload: record.payload,
+                    remoteUpdatedAt: existing.updatedAt, remotePayload: existing.payload
+                )
+                if winner == .remote {
+                    serverWon.append(existing)
+                    continue
+                }
+            }
             seq += 1
             storage[record.recordName] = record
             changeSeq[record.recordName] = seq
         }
+        return serverWon
+    }
+
+    /// Test helper: seed a record directly into the zone as if another device had pushed
+    /// it, bypassing `push`'s conflict resolution.
+    func seed(_ record: SyncRecord) {
+        lock.lock(); defer { lock.unlock() }
+        seq += 1
+        storage[record.recordName] = record
+        changeSeq[record.recordName] = seq
     }
 
     func fetchChanges(since token: Data?) async throws -> SyncChangeBatch {

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/InMemoryCloudKitTransportTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/InMemoryCloudKitTransportTests.swift
@@ -76,4 +76,27 @@ final class InMemoryCloudKitTransportTests: XCTestCase {
         try await transport.push([rec("episodes", "e1")])
         XCTAssertEqual(transport.pushCount, 1, "only the successful push counts")
     }
+
+    // MARK: - LWW at push (#461)
+
+    func testPushKeepsNewerServerRecordAndReturnsIt() async throws {
+        let transport = InMemoryCloudKitTransport()
+        transport.seed(rec("episodes", "e1", updatedAt: 5, payload: #"{"v":"server"}"#))
+
+        let serverWon = try await transport.push([rec("episodes", "e1", updatedAt: 2, payload: #"{"v":"local"}"#)])
+
+        XCTAssertEqual(serverWon.map { $0.recordName }, ["episodes:e1"], "the newer server record is returned")
+        XCTAssertEqual(transport.record(named: "episodes:e1")?.updatedAt, 5, "the stale push must not clobber it")
+        XCTAssertEqual(transport.record(named: "episodes:e1")?.payload, #"{"v":"server"}"#)
+    }
+
+    func testPushOverwritesOlderServerRecordAndReturnsEmpty() async throws {
+        let transport = InMemoryCloudKitTransport()
+        transport.seed(rec("episodes", "e1", updatedAt: 2))
+
+        let serverWon = try await transport.push([rec("episodes", "e1", updatedAt: 5)])
+
+        XCTAssertTrue(serverWon.isEmpty, "our newer version wins, nothing to converge")
+        XCTAssertEqual(transport.record(named: "episodes:e1")?.updatedAt, 5)
+    }
 }

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
@@ -113,6 +113,39 @@ final class SyncEngineTests: XCTestCase {
         XCTAssertEqual(record?.payload, captured, "tombstone must carry the captured delete payload, not {}")
     }
 
+    // MARK: - Concurrent-edit-during-sync hardening (#461)
+
+    func testPushDoesNotClobberNewerServerRecordAndConvergesLocally() async throws {
+        // A local edit is queued at t=1000.
+        try insertMedication("m1", name: "Local", updatedAt: 1000)
+        try pendingStore.enqueue(tableName: "medications", recordId: "m1", changeType: .upsert, at: 1000)
+        // Another device wrote a NEWER version into the zone during our pull→push window.
+        transport.seed(remoteMedication("m1", name: "Remote", updatedAt: 2000))
+
+        _ = try await engine.push(now: 3000)
+
+        // Our stale push must not overwrite the newer server record...
+        XCTAssertEqual(transport.record(named: "medications:m1")?.updatedAt, 2000)
+        XCTAssertEqual(transport.record(named: "medications:m1")?.payload.contains("Remote"), true)
+        // ...and the local DB converged to the server's version (losing local edit archived).
+        XCTAssertEqual(try medicationName("m1"), "Remote")
+        XCTAssertEqual(try pendingStore.pendingCount(), 0, "queue drained")
+    }
+
+    func testPushOverwritesOlderServerRecord() async throws {
+        // Our local edit is the newer one.
+        try insertMedication("m1", name: "Local", updatedAt: 5000)
+        try pendingStore.enqueue(tableName: "medications", recordId: "m1", changeType: .upsert, at: 5000)
+        transport.seed(remoteMedication("m1", name: "Remote", updatedAt: 2000))
+
+        _ = try await engine.push(now: 6000)
+
+        // Our newer version wins and lands on the server; local is unchanged.
+        XCTAssertEqual(transport.record(named: "medications:m1")?.payload.contains("Local"), true)
+        XCTAssertEqual(transport.record(named: "medications:m1")?.updatedAt, 5000)
+        XCTAssertEqual(try medicationName("m1"), "Local")
+    }
+
     // MARK: - Pull
 
     func testPullAppliesRemoteRecordAndSavesToken() async throws {


### PR DESCRIPTION
Closes #461

## Problem
Push used `savePolicy: .allKeys` (force-overwrite) because the client resolves LWW itself. Pull-then-push (#454) closed the common clobber case, but a residual race remained: if another device wrote a **newer** version into CloudKit during our pull→push window, our push force-overwrote it and the newer edit was lost.

## Fix — make the push contract last-write-wins aware
- **`CloudKitTransport.push`** now returns the server records that won LWW against our push (empty in the common no-conflict case).
- **`CloudKitSyncTransport`**: `.allKeys` → per-record `.ifServerRecordUnchanged` (`atomically: false`). On `CKError.serverRecordChanged`, re-resolve LWW against the server record (`updatedAt`): if ours is newer, re-save into the fetched server record — which carries the current change tag — and retry (bounded by `maxPushAttempts`); if the server's is newer, drop ours and return it. A bounded force-save last resort prevents a livelock on a pathologically hot record.
- **`InMemoryCloudKitTransport`** models the same contract (LWW at push), so the race is **unit-testable**; adds a `seed()` helper to plant a server record directly.
- **`SyncEngine.push`** applies the returned server-won records via `RemoteChangeApplier`, so the local DB converges in the same cycle and the losing local edit is archived as a conflict. `now` is threaded through `push`.

## Tests
- A stale local push does **not** clobber a newer server record, and the engine converges locally (`testPushDoesNotClobberNewerServerRecordAndConvergesLocally`).
- A newer local push overwrites an older server record (`testPushOverwritesOlderServerRecord`).
- Transport-level LWW-at-push in both directions (`InMemoryCloudKitTransportTests`).

Full unit suite green locally. The real CloudKit conflict path is **device-verify-only** (cannot run in CI/simulator); the contract is exercised against the in-memory fake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)