### PR TITLE
fix(ci): pass workflow inputs to summary step via env

### DIFF
--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -69,8 +69,12 @@ jobs:
         run: rm -rf ~/.private_keys || true
 
       - name: Summary
+        env:
+          BUILD_NUMBER: ${{ github.event.inputs.build_number }}
+          AUTO_RELEASE: ${{ github.event.inputs.auto_release }}
+          PHASED_RELEASE: ${{ github.event.inputs.phased_release }}
         run: |
           echo "## Production Submission" >> $GITHUB_STEP_SUMMARY
-          echo "- **Build:** ${{ github.event.inputs.build_number }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Auto-release:** ${{ github.event.inputs.auto_release }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Phased release:** ${{ github.event.inputs.phased_release }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build:** $BUILD_NUMBER" >> $GITHUB_STEP_SUMMARY
+          echo "- **Auto-release:** $AUTO_RELEASE" >> $GITHUB_STEP_SUMMARY
+          echo "- **Phased release:** $PHASED_RELEASE" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Security fix (audit finding 6, Medium)

`promote-production.yml`'s Summary step interpolated `workflow_dispatch` inputs directly into a `run:` block — GitHub substitutes `${{ }}` before the shell parses the script, so a crafted `build_number` could inject shell commands. Impact was limited (workflow_dispatch needs write access, and the step has no secrets), but it's the one spot in the job that didn't route inputs through `env:`. Now it does, matching the submit step above it. Audited all other workflows: no other `run:` blocks interpolate inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)