### PR TITLE
feat(ios): option to hide medication names in notifications

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/MedicationNotificationService.swift
+++ b/mobile-apps/ios/MigraLog/Services/MedicationNotificationService.swift
@@ -7,6 +7,7 @@ private enum NotificationDefaultsKey {
     static let followUpDelay = "notification_follow_up_delay"
     static let timeSensitiveEnabled = "notification_time_sensitive_enabled"
     static let criticalAlertsEnabled = "notification_critical_alerts_enabled"
+    static let showMedicationNames = "notification_show_medication_names"
 }
 
 // MARK: - Protocol
@@ -205,7 +206,9 @@ actor MedicationNotificationScheduler: MedicationNotificationServiceProtocol {
         let notificationId = UUID().uuidString
         let trigger = makeTrigger(from: triggerDate)
         let title = isFollowUp ? "Follow-Up Reminder" : "Medication Reminder"
-        let body = "Time to take \(medication.name) (\(medication.dosageAmount)\(medication.dosageUnit))"
+        let body = showMedicationNames()
+            ? "Time to take \(medication.name) (\(medication.dosageAmount)\(medication.dosageUnit))"
+            : "Time to take your medication"
 
         var userInfo: [String: Any] = [
             "medicationId": medication.id,
@@ -268,7 +271,9 @@ actor MedicationNotificationScheduler: MedicationNotificationServiceProtocol {
         let trigger = makeTrigger(from: triggerDate)
         let names = items.map(\.0.name)
         let title = isFollowUp ? "Follow-Up Reminder" : "Medication Reminder"
-        let body = "Time to take: \(names.joined(separator: ", "))"
+        let body = showMedicationNames()
+            ? "Time to take: \(names.joined(separator: ", "))"
+            : "Time to take \(items.count) medications"
         let groupKey = "\(time)_\(notificationType.rawValue)"
 
         let medicationIds = items.map(\.0.id)
@@ -743,6 +748,12 @@ actor MedicationNotificationScheduler: MedicationNotificationServiceProtocol {
         guard let date = DateFormatting.date(from: dateString),
               let components = parseTime(time) else { return nil }
         return Calendar.current.date(bySettingHour: components.hour, minute: components.minute, second: 0, of: date)
+    }
+
+    /// Whether notification bodies may include medication names. Defaults to
+    /// true; users can turn this off so names never appear on the lock screen.
+    private func showMedicationNames() -> Bool {
+        UserDefaults.standard.object(forKey: NotificationDefaultsKey.showMedicationNames) as? Bool ?? true
     }
 
     private func interruptionSettings(isFollowUp: Bool) -> (UNNotificationInterruptionLevel, Bool) {

--- a/mobile-apps/ios/MigraLog/ViewModels/NotificationSettingsViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/NotificationSettingsViewModel.swift
@@ -19,6 +19,7 @@ final class NotificationSettingsViewModel {
     var timeSensitiveEnabled: Bool = false
     var followUpDelay: Int = 30 // minutes
     var criticalAlertsEnabled: Bool = false
+    var showMedicationNames: Bool = true
     var dailyCheckinEnabled: Bool = true
     var dailyCheckinTime: Date = {
         var components = DateComponents()
@@ -37,6 +38,7 @@ final class NotificationSettingsViewModel {
         static let followUpDelay = "notification_follow_up_delay"
         static let criticalAlertsEnabled = "notification_critical_alerts_enabled"
         static let medicationOverrides = "notification_medication_overrides"
+        static let showMedicationNames = "notification_show_medication_names"
         static let dailyCheckinEnabled = "daily_checkin_enabled"
         static let dailyCheckinTime = "daily_checkin_time"
     }
@@ -78,6 +80,7 @@ final class NotificationSettingsViewModel {
         timeSensitiveEnabled = defaults.bool(forKey: Keys.timeSensitiveEnabled)
         followUpDelay = defaults.object(forKey: Keys.followUpDelay) as? Int ?? 30
         criticalAlertsEnabled = defaults.bool(forKey: Keys.criticalAlertsEnabled)
+        showMedicationNames = defaults.object(forKey: Keys.showMedicationNames) as? Bool ?? true
         dailyCheckinEnabled = defaults.object(forKey: Keys.dailyCheckinEnabled) as? Bool ?? true
 
         if let timeInterval = defaults.object(forKey: Keys.dailyCheckinTime) as? TimeInterval {
@@ -96,6 +99,7 @@ final class NotificationSettingsViewModel {
         defaults.set(timeSensitiveEnabled, forKey: Keys.timeSensitiveEnabled)
         defaults.set(followUpDelay, forKey: Keys.followUpDelay)
         defaults.set(criticalAlertsEnabled, forKey: Keys.criticalAlertsEnabled)
+        defaults.set(showMedicationNames, forKey: Keys.showMedicationNames)
         defaults.set(dailyCheckinEnabled, forKey: Keys.dailyCheckinEnabled)
         defaults.set(dailyCheckinTime.timeIntervalSinceReferenceDate, forKey: Keys.dailyCheckinTime)
         persistMedicationOverrides()

--- a/mobile-apps/ios/MigraLog/Views/Settings/NotificationSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/NotificationSettingsScreen.swift
@@ -46,11 +46,18 @@ struct NotificationSettingsScreen: View {
                             viewModel.saveSettings()
                             Task { await viewModel.applyMedicationNotificationSettingChange() }
                         }
+
+                    Toggle("Show Medication Names", isOn: $viewModel.showMedicationNames)
+                        .onChange(of: viewModel.showMedicationNames) { _, _ in
+                            viewModel.saveSettings()
+                            Task { await viewModel.syncMedicationNotifications() }
+                        }
+                        .accessibilityIdentifier("show-medication-names-toggle")
                 } header: {
                     Text("Medication Reminders")
                 } footer: {
                     // swiftlint:disable:next line_length
-                    Text("Time-sensitive reminders cut through Focus modes. Follow-up reminders fire after the chosen delay; turn on Critical Alerts to make them break through Do Not Disturb and silent mode.")
+                    Text("Time-sensitive reminders cut through Focus modes. Follow-up reminders fire after the chosen delay; turn on Critical Alerts to make them break through Do Not Disturb and silent mode. Turn off Show Medication Names to keep medication details off the lock screen.")
                 }
 
                 Section("Daily Check-in") {

--- a/mobile-apps/ios/MigraLogTests/Services/MedicationNotificationServiceTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/MedicationNotificationServiceTests.swift
@@ -169,6 +169,50 @@ final class MedicationNotificationServiceTests: XCTestCase {
         XCTAssertTrue(firstNotification?.body.contains("50.0mg") ?? false)
     }
 
+    func testScheduledNotification_hidesMedicationNameWhenDisabled() async throws {
+        UserDefaults.standard.set(false, forKey: "notification_show_medication_names")
+        defer { UserDefaults.standard.removeObject(forKey: "notification_show_medication_names") }
+
+        let medication = TestFixtures.makeMedication(
+            id: "med-1",
+            name: "Topiramate",
+            type: .preventative,
+            dosageAmount: 50,
+            dosageUnit: "mg",
+            scheduleFrequency: .daily
+        )
+        let schedule = TestFixtures.makeSchedule(id: "sched-1", medicationId: "med-1", time: "08:00")
+        mockMedicationRepo.medications = [medication]
+        mockMedicationRepo.schedules = [schedule]
+
+        try await sut.rescheduleAllMedicationNotifications()
+
+        let firstNotification = mockNotificationService.scheduledNotifications.first
+        XCTAssertEqual(firstNotification?.body, "Time to take your medication")
+        XCTAssertFalse(firstNotification?.body.contains("Topiramate") ?? true)
+    }
+
+    func testGroupedNotification_hidesMedicationNamesWhenDisabled() async throws {
+        UserDefaults.standard.set(false, forKey: "notification_show_medication_names")
+        defer { UserDefaults.standard.removeObject(forKey: "notification_show_medication_names") }
+
+        let med1 = TestFixtures.makeMedication(id: "med-1", name: "Topiramate", type: .preventative, scheduleFrequency: .daily)
+        let med2 = TestFixtures.makeMedication(id: "med-2", name: "Propranolol", type: .preventative, scheduleFrequency: .daily)
+        let sched1 = TestFixtures.makeSchedule(id: "sched-1", medicationId: "med-1", time: "08:00")
+        let sched2 = TestFixtures.makeSchedule(id: "sched-2", medicationId: "med-2", time: "08:00")
+        mockMedicationRepo.medications = [med1, med2]
+        mockMedicationRepo.schedules = [sched1, sched2]
+
+        try await sut.rescheduleAllMedicationNotifications()
+
+        let grouped = mockNotificationService.scheduledNotifications.first {
+            $0.categoryIdentifier == NotificationCategory.multipleMedication
+        }
+        XCTAssertEqual(grouped?.body, "Time to take 2 medications")
+        XCTAssertFalse(grouped?.body.contains("Topiramate") ?? true)
+        XCTAssertFalse(grouped?.body.contains("Propranolol") ?? true)
+    }
+
     func testGroupedNotification_usesMultipleMedicationCategory() async throws {
         let med1 = TestFixtures.makeMedication(id: "med-1", name: "Topiramate", type: .preventative, scheduleFrequency: .daily)
         let med2 = TestFixtures.makeMedication(id: "med-2", name: "Propranolol", type: .preventative, scheduleFrequency: .daily)


### PR DESCRIPTION
## Security audit finding 4 (Medium)

Medication reminder notifications include medication names and doses, visible on the lock screen. Per product decision: names stay **on by default**, with an option to hide them.

**Changes**
- New `notification_show_medication_names` setting (default true)
- When off: individual reminders read "Time to take your medication", grouped ones "Time to take N medications" — no names or doses in any notification body
- "Show Medication Names" toggle in Settings → Notifications → Medication Reminders; toggling reschedules all pending notifications so already-queued bodies update immediately
- Unit tests for the hidden-name path (individual + grouped)

**Testing**
- Full unit suite + Smoke UI suite passed locally on iPhone 17 Pro / iOS 26 sim
- SwiftLint: no error-level violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)