### PR TITLE
fix(ios): remove PHI from logs and Sentry error context

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/NotificationResponseHandler.swift
+++ b/mobile-apps/ios/MigraLog/Services/NotificationResponseHandler.swift
@@ -273,7 +273,7 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
             }
         } catch {
             logger.error("Failed to log clear day from notification", error: error)
-            ErrorLogger.shared.logError(error, context: ["action": "clearDay", "date": date])
+            ErrorLogger.shared.logError(error, context: ["action": "clearDay"])
         }
     }
 
@@ -305,7 +305,7 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
             )
 
             _ = try await doseLogger.record(dose)
-            logger.info("Dose logged via notification: \(medication.name) - \(status)")
+            logger.info("Dose logged via notification: \(medication.id) - \(status)")
 
             await MainActor.run {
                 NotificationCenter.default.post(name: .medicationDataChanged, object: nil)

--- a/mobile-apps/ios/MigraLog/ViewModels/LogMedicationViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/LogMedicationViewModel.swift
@@ -118,7 +118,7 @@ final class LogMedicationViewModel {
             categoryUsage = computeCategoryUsage(for: categories, now: Date())
             categoryCooldowns = computeCategoryCooldowns(for: medications, now: Date())
         } catch {
-            ErrorLogger.shared.logError(error, context: ["action": "quickLog", "medication": medication.name])
+            ErrorLogger.shared.logError(error, context: ["action": "quickLog", "medicationId": medication.id])
         }
     }
 }


### PR DESCRIPTION
## Security fix (audit finding 2, High)

Medication names and exact dates were logged, violating the project's no-PHI-in-logs rule:

- `NotificationResponseHandler.swift:308` — medication **name** went to os.Logger (unified log, readable via Console.app) and the in-app log buffer → now logs the medication **ID**
- `NotificationResponseHandler.swift:276` — clearDay failure sent the specific **date** to Sentry context ("date" is not in the Sentry scrubber's redaction keys) → date removed
- `LogMedicationViewModel.swift:121` — quickLog failure put `medication.name` in Sentry context (currently caught by the beforeSend scrubber, but PHI should never leave the source) → now sends `medicationId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)