### PR TITLE
fix(ios): export warning + tmp file cleanup

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/ExportService.swift
+++ b/mobile-apps/ios/MigraLog/Services/ExportService.swift
@@ -47,6 +47,15 @@ final class ExportService: ExportServiceProtocol {
         }
 
         let tempDir = fileManager.temporaryDirectory
+
+        // Exports are plaintext health data; don't let stale copies sit in
+        // tmp until iOS gets around to purging them.
+        if let existing = try? fileManager.contentsOfDirectory(at: tempDir, includingPropertiesForKeys: nil) {
+            for file in existing where file.lastPathComponent.hasPrefix("migralog_export_") {
+                try? fileManager.removeItem(at: file)
+            }
+        }
+
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd_HHmmss"
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")

--- a/mobile-apps/ios/MigraLog/Views/Settings/DataSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DataSettingsScreen.swift
@@ -10,6 +10,7 @@ struct DataSettingsScreen: View {
     @State private var showRestoreConfirm = false
     @State private var showRestoreSuccess = false
     @State private var exportURL: URL?
+    @State private var showExportWarning = false
     @State private var pendingBackupShareURL: URL?
     @State private var showBackupShareWarning = false
     @State private var showBackupShareSheet = false
@@ -21,7 +22,7 @@ struct DataSettingsScreen: View {
         List {
             Section {
                 Button {
-                    Task { await exportJSON() }
+                    showExportWarning = true
                 } label: {
                     HStack {
                         Label("Export as JSON", systemImage: "doc.text")
@@ -74,10 +75,25 @@ struct DataSettingsScreen: View {
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Backup & Export")
-        .sheet(isPresented: $showShareSheet) {
+        .sheet(isPresented: $showShareSheet, onDismiss: {
+            // The export is plaintext health data in tmp — remove it as soon
+            // as the share sheet is done with it.
+            if let url = exportURL {
+                try? FileManager.default.removeItem(at: url)
+                exportURL = nil
+            }
+        }) {
             if let url = exportURL {
                 ShareSheet(items: [url])
             }
+        }
+        .alert("Share Unencrypted Export?", isPresented: $showExportWarning) {
+            Button("Export", role: .destructive) {
+                Task { await exportJSON() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Exports contain your complete health history — episodes, medications, and notes — unencrypted. Only share them with people and apps you trust.")
         }
         .sheet(isPresented: $showDocumentPicker) {
             DatabaseDocumentPicker { url in


### PR DESCRIPTION
## Security fix (audit finding 8, Medium)

JSON exports contain the complete plaintext health history, were written to `tmp/` and left there until iOS purged them, and shared with no warning.

**Changes**
- Export button now shows the same "unencrypted health data" warning as backup sharing (added in #475) before creating the file
- The export file is deleted as soon as the share sheet is dismissed
- Stale `migralog_export_*.json` files are swept from tmp before each new export

🤖 Generated with [Claude Code](https://claude.com/claude-code)