### PR TITLE
fix(ios): remove DEBUG SQL trace that printed health data

### DIFF
--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -43,11 +43,9 @@ final class DatabaseManager: Sendable {
             databaseFileURL = dbURL
             var config = Configuration()
             config.foreignKeysEnabled = true
-            #if DEBUG
-            config.prepareDatabase { db in
-                db.trace { print("SQL: \($0)") }
-            }
-            #endif
+            // No SQL tracing, even in DEBUG: statements embed health data
+            // (episodes, medications, notes) and must stay out of console
+            // output and captured build/test logs.
             let queue = try DatabaseQueue(path: dbURL.path, configuration: config)
             let mgr = DatabaseManager.buildMigrator()
             try mgr.migrate(queue)


### PR DESCRIPTION
## Security fix (audit finding 7, Medium)

`DatabaseManager` enabled `db.trace { print("SQL: ...") }` in DEBUG builds, printing every SQL statement — including bound health-data values (episodes, medications, notes) — to the console. That output lands in Xcode logs and any captured simulator/CI logs, normalizing PHI in places the no-PHI-in-logs rule is meant to keep it out of. Removed, with a comment explaining why it must not come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)