### PR TITLE
fix(ci): gate opencode comment trigger + pin action SHA

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -5,8 +5,9 @@ on:
 jobs:
   opencode:
     if: |
-      contains(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, '/opencode')
+      (contains(github.event.comment.body, '/oc') ||
+       contains(github.event.comment.body, '/opencode')) &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -17,7 +18,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run opencode
-        uses: sst/opencode/github@latest
+        uses: sst/opencode/github@76c631d198f9ff620e15468e45f3457d50481b57 # v1.16.2
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:


### PR DESCRIPTION
## Security fix (audit finding 1, High)

The `opencode.yml` workflow triggers on any issue comment containing `/oc` or `/opencode`. On a public repo, any GitHub user can comment, so a stranger's comment becomes the agent's prompt — with `ANTHROPIC_API_KEY`, `id-token: write`, and `pull-requests: write` in scope. The action was also pinned to the mutable `@latest` tag.

**Changes**
- Require `comment.author_association` ∈ {OWNER, MEMBER, COLLABORATOR} in the job `if:`
- Pin `sst/opencode/github` to the v1.16.2 commit SHA (`76c631d`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)