### PR TITLE
fix(ios): stabilize nightly DailyStatus UI test (#468)

### DIFF
--- a/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
@@ -69,8 +69,35 @@ final class DashboardViewModel {
 
     // MARK: - Actions
 
+    /// Coalesces overlapping reloads. The dashboard fires `loadData()` from several
+    /// triggers that can overlap (first appearance, sheet dismissal, the
+    /// `.medicationDataChanged` notification). Running them concurrently thrashes the
+    /// `@Observable` state and keeps the view re-rendering, so the app never reaches the
+    /// idle state XCUITest waits on before a tab button becomes hittable. We serialise
+    /// into at most one in-flight pass plus a single trailing refresh, so the latest data
+    /// is still fetched after a write without the concurrent churn.
+    @ObservationIgnored private var loadTask: Task<Void, Never>?
+    @ObservationIgnored private var reloadRequested = false
+
     @MainActor
     func loadData() async {
+        if loadTask != nil {
+            // A load is already running; request one trailing refresh instead of
+            // starting a concurrent pass.
+            reloadRequested = true
+            return
+        }
+        repeat {
+            reloadRequested = false
+            let task = Task { @MainActor in await self.performLoad() }
+            loadTask = task
+            await task.value
+            loadTask = nil
+        } while reloadRequested
+    }
+
+    @MainActor
+    private func performLoad() async {
         isLoading = true
         error = nil
         do {

--- a/mobile-apps/ios/MigraLogUITests/UITestHelpers.swift
+++ b/mobile-apps/ios/MigraLogUITests/UITestHelpers.swift
@@ -106,9 +106,14 @@ enum UITestHelpers {
     }
 
     /// Navigate to a specific tab in the tab bar.
+    ///
+    /// The tab bar is always present, so a tab button that is not yet hittable means the
+    /// app has not reached idle (e.g. the screen we're leaving is still reloading). On a
+    /// loaded CI runner that settle can exceed the default 5s window, so we wait longer
+    /// here rather than fail a navigation that would otherwise succeed.
     static func navigateTo(tab: Tab, in app: XCUIApplication) {
         let tabButton = app.tabBars.buttons[tab.rawValue]
-        waitForHittable(tabButton)
+        waitForHittable(tabButton, timeout: 15)
         tabButton.tap()
         Thread.sleep(forTimeInterval: animationWait)
     }


### PR DESCRIPTION
Closes #468.

## Problem
The nightly Full UI suite failed on `testFullDailyStatusWorkflow` with `Element "Trends" Button did not become hittable within 5.0s`. The tab bar is always present, so the button *does* become hittable — just not within the test's 5s window on a loaded CI runner. Passes single-run locally; this is a timing/load flake of the same class as #440/#441.

## Root cause
The dashboard fires `loadData()` from several triggers that can overlap — first appearance (`.task` + `.onAppear` bumping `refreshId`), each sheet's `onDismiss`, and the `.medicationDataChanged` notification. `loadData()` had an `isLoading` flag but **no guard against concurrent execution**, so overlapping passes each spun up five parallel fetches and repeatedly mutated `@Observable` state. The continuous re-rendering kept the app from reaching the idle state XCUITest waits on before evaluating hittability, so a `navigateTo(.trends)` right after the episode writes timed out.

## Fix
- **DashboardViewModel** (root cause): coalesce overlapping reloads. `loadData()` now serialises into at most one in-flight pass plus a single trailing refresh — so data after a write is still fetched — instead of running concurrent passes that thrash state.
- **UITestHelpers.navigateTo**: wait up to 15s for the tab button to become hittable. The tab bar is always present, so a longer wait only gives a loaded runner room to go idle; it can't mask a genuinely missing tab (mirrors #441's `timeout: 10`).

## Verification
Local, iPhone 17 Pro (OS 26.0):
- `testFullDailyStatusWorkflow` passes **3/3** under `-run-tests-until-failure`.
- `DashboardViewModelTests` **60/60** green (coalescing didn't change VM behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)