### PR TITLE
fix(ios): exclude backups from device backups + share warning

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/BackupService.swift
+++ b/mobile-apps/ios/MigraLog/Services/BackupService.swift
@@ -62,6 +62,18 @@ final class BackupService: BackupServiceProtocol {
             }
         }
 
+        // Backups are plaintext copies of the health database; keep them out of
+        // iCloud/iTunes device backups. The flag on the directory covers every
+        // backup inside it, including ones created before this flag was added.
+        var excludedDir = backupDir
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        do {
+            try excludedDir.setResourceValues(resourceValues)
+        } catch {
+            logger.error("Failed to exclude backup directory from device backups", error: error)
+        }
+
         return backupDir
     }
 

--- a/mobile-apps/ios/MigraLog/Views/Settings/DataSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DataSettingsScreen.swift
@@ -10,6 +10,9 @@ struct DataSettingsScreen: View {
     @State private var showRestoreConfirm = false
     @State private var showRestoreSuccess = false
     @State private var exportURL: URL?
+    @State private var pendingBackupShareURL: URL?
+    @State private var showBackupShareWarning = false
+    @State private var showBackupShareSheet = false
     @State private var backups: [BackupMetadata] = []
     @State private var showError = false
     @State private var errorMessage = ""
@@ -94,6 +97,21 @@ struct DataSettingsScreen: View {
         } message: {
             Text("This will replace all current data with the backup. This action cannot be undone. Please create a backup first if needed.")
         }
+        .alert("Share Unencrypted Backup?", isPresented: $showBackupShareWarning) {
+            Button("Share", role: .destructive) {
+                showBackupShareSheet = true
+            }
+            Button("Cancel", role: .cancel) {
+                pendingBackupShareURL = nil
+            }
+        } message: {
+            Text("Backups contain your complete health history — episodes, medications, and notes — unencrypted. Only share them with people and apps you trust.")
+        }
+        .sheet(isPresented: $showBackupShareSheet) {
+            if let url = pendingBackupShareURL {
+                ShareSheet(items: [url])
+            }
+        }
         .alert("Restore Complete", isPresented: $showRestoreSuccess) {
             Button("OK", role: .cancel) {}
         } message: {
@@ -117,7 +135,10 @@ struct DataSettingsScreen: View {
             }
             Spacer()
             if let url, FileManager.default.fileExists(atPath: url.path) {
-                ShareLink(item: url) {
+                Button {
+                    pendingBackupShareURL = url
+                    showBackupShareWarning = true
+                } label: {
                     Image(systemName: "square.and.arrow.up")
                         .foregroundStyle(.tint)
                 }


### PR DESCRIPTION
## Security fix (audit finding 3, High)

Backup files are plaintext copies of the health database, stored in `Documents/backups/`. They were included in iCloud/iTunes device backups and shareable with one tap and no warning.

**Changes**
- `BackupService.backupDirectoryURL()` now marks the backups directory `isExcludedFromBackup`, keeping plaintext health data out of device backups. Setting the flag on the directory also covers backups created before this fix.
- The share button in Backup & Export now shows a warning ("Backups contain your complete health history … unencrypted") before presenting the share sheet.

**Testing**
- Full unit suite (`MigraLogTests`) passed locally on iPhone 17 Pro / iOS 26 sim
- SwiftLint: no error-level violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)