### PR TITLE
feat(ios): list included medications under each overuse-risk chart (#435)

### DIFF
--- a/mobile-apps/ios/MigraLog/Utils/AnalyticsInsights.swift
+++ b/mobile-apps/ios/MigraLog/Utils/AnalyticsInsights.swift
@@ -68,7 +68,27 @@ enum AnalyticsInsights {
     struct ClassIntakeSeries: Equatable, Identifiable {
         let medClass: AcuteMedClass
         let points: [DailyCount]
+        /// Names of the medications counted into this class, for display —
+        /// the class membership is user-configurable per medication.
+        let medicationNames: [String]
         var id: String { medClass.rawValue }
+    }
+
+    /// Medication names per acute class: rescue medications that are active
+    /// or contributed a taken dose in the analyzed window, sorted by name.
+    static func classMedicationNames(
+        medications: [Medication],
+        doses: [MedicationDose]
+    ) -> [AcuteMedClass: [String]] {
+        let dosedMedIds = Set(doses.filter { $0.status == .taken }.map(\.medicationId))
+        var names: [AcuteMedClass: [String]] = [:]
+        for med in medications where med.type == .rescue {
+            guard let medClass = AcuteMedClass(category: med.category) else { continue }
+            if med.active || dosedMedIds.contains(med.id) {
+                names[medClass, default: []].append(med.name)
+            }
+        }
+        return names.mapValues { $0.sorted() }
     }
 
     enum SeverityBin: String, CaseIterable, Identifiable {

--- a/mobile-apps/ios/MigraLog/ViewModels/AnalyticsViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/AnalyticsViewModel.swift
@@ -417,10 +417,12 @@ final class AnalyticsViewModel {
         )
 
         headacheDayTrend = AnalyticsInsights.rollingCounts(of: headacheDays, from: rangeStart, to: rangeEnd, calendar: calendar)
+        let classMedNames = AnalyticsInsights.classMedicationNames(medications: allMedications, doses: allDoses)
         intakeSeries = AnalyticsInsights.AcuteMedClass.allCases.map { medClass in
             AnalyticsInsights.ClassIntakeSeries(
                 medClass: medClass,
-                points: AnalyticsInsights.rollingCounts(of: intake[medClass] ?? [], from: rangeStart, to: rangeEnd, calendar: calendar)
+                points: AnalyticsInsights.rollingCounts(of: intake[medClass] ?? [], from: rangeStart, to: rangeEnd, calendar: calendar),
+                medicationNames: classMedNames[medClass] ?? []
             )
         }
 

--- a/mobile-apps/ios/MigraLog/Views/Analytics/InsightsChartsSection.swift
+++ b/mobile-apps/ios/MigraLog/Views/Analytics/InsightsChartsSection.swift
@@ -245,6 +245,12 @@ private struct ClassIntakeChart: View {
             }
             .chartYScale(domain: 0...yMax)
             .frame(height: 110)
+
+            if !series.medicationNames.isEmpty {
+                Text("Includes: \(series.medicationNames.joined(separator: ", "))")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
         }
         .padding(.top, 4)
     }

--- a/mobile-apps/ios/MigraLogTests/Utils/AnalyticsInsightsTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Utils/AnalyticsInsightsTests.swift
@@ -171,6 +171,24 @@ final class AnalyticsInsightsTests: XCTestCase {
         XCTAssertNil(intake[.triptan])
     }
 
+    func testClassMedicationNames_activeOrDosedRescueMedsSortedByName() {
+        let active = TestFixtures.makeMedication(id: "med-a", name: "Sumatriptan", type: .rescue, category: .triptan)
+        // Inactive but used in the window — still counted, so still listed.
+        let retired = TestFixtures.makeMedication(id: "med-r", name: "Rizatriptan", type: .rescue, active: false, category: .triptan)
+        // Inactive and unused — not listed.
+        let dormant = TestFixtures.makeMedication(id: "med-d", name: "Eletriptan", type: .rescue, active: false, category: .triptan)
+        let preventative = TestFixtures.makeMedication(id: "med-p", name: "Topiramate", type: .preventative, category: .preventive)
+        let doses = [TestFixtures.makeDose(medicationId: "med-r", timestamp: ms(daysAgo: 2))]
+
+        let names = AnalyticsInsights.classMedicationNames(
+            medications: [active, retired, dormant, preventative],
+            doses: doses
+        )
+
+        XCTAssertEqual(names[.triptan], ["Rizatriptan", "Sumatriptan"])
+        XCTAssertNil(names[.simpleAnalgesic])
+    }
+
     func testIntakeDays_skippedDosesAndExcludedDaysIgnored() {
         let triptan = TestFixtures.makeMedication(id: "med-t", type: .rescue, category: .triptan)
         let doses = [

--- a/mobile-apps/ios/MigraLogTests/ViewModels/AnalyticsViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/AnalyticsViewModelTests.swift
@@ -195,6 +195,8 @@ final class AnalyticsViewModelTests: XCTestCase {
         XCTAssertEqual(sut.intakeSeries.count, 3)
         let triptanSeries = sut.intakeSeries.first { $0.medClass == .triptan }
         XCTAssertEqual(triptanSeries?.points.last?.count, 1)
+        // The series carries the names of the medications it counts.
+        XCTAssertEqual(triptanSeries?.medicationNames, ["Ibuprofen"])
         // One rated episode this week → one severity entry; time-of-day total is 1.
         XCTAssertEqual(sut.severityWeekCounts.map(\.count).reduce(0, +), 1)
         XCTAssertEqual(sut.severityWeekCounts.first?.bin, .severe)

--- a/mobile-apps/ios/MigraLogUITests/ScreenshotsUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/ScreenshotsUITests.swift
@@ -146,13 +146,16 @@ final class ScreenshotsUITests: XCTestCase {
         }
         let scroll = app.scrollViews.firstMatch
 
-        let headacheBurden = app.staticTexts["Headache Burden"]
-        UITestHelpers.scrollToElement(headacheBurden, in: scroll, maxScrolls: 15)
+        // Scroll targets are the card BELOW the content each shot should show
+        // in full. Card order: Warnings, Monthly Summary, Headache Burden,
+        // Medication Overuse, Severity, Time of Day, Adherence.
+        let severityHeader = app.staticTexts["Severity by Week"]
+        UITestHelpers.scrollToElement(severityHeader, in: scroll, maxScrolls: 15)
         Thread.sleep(forTimeInterval: 1.0)
         attachScreenshot(named: "07-Trends-Insights")
 
-        let monthlySummary = app.staticTexts["Monthly Summary"]
-        UITestHelpers.scrollToElement(monthlySummary, in: scroll, maxScrolls: 15)
+        let adherenceHeader = app.staticTexts["Preventative Adherence"]
+        UITestHelpers.scrollToElement(adherenceHeader, in: scroll, maxScrolls: 15)
         Thread.sleep(forTimeInterval: 1.0)
         attachScreenshot(named: "08-Trends-Insights-Distributions")
     }


### PR DESCRIPTION
## Summary
Follow-up tweak to the insight charts: each Medication Overuse Risk class chart now lists, in small text under the chart, the medications it's counting (e.g. "Includes: Sumatriptan"). Since class membership comes from each medication's user-editable category, this makes the chart's inputs transparent.

- Listed meds = active rescue medications in the class, plus inactive ones that contributed a taken dose in the window (sorted by name)
- `ClassIntakeSeries` carries the names; new `classMedicationNames` engine helper with unit coverage
- Screenshot-test scroll targets updated for the post-#483 card order (Monthly Summary now sits above the charts)

## Testing
- [x] Unit tests pass (new `testClassMedicationNames_activeOrDosedRescueMedsSortedByName` + extended series test)
- [x] SwiftLint: no errors
- [x] Rendering verified via `ScreenshotsUITests/test07_TrendsInsights` on iPhone — "Includes:" lines visible under both class charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)