### PR TITLE
feat(ios): make better use of iPad space across screens (#436)

### DIFF
--- a/mobile-apps/ios/MigraLog/App/ContentView.swift
+++ b/mobile-apps/ios/MigraLog/App/ContentView.swift
@@ -5,9 +5,9 @@ struct ContentView: View {
     @Environment(TimezoneChangeService.self) private var timezoneChangeService
     @Environment(SyncService.self) private var syncService
     @Environment(\.scenePhase) private var scenePhase
-    @State private var selectedTab: TabSection = .dashboard
 
     var body: some View {
+        @Bindable var appState = appState
         Group {
             if DatabaseManager.initializationError != nil {
                 DatabaseErrorView()
@@ -16,7 +16,7 @@ struct ContentView: View {
             } else if !appState.isOnboardingComplete {
                 WelcomeScreen()
             } else {
-                AdaptiveNavigation(selectedTab: $selectedTab)
+                AdaptiveNavigation(selectedTab: $appState.selectedTab)
             }
         }
         .alert(
@@ -28,7 +28,7 @@ struct ContentView: View {
             presenting: timezoneChangeService.pendingChange
         ) { change in
             Button("Review Schedules") {
-                selectedTab = .medications
+                appState.selectedTab = .medications
                 timezoneChangeService.dismissChange()
             }
             Button("OK", role: .cancel) {

--- a/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
+++ b/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
@@ -99,6 +99,28 @@ final class AppState {
     var isOnboardingComplete: Bool = false
     var isLoading: Bool = true
 
+    // MARK: - Cross-tab navigation
+
+    /// Tab selection lives here so any screen (e.g. Dashboard cards) can
+    /// switch tabs and preselect an item in that tab's split view.
+    var selectedTab: TabSection = .dashboard
+    /// Selection for the Episodes split view (iPad regular width).
+    var selectedEpisodeId: String?
+    /// Selection for the Medications split view (iPad regular width).
+    var selectedMedicationId: String?
+
+    /// Switch to the Episodes tab with the given episode selected.
+    func showEpisode(_ episodeId: String) {
+        selectedEpisodeId = episodeId
+        selectedTab = .episodes
+    }
+
+    /// Switch to the Medications tab with the given medication selected.
+    func showMedication(_ medicationId: String) {
+        selectedMedicationId = medicationId
+        selectedTab = .medications
+    }
+
     private let onboardingKey = "isOnboardingComplete"
 
     /// Whether the app is running under UI testing mode

--- a/mobile-apps/ios/MigraLog/Views/AdaptiveNavigation.swift
+++ b/mobile-apps/ios/MigraLog/Views/AdaptiveNavigation.swift
@@ -60,19 +60,20 @@ private enum SplitViewMetrics {
 
 struct EpisodesTab: View {
     @Environment(\.horizontalSizeClass) private var sizeClass
-    @State private var selectedEpisodeId: String?
+    @Environment(AppState.self) private var appState
 
     var body: some View {
+        @Bindable var appState = appState
         if sizeClass == .regular {
             NavigationSplitView {
-                EpisodesListColumn(selectedEpisodeId: $selectedEpisodeId)
+                EpisodesListColumn(selectedEpisodeId: $appState.selectedEpisodeId)
                     .navigationSplitViewColumnWidth(
                         min: SplitViewMetrics.listColumnMin,
                         ideal: SplitViewMetrics.listColumnIdeal,
                         max: SplitViewMetrics.listColumnMax
                     )
             } detail: {
-                if let episodeId = selectedEpisodeId {
+                if let episodeId = appState.selectedEpisodeId {
                     EpisodeDetailScreen(episodeId: episodeId)
                 } else {
                     ContentUnavailableView(
@@ -94,19 +95,20 @@ struct EpisodesTab: View {
 
 struct MedicationsTab: View {
     @Environment(\.horizontalSizeClass) private var sizeClass
-    @State private var selectedMedicationId: String?
+    @Environment(AppState.self) private var appState
 
     var body: some View {
+        @Bindable var appState = appState
         if sizeClass == .regular {
             NavigationSplitView {
-                MedicationsListColumn(selectedMedicationId: $selectedMedicationId)
+                MedicationsListColumn(selectedMedicationId: $appState.selectedMedicationId)
                     .navigationSplitViewColumnWidth(
                         min: SplitViewMetrics.listColumnMin,
                         ideal: SplitViewMetrics.listColumnIdeal,
                         max: SplitViewMetrics.listColumnMax
                     )
             } detail: {
-                if let medicationId = selectedMedicationId {
+                if let medicationId = appState.selectedMedicationId {
                     MedicationDetailScreen(medicationId: medicationId)
                 } else {
                     ContentUnavailableView(

--- a/mobile-apps/ios/MigraLog/Views/Analytics/AnalyticsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Analytics/AnalyticsScreen.swift
@@ -99,9 +99,23 @@ struct AnalyticsScreen: View {
 
 struct MonthlyCalendarView: View {
     @Bindable var viewModel: AnalyticsViewModel
+    /// When set, day cells grow so the month grid fills this height
+    /// (wide iPad panes). When nil, cells use the compact 44pt minimum.
+    var fillHeight: CGFloat?
     @State private var displayMonth = Date()
 
     private let weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+    /// Vertical space inside the card not occupied by the day grid:
+    /// card padding, month navigation, weekday header, and stack spacing.
+    private static let cardChromeHeight: CGFloat = 110
+
+    private func dayCellHeight(rows: Int) -> CGFloat {
+        guard let fillHeight, rows > 0 else { return 44 }
+        let gridSpacing = CGFloat(rows - 1) * 6
+        let available = fillHeight - Self.cardChromeHeight - gridSpacing
+        return max(44, min(160, available / CGFloat(rows)))
+    }
 
     var body: some View {
         VStack(spacing: 8) {
@@ -141,6 +155,7 @@ struct MonthlyCalendarView: View {
 
             // Calendar grid
             let days = calendarDays(for: displayMonth)
+            let cellHeight = dayCellHeight(rows: days.count / 7)
             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 2), count: 7), spacing: 6) {
                 ForEach(days, id: \.self) { date in
                     if let date = date {
@@ -149,6 +164,7 @@ struct MonthlyCalendarView: View {
                             date: date,
                             status: viewModel.calendarStatuses[dateStr],
                             hasOverlay: viewModel.calendarOverlayDates.contains(dateStr),
+                            minHeight: cellHeight,
                             onTap: {
                                 viewModel.selectedCalendarDate = date
                                 viewModel.showDailyStatusPrompt = true
@@ -157,7 +173,7 @@ struct MonthlyCalendarView: View {
                         .accessibilityIdentifier("calendar-day-\(DateFormatting.dateString(from: date))")
                     } else {
                         Color.clear
-                            .frame(maxWidth: .infinity, minHeight: 44)
+                            .frame(maxWidth: .infinity, minHeight: cellHeight)
                     }
                 }
             }
@@ -212,6 +228,7 @@ struct CalendarDayCell: View {
     let date: Date
     let status: DayStatus?
     let hasOverlay: Bool
+    var minHeight: CGFloat = 44
     let onTap: () -> Void
 
     private var isToday: Bool {
@@ -239,7 +256,7 @@ struct CalendarDayCell: View {
                     .fill(hasOverlay ? Color(.systemGray3) : .clear)
                     .frame(height: 4)
             }
-            .frame(maxWidth: .infinity, minHeight: 44)
+            .frame(maxWidth: .infinity, minHeight: minHeight)
             .background(isToday ? Color.accentColor.opacity(0.1) : Color.clear)
             .clipShape(RoundedRectangle(cornerRadius: 6))
         }
@@ -629,19 +646,30 @@ struct AnalyticsVisualizationPane: View {
     @Bindable var viewModel: AnalyticsViewModel
     @State private var selectedSection: AnalyticsSection = .calendar
 
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                AnalyticsSectionPicker(selection: $selectedSection)
+    /// Vertical space above the calendar card: pane padding, the
+    /// Calendar/Insights picker, and the stack spacing below it.
+    private static let paneChromeHeight: CGFloat = 96
 
-                switch selectedSection {
-                case .calendar:
-                    MonthlyCalendarView(viewModel: viewModel)
-                case .insights:
-                    InsightsChartsSection(viewModel: viewModel)
+    var body: some View {
+        GeometryReader { geo in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    AnalyticsSectionPicker(selection: $selectedSection)
+
+                    switch selectedSection {
+                    case .calendar:
+                        // Fill the pane height so the month grid uses the
+                        // wide canvas instead of floating over empty space.
+                        MonthlyCalendarView(
+                            viewModel: viewModel,
+                            fillHeight: geo.size.height - Self.paneChromeHeight
+                        )
+                    case .insights:
+                        InsightsChartsSection(viewModel: viewModel)
+                    }
                 }
+                .padding()
             }
-            .padding()
         }
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Analytics/InsightsChartsSection.swift
+++ b/mobile-apps/ios/MigraLog/Views/Analytics/InsightsChartsSection.swift
@@ -10,25 +10,15 @@ import SwiftUI
 struct InsightsChartsSection: View {
     @Bindable var viewModel: AnalyticsViewModel
 
-    /// Two-up on wide iPad panes, single column on narrow widths. Driven by
-    /// available width, so iPhone layouts are unaffected.
-    private static let pairedColumns = [
-        GridItem(.adaptive(minimum: 420, maximum: .infinity), spacing: 16, alignment: .top)
-    ]
-
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             WarningCalloutsCard(warnings: viewModel.insightWarnings)
-            LazyVGrid(columns: Self.pairedColumns, alignment: .leading, spacing: 16) {
-                MonthlySummaryCard(summaries: viewModel.monthlySummaries, medications: viewModel.summaryMedications)
-                HeadacheBurdenChartCard(points: viewModel.headacheDayTrend)
-            }
+            MonthlySummaryCard(summaries: viewModel.monthlySummaries, medications: viewModel.summaryMedications)
+            HeadacheBurdenChartCard(points: viewModel.headacheDayTrend)
             MedicationOveruseChartCard(series: viewModel.intakeSeries)
-            LazyVGrid(columns: Self.pairedColumns, alignment: .leading, spacing: 16) {
-                SeverityDistributionChartCard(counts: viewModel.severityWeekCounts)
-                TimeOfDayChartCard(bins: viewModel.timeOfDayBins)
-                AdherenceChartCard(weeks: viewModel.weeklyAdherence)
-            }
+            SeverityDistributionChartCard(counts: viewModel.severityWeekCounts)
+            TimeOfDayChartCard(bins: viewModel.timeOfDayBins)
+            AdherenceChartCard(weeks: viewModel.weeklyAdherence)
         }
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Analytics/InsightsChartsSection.swift
+++ b/mobile-apps/ios/MigraLog/Views/Analytics/InsightsChartsSection.swift
@@ -10,15 +10,25 @@ import SwiftUI
 struct InsightsChartsSection: View {
     @Bindable var viewModel: AnalyticsViewModel
 
+    /// Two-up on wide iPad panes, single column on narrow widths. Driven by
+    /// available width, so iPhone layouts are unaffected.
+    private static let pairedColumns = [
+        GridItem(.adaptive(minimum: 420, maximum: .infinity), spacing: 16, alignment: .top)
+    ]
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             WarningCalloutsCard(warnings: viewModel.insightWarnings)
-            MonthlySummaryCard(summaries: viewModel.monthlySummaries, medications: viewModel.summaryMedications)
-            HeadacheBurdenChartCard(points: viewModel.headacheDayTrend)
+            LazyVGrid(columns: Self.pairedColumns, alignment: .leading, spacing: 16) {
+                MonthlySummaryCard(summaries: viewModel.monthlySummaries, medications: viewModel.summaryMedications)
+                HeadacheBurdenChartCard(points: viewModel.headacheDayTrend)
+            }
             MedicationOveruseChartCard(series: viewModel.intakeSeries)
-            SeverityDistributionChartCard(counts: viewModel.severityWeekCounts)
-            TimeOfDayChartCard(bins: viewModel.timeOfDayBins)
-            AdherenceChartCard(weeks: viewModel.weeklyAdherence)
+            LazyVGrid(columns: Self.pairedColumns, alignment: .leading, spacing: 16) {
+                SeverityDistributionChartCard(counts: viewModel.severityWeekCounts)
+                TimeOfDayChartCard(bins: viewModel.timeOfDayBins)
+                AdherenceChartCard(weeks: viewModel.weeklyAdherence)
+            }
         }
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Components/AdaptiveDetailLayout.swift
+++ b/mobile-apps/ios/MigraLog/Views/Components/AdaptiveDetailLayout.swift
@@ -9,7 +9,8 @@ import SwiftUI
 /// the same detail view adapts as the iPad split pane grows/shrinks (rotation,
 /// Split View / Slide Over multitasking).
 ///
-/// `footer` always spans the full width below the columns.
+/// `footer` follows the content on narrow widths; on wide panes it joins the
+/// bottom of the primary column rather than spanning both columns.
 struct AdaptiveDetailLayout<Primary: View, Secondary: View, Footer: View>: View {
     /// Width at or above which the two-column layout is used.
     var breakpoint: CGFloat = 760
@@ -27,9 +28,13 @@ struct AdaptiveDetailLayout<Primary: View, Secondary: View, Footer: View>: View 
             ScrollView {
                 VStack(alignment: .leading, spacing: sectionSpacing) {
                     if geo.size.width >= breakpoint {
+                        // Wide: footer joins the primary column so actions sit
+                        // with the summary instead of stretching pane-wide
+                        // below both columns.
                         HStack(alignment: .top, spacing: columnSpacing) {
                             VStack(alignment: .leading, spacing: sectionSpacing) {
                                 primary()
+                                footer()
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -41,8 +46,8 @@ struct AdaptiveDetailLayout<Primary: View, Secondary: View, Footer: View>: View 
                     } else {
                         primary()
                         secondary()
+                        footer()
                     }
-                    footer()
                 }
                 .padding()
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/mobile-apps/ios/MigraLog/Views/Components/ReadableContentWidth.swift
+++ b/mobile-apps/ios/MigraLog/Views/Components/ReadableContentWidth.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Caps a settings-style Form/List at a readable width on wide layouts
+/// (iPad / regular panes) so rows and controls don't stretch edge-to-edge.
+/// Narrow layouts are unaffected — the cap only bites when the container
+/// is wider than `maxWidth`.
+///
+/// The surrounding area is filled with the grouped background so the
+/// centered form doesn't sit on a mismatched color.
+struct ReadableContentWidth: ViewModifier {
+    var maxWidth: CGFloat = 700
+
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: maxWidth)
+            .frame(maxWidth: .infinity)
+            .background(Color(.systemGroupedBackground))
+    }
+}
+
+extension View {
+    /// Constrain settings-style content to a readable column on wide layouts.
+    func readableContentWidth(maxWidth: CGFloat = 700) -> some View {
+        modifier(ReadableContentWidth(maxWidth: maxWidth))
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/DailyStatus/DailyStatusPromptScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/DailyStatus/DailyStatusPromptScreen.swift
@@ -317,6 +317,7 @@ struct DailyStatusPromptScreen: View {
             await checkinService.topUp()
 
             await viewModel.loadCalendarData(for: date)
+            NotificationCenter.default.post(name: .dailyStatusDataChanged, object: nil)
             dismiss()
         } catch {
             AppLogger.shared.error("Failed to save daily status", error: error)
@@ -329,6 +330,7 @@ struct DailyStatusPromptScreen: View {
             let repo = DailyStatusRepository(dbManager: DatabaseManager.shared)
             try repo.deleteStatus(status.id)
             await viewModel.loadCalendarData(for: date)
+            NotificationCenter.default.post(name: .dailyStatusDataChanged, object: nil)
             dismiss()
         } catch {
             AppLogger.shared.error("Failed to delete daily status", error: error)

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct DashboardScreen: View {
     @Environment(AppState.self) private var appState
     @State private var viewModel = DashboardViewModel()
+    /// Backs the iPad-only "This Month" calendar card; never fetched on iPhone.
+    @State private var calendarViewModel = AnalyticsViewModel()
     @State private var refreshId = UUID()
     @State private var refreshTask: Task<Void, Never>?
     @Environment(\.horizontalSizeClass) private var sizeClass
@@ -11,7 +13,7 @@ struct DashboardScreen: View {
         GeometryReader { geo in
             ScrollView {
                 if sizeClass == .regular {
-                    iPadDashboardLayout(width: geo.size.width)
+                    iPadDashboardLayout(width: geo.size.width, height: geo.size.height)
                 } else {
                     iPhoneDashboardLayout
                 }
@@ -59,6 +61,9 @@ struct DashboardScreen: View {
                 refreshId = UUID()
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .dailyStatusDataChanged)) { _ in
+            refreshId = UUID()
+        }
     }
 
     // MARK: - iPhone Layout (existing single-column)
@@ -78,18 +83,23 @@ struct DashboardScreen: View {
 
     // MARK: - iPad Layout (adapts to available width / orientation)
 
-    /// Width at/above which the dashboard uses the wide (landscape) two-column
-    /// master arrangement instead of the stacked portrait grid.
-    private static let dashboardLandscapeBreakpoint: CGFloat = 1000
+    /// Width at/above which the dashboard uses the wide (landscape) three-column
+    /// master arrangement instead of the stacked portrait grid. Above 13" iPad
+    /// portrait width (1032) so portrait never gets three cramped columns.
+    private static let dashboardLandscapeBreakpoint: CGFloat = 1100
     /// Cap so content doesn't stretch edge-to-edge on a 13" display.
-    private static let dashboardMaxWidth: CGFloat = 1200
+    private static let dashboardMaxWidth: CGFloat = 1400
+    /// Chrome above the landscape columns: outer padding plus nav bar slack,
+    /// used to size the month calendar to the visible column height.
+    private static let landscapeChromeHeight: CGFloat = 48
 
     @ViewBuilder
-    private func iPadDashboardLayout(width: CGFloat) -> some View {
+    private func iPadDashboardLayout(width: CGFloat, height: CGFloat) -> some View {
         Group {
             if width >= Self.dashboardLandscapeBreakpoint {
-                // Landscape / wide: two balanced columns so the tall cards use
-                // the horizontal space instead of scrolling vertically.
+                // Landscape / wide: three balanced columns — actions, activity,
+                // and the month calendar — so the wide canvas carries real
+                // content instead of trailing whitespace.
                 HStack(alignment: .top, spacing: 16) {
                     VStack(spacing: 16) {
                         TodaysMedicationsCard(viewModel: viewModel)
@@ -105,10 +115,17 @@ struct DashboardScreen: View {
                         RecentEpisodesCard(viewModel: viewModel)
                     }
                     .frame(maxWidth: .infinity, alignment: .top)
+
+                    MonthlyCalendarView(
+                        viewModel: calendarViewModel,
+                        fillHeight: height - Self.landscapeChromeHeight
+                    )
+                    .frame(maxWidth: .infinity, alignment: .top)
                 }
             } else {
                 // Portrait iPad: medications + status side by side, then
-                // full-width actions and recent episodes.
+                // full-width actions, then recent episodes beside the
+                // month calendar.
                 VStack(spacing: 16) {
                     HStack(alignment: .top, spacing: 16) {
                         TodaysMedicationsCard(viewModel: viewModel)
@@ -120,7 +137,12 @@ struct DashboardScreen: View {
                         startEpisodeButton
                         logMedicationButton
                     }
-                    RecentEpisodesCard(viewModel: viewModel)
+                    HStack(alignment: .top, spacing: 16) {
+                        RecentEpisodesCard(viewModel: viewModel)
+                            .frame(maxWidth: .infinity)
+                        MonthlyCalendarView(viewModel: calendarViewModel)
+                            .frame(maxWidth: .infinity)
+                    }
                 }
             }
         }

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -285,6 +285,10 @@ struct TodaysMedicationsCard: View {
                 .padding()
                 .background(Color(.secondarySystemBackground))
                 .clipShape(RoundedRectangle(cornerRadius: 12))
+                // Contain children so this identifier stays on the card and
+                // doesn't override the per-row identifiers (e.g.
+                // medication-name-link-*).
+                .accessibilityElement(children: .contain)
                 .accessibilityIdentifier("todays-medications-card")
             }
         }
@@ -295,6 +299,13 @@ struct MedicationScheduleRow: View {
     let item: MedicationScheduleItem
     @Bindable var viewModel: DashboardViewModel
     @Environment(\.horizontalSizeClass) private var sizeClass
+    @Environment(AppState.self) private var appState
+
+    private var medicationNameLabel: some View {
+        Text(item.medication.name)
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(.primary)
+    }
 
     private var doseLabel: String {
         MedicationFormatting.formatDose(
@@ -333,16 +344,28 @@ struct MedicationScheduleRow: View {
             }
 
             HStack {
-                NavigationLink {
-                    MedicationDetailScreen(medicationId: item.medication.id)
-                } label: {
-                    Text(item.medication.name)
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(.primary)
+                // iPad: jump to the Medications tab with this medication
+                // selected so the split-view list stays visible; iPhone
+                // pushes the detail screen as before.
+                if sizeClass == .regular {
+                    Button {
+                        appState.showMedication(item.medication.id)
+                    } label: {
+                        medicationNameLabel
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("medication-name-link-\(item.medication.id)")
+                    .accessibilityHint("Open medication details")
+                } else {
+                    NavigationLink {
+                        MedicationDetailScreen(medicationId: item.medication.id)
+                    } label: {
+                        medicationNameLabel
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("medication-name-link-\(item.medication.id)")
+                    .accessibilityHint("Open medication details")
                 }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("medication-name-link-\(item.medication.id)")
-                .accessibilityHint("Open medication details")
 
                 Spacer()
 
@@ -407,6 +430,8 @@ struct MedicationScheduleRow: View {
 
 struct RecentEpisodesCard: View {
     @Bindable var viewModel: DashboardViewModel
+    @Environment(AppState.self) private var appState
+    @Environment(\.horizontalSizeClass) private var sizeClass
 
     private var hasContent: Bool {
         viewModel.currentEpisode != nil || !viewModel.recentEpisodes.isEmpty
@@ -420,31 +445,41 @@ struct RecentEpisodesCard: View {
 
                 // Ongoing episode first
                 if let episode = viewModel.currentEpisode {
-                    NavigationLink {
-                        EpisodeDetailScreen(episodeId: episode.id)
-                    } label: {
-                        EpisodeCardView(
-                            episode: episode,
-                            readings: viewModel.recentReadings[episode.id] ?? []
-                        )
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("active-episode-card")
+                    episodeLink(episode)
+                        .accessibilityIdentifier("active-episode-card")
                 }
 
                 // Recent closed episodes
                 ForEach(viewModel.recentEpisodes) { episode in
-                    NavigationLink {
-                        EpisodeDetailScreen(episodeId: episode.id)
-                    } label: {
-                        EpisodeCardView(
-                            episode: episode,
-                            readings: viewModel.recentReadings[episode.id] ?? []
-                        )
-                    }
-                    .buttonStyle(.plain)
+                    episodeLink(episode)
                 }
             }
+        }
+    }
+
+    /// On iPad (regular width) switch to the Episodes tab with the episode
+    /// preselected so the split-view list stays visible; on iPhone push the
+    /// detail screen as before.
+    @ViewBuilder
+    private func episodeLink(_ episode: Episode) -> some View {
+        let card = EpisodeCardView(
+            episode: episode,
+            readings: viewModel.recentReadings[episode.id] ?? []
+        )
+        if sizeClass == .regular {
+            Button {
+                appState.showEpisode(episode.id)
+            } label: {
+                card
+            }
+            .buttonStyle(.plain)
+        } else {
+            NavigationLink {
+                EpisodeDetailScreen(episodeId: episode.id)
+            } label: {
+                card
+            }
+            .buttonStyle(.plain)
         }
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -161,7 +161,7 @@ struct EpisodeDetailScreen: View {
         } message: {
             Text("This cannot be undone.")
         }
-        .task {
+        .task(id: episodeId) {
             await viewModel.loadEpisode(episodeId)
         }
     }

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodesScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodesScreen.swift
@@ -115,6 +115,9 @@ struct EpisodeCardView: View {
 struct EpisodeListRowView: View {
     let episode: Episode
     let readings: [IntensityReading]
+    /// Swaps the "Ongoing" pill to white-on-translucent-white so it stays
+    /// legible on the accent-colored selection background.
+    var isSelected: Bool = false
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
@@ -127,8 +130,8 @@ struct EpisodeListRowView: View {
                             .font(.caption)
                             .padding(.horizontal, 8)
                             .padding(.vertical, 4)
-                            .background(Color.red.opacity(0.2))
-                            .foregroundStyle(.red)
+                            .background(isSelected ? Color.white.opacity(0.25) : Color.red.opacity(0.2))
+                            .foregroundStyle(isSelected ? .white : .red)
                             .clipShape(Capsule())
                     }
                 }
@@ -197,7 +200,8 @@ struct EpisodesListColumn: View {
                 List(viewModel.episodes, selection: $selectedEpisodeId) { episode in
                     EpisodeListRowView(
                         episode: episode,
-                        readings: viewModel.readingsMap[episode.id] ?? []
+                        readings: viewModel.readingsMap[episode.id] ?? [],
+                        isSelected: episode.id == selectedEpisodeId
                     )
                     .tag(episode.id)
                 }

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodesScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodesScreen.swift
@@ -115,9 +115,6 @@ struct EpisodeCardView: View {
 struct EpisodeListRowView: View {
     let episode: Episode
     let readings: [IntensityReading]
-    /// Swaps the "Ongoing" pill to white-on-translucent-white so it stays
-    /// legible on the accent-colored selection background.
-    var isSelected: Bool = false
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
@@ -126,12 +123,15 @@ struct EpisodeListRowView: View {
                     Text(DateFormatting.relativeDate(episode.startDate))
                         .font(.headline)
                     if episode.isActive {
+                        // Tint over an opaque base so the pill keeps its
+                        // color identity on the selection highlight.
                         Text("Ongoing")
                             .font(.caption)
                             .padding(.horizontal, 8)
                             .padding(.vertical, 4)
-                            .background(isSelected ? Color.white.opacity(0.25) : Color.red.opacity(0.2))
-                            .foregroundStyle(isSelected ? .white : .red)
+                            .background(Color.red.opacity(0.2))
+                            .background(Color(.systemBackground))
+                            .foregroundStyle(.red)
                             .clipShape(Capsule())
                     }
                 }
@@ -200,8 +200,7 @@ struct EpisodesListColumn: View {
                 List(viewModel.episodes, selection: $selectedEpisodeId) { episode in
                     EpisodeListRowView(
                         episode: episode,
-                        readings: viewModel.readingsMap[episode.id] ?? [],
-                        isSelected: episode.id == selectedEpisodeId
+                        readings: viewModel.readingsMap[episode.id] ?? []
                     )
                     .tag(episode.id)
                 }

--- a/mobile-apps/ios/MigraLog/Views/Medications/AddMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/AddMedicationScreen.swift
@@ -127,6 +127,7 @@ struct AddMedicationScreen: View {
             }
         }
         .navigationTitle("Add Medication")
+        .readableContentWidth()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {

--- a/mobile-apps/ios/MigraLog/Views/Medications/EditMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/EditMedicationScreen.swift
@@ -82,6 +82,7 @@ struct EditMedicationScreen: View {
             }
         }
         .navigationTitle("Edit Medication")
+        .readableContentWidth()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {

--- a/mobile-apps/ios/MigraLog/Views/Medications/MedicationDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/MedicationDetailScreen.swift
@@ -185,7 +185,7 @@ struct MedicationDetailScreen: View {
             }
             Button("Cancel", role: .cancel) { showDeleteDoseConfirm = nil }
         }
-        .task {
+        .task(id: medicationId) {
             await viewModel.loadMedication(medicationId)
         }
     }

--- a/mobile-apps/ios/MigraLog/Views/Medications/MedicationsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/MedicationsScreen.swift
@@ -119,11 +119,10 @@ struct MedicationRowView: View {
 
 /// Plain list row for Medications iPad list column.
 /// Avoids `.secondary` foreground styles that fade on List selection highlight.
-/// `isSelected` swaps the chips to white-on-translucent-white so they stay
-/// legible on the accent-colored selection background.
+/// Chips use explicit colors and opaque backgrounds so they look the same on
+/// the accent-colored selection highlight as on a normal row.
 struct MedicationListRowView: View {
     let medication: Medication
-    var isSelected: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -134,14 +133,15 @@ struct MedicationListRowView: View {
                 .font(.subheadline)
                 .foregroundStyle(.primary)
             HStack(spacing: 6) {
-                MedicationTypeBadge(type: medication.type, onSelectionHighlight: isSelected)
+                MedicationTypeBadge(type: medication.type)
                 if let category = medication.category {
                     Text(category.displayName)
                         .font(.caption2.weight(.semibold))
                         .padding(.horizontal, 10)
                         .padding(.vertical, 4)
-                        .foregroundStyle(isSelected ? .white : .primary)
-                        .background(isSelected ? Color.white.opacity(0.25) : Color(.systemGray5))
+                        .foregroundStyle(Color(.secondaryLabel))
+                        .background(Color(.systemGray5))
+                        .background(Color(.systemBackground))
                         .clipShape(Capsule())
                 }
             }
@@ -161,7 +161,7 @@ struct MedicationsListColumn: View {
             if !viewModel.preventativeMedications.isEmpty {
                 Section("Preventative") {
                     ForEach(viewModel.preventativeMedications) { med in
-                        MedicationListRowView(medication: med, isSelected: med.id == selectedMedicationId)
+                        MedicationListRowView(medication: med)
                             .tag(med.id)
                     }
                 }
@@ -170,7 +170,7 @@ struct MedicationsListColumn: View {
             if !viewModel.rescueMedications.isEmpty {
                 Section("Rescue") {
                     ForEach(viewModel.rescueMedications) { med in
-                        MedicationListRowView(medication: med, isSelected: med.id == selectedMedicationId)
+                        MedicationListRowView(medication: med)
                             .tag(med.id)
                     }
                 }
@@ -179,7 +179,7 @@ struct MedicationsListColumn: View {
             if !viewModel.otherMedications.isEmpty {
                 Section("Other") {
                     ForEach(viewModel.otherMedications) { med in
-                        MedicationListRowView(medication: med, isSelected: med.id == selectedMedicationId)
+                        MedicationListRowView(medication: med)
                             .tag(med.id)
                     }
                 }
@@ -227,11 +227,10 @@ struct MedicationsListColumn: View {
 }
 
 /// Colored badge for medication type (Preventative/Rescue/Other).
-/// `onSelectionHighlight` switches to white-on-translucent-white for
-/// legibility on a List selection's accent-colored background.
+/// The tint layers over an opaque base so the badge keeps its color
+/// identity on a List selection's accent-colored highlight.
 struct MedicationTypeBadge: View {
     let type: MedicationType
-    var onSelectionHighlight: Bool = false
 
     var body: some View {
         let badgeColor = MedicationTypeColors.color(for: type)
@@ -239,8 +238,9 @@ struct MedicationTypeBadge: View {
             .font(.caption2.weight(.semibold))
             .padding(.horizontal, 10)
             .padding(.vertical, 4)
-            .foregroundStyle(onSelectionHighlight ? .white : badgeColor)
-            .background(onSelectionHighlight ? Color.white.opacity(0.25) : badgeColor.opacity(0.2))
+            .foregroundStyle(badgeColor)
+            .background(badgeColor.opacity(0.2))
+            .background(Color(.systemBackground))
             .clipShape(Capsule())
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Medications/MedicationsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/MedicationsScreen.swift
@@ -119,8 +119,11 @@ struct MedicationRowView: View {
 
 /// Plain list row for Medications iPad list column.
 /// Avoids `.secondary` foreground styles that fade on List selection highlight.
+/// `isSelected` swaps the chips to white-on-translucent-white so they stay
+/// legible on the accent-colored selection background.
 struct MedicationListRowView: View {
     let medication: Medication
+    var isSelected: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -131,14 +134,14 @@ struct MedicationListRowView: View {
                 .font(.subheadline)
                 .foregroundStyle(.primary)
             HStack(spacing: 6) {
-                MedicationTypeBadge(type: medication.type)
+                MedicationTypeBadge(type: medication.type, onSelectionHighlight: isSelected)
                 if let category = medication.category {
                     Text(category.displayName)
                         .font(.caption2.weight(.semibold))
                         .padding(.horizontal, 10)
                         .padding(.vertical, 4)
-                        .foregroundStyle(.primary)
-                        .background(Color(.systemGray5))
+                        .foregroundStyle(isSelected ? .white : .primary)
+                        .background(isSelected ? Color.white.opacity(0.25) : Color(.systemGray5))
                         .clipShape(Capsule())
                 }
             }
@@ -158,7 +161,7 @@ struct MedicationsListColumn: View {
             if !viewModel.preventativeMedications.isEmpty {
                 Section("Preventative") {
                     ForEach(viewModel.preventativeMedications) { med in
-                        MedicationListRowView(medication: med)
+                        MedicationListRowView(medication: med, isSelected: med.id == selectedMedicationId)
                             .tag(med.id)
                     }
                 }
@@ -167,7 +170,7 @@ struct MedicationsListColumn: View {
             if !viewModel.rescueMedications.isEmpty {
                 Section("Rescue") {
                     ForEach(viewModel.rescueMedications) { med in
-                        MedicationListRowView(medication: med)
+                        MedicationListRowView(medication: med, isSelected: med.id == selectedMedicationId)
                             .tag(med.id)
                     }
                 }
@@ -176,7 +179,7 @@ struct MedicationsListColumn: View {
             if !viewModel.otherMedications.isEmpty {
                 Section("Other") {
                     ForEach(viewModel.otherMedications) { med in
-                        MedicationListRowView(medication: med)
+                        MedicationListRowView(medication: med, isSelected: med.id == selectedMedicationId)
                             .tag(med.id)
                     }
                 }
@@ -223,9 +226,12 @@ struct MedicationsListColumn: View {
     }
 }
 
-/// Colored badge for medication type (Preventative/Rescue/Other)
+/// Colored badge for medication type (Preventative/Rescue/Other).
+/// `onSelectionHighlight` switches to white-on-translucent-white for
+/// legibility on a List selection's accent-colored background.
 struct MedicationTypeBadge: View {
     let type: MedicationType
+    var onSelectionHighlight: Bool = false
 
     var body: some View {
         let badgeColor = MedicationTypeColors.color(for: type)
@@ -233,8 +239,8 @@ struct MedicationTypeBadge: View {
             .font(.caption2.weight(.semibold))
             .padding(.horizontal, 10)
             .padding(.vertical, 4)
-            .foregroundStyle(badgeColor)
-            .background(badgeColor.opacity(0.2))
+            .foregroundStyle(onSelectionHighlight ? .white : badgeColor)
+            .background(onSelectionHighlight ? Color.white.opacity(0.25) : badgeColor.opacity(0.2))
             .clipShape(Capsule())
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Settings/CategorySafetyRulesScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/CategorySafetyRulesScreen.swift
@@ -17,6 +17,7 @@ struct CategorySafetyRulesScreen: View {
             }
         }
         .navigationTitle("Medication Safety Limits")
+        .readableContentWidth()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {

--- a/mobile-apps/ios/MigraLog/Views/Settings/DataSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DataSettingsScreen.swift
@@ -75,6 +75,7 @@ struct DataSettingsScreen: View {
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Backup & Export")
+        .readableContentWidth()
         .sheet(isPresented: $showShareSheet, onDismiss: {
             // The export is plaintext health data in tmp — remove it as soon
             // as the share sheet is done with it.

--- a/mobile-apps/ios/MigraLog/Views/Settings/DeveloperToolsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DeveloperToolsScreen.swift
@@ -44,6 +44,7 @@ struct DeveloperToolsScreen: View {
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Developer Tools")
+        .readableContentWidth()
         .alert("Reset Database", isPresented: $showResetConfirm) {
             Button("Reset", role: .destructive) {
                 try? DatabaseManager.shared.resetDatabase()
@@ -77,5 +78,6 @@ struct ErrorLogsScreen: View {
             }
         }
         .navigationTitle("Error Logs")
+        .readableContentWidth()
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Settings/LocationSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/LocationSettingsScreen.swift
@@ -31,6 +31,7 @@ struct LocationSettingsScreen: View {
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Location Services")
+        .readableContentWidth()
         .onAppear {
             authStatus = LocationService.shared.authorizationStatus
         }

--- a/mobile-apps/ios/MigraLog/Views/Settings/NotificationSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/NotificationSettingsScreen.swift
@@ -83,6 +83,7 @@ struct NotificationSettingsScreen: View {
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Notification Settings")
+        .readableContentWidth()
         .task {
             viewModel.loadSettings()
             await viewModel.syncDailyCheckinNotification()

--- a/mobile-apps/ios/MigraLog/Views/Settings/ScheduledNotificationsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/ScheduledNotificationsScreen.swift
@@ -77,6 +77,7 @@ struct ScheduledNotificationsScreen: View {
             }
         }
         .navigationTitle("Scheduled Notifications")
+        .readableContentWidth()
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
@@ -284,6 +285,7 @@ private struct ScheduledNotificationDetailView: View {
             }
         }
         .navigationTitle("Notification Detail")
+        .readableContentWidth()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {

--- a/mobile-apps/ios/MigraLog/Views/Settings/SettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/SettingsScreen.swift
@@ -80,6 +80,7 @@ struct SettingsScreen: View {
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Settings")
+        .readableContentWidth()
     }
 }
 

--- a/mobile-apps/ios/MigraLog/Views/Settings/SyncSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/SyncSettingsScreen.swift
@@ -45,6 +45,7 @@ struct SyncSettingsScreen: View {
             }
         }
         .navigationTitle("iCloud Sync")
+        .readableContentWidth()
         .alert("Sync Error", isPresented: Binding(
             get: { errorMessage != nil },
             set: { if !$0 { errorMessage = nil } }

--- a/mobile-apps/ios/MigraLog/Views/Settings/TestNotificationsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/TestNotificationsScreen.swift
@@ -64,6 +64,7 @@ struct TestNotificationsScreen: View {
             }
         }
         .navigationTitle("Test Notifications")
+        .readableContentWidth()
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {

--- a/mobile-apps/ios/MigraLog/Views/Settings/TrackingOptionsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/TrackingOptionsScreen.swift
@@ -16,6 +16,7 @@ struct TrackingOptionsScreen: View {
             }
         }
         .navigationTitle("Tracking Options")
+        .readableContentWidth()
         .navigationBarTitleDisplayMode(.inline)
         .task {
             viewModel.load()

--- a/mobile-apps/ios/MigraLogUITests/IPadLayoutAuditUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/IPadLayoutAuditUITests.swift
@@ -1,0 +1,214 @@
+import XCTest
+import UIKit
+
+/// iPad layout audit (issue #436): tours every screen in portrait AND landscape,
+/// attaching a screenshot at each stop. Not a functional test — it exists to
+/// produce review artifacts for layout work. Run on an iPad destination:
+///
+///     xcodebuild test -scheme MigraLog \
+///       -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M5)' \
+///       -only-testing:MigraLogUITests/IPadLayoutAuditUITests
+///
+/// Extract attachments with `xcrun xcresulttool export attachments`.
+final class IPadLayoutAuditUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        XCUIDevice.shared.orientation = .portrait
+        app = XCUIApplication()
+        app.launchArguments = ["--uitesting", "--load-screenshot-data"]
+        app.launch()
+        UITestHelpers.waitForDashboard(in: app)
+    }
+
+    override func tearDownWithError() throws {
+        XCUIDevice.shared.orientation = .portrait
+        app = nil
+    }
+
+    // MARK: - Dashboard + sheets
+
+    func test01_Dashboard() throws {
+        navigate(to: "Dashboard")
+        snapBoth("dashboard")
+    }
+
+    func test02_NewEpisodeSheet() throws {
+        navigate(to: "Dashboard")
+        let start = UITestHelpers.findElement("start-episode-button", in: app)
+        UITestHelpers.waitForHittable(start).tap()
+        Thread.sleep(forTimeInterval: 1.0)
+        snapBoth("sheet-new-episode")
+        dismissSheet()
+    }
+
+    func test03_LogMedicationSheet() throws {
+        navigate(to: "Dashboard")
+        let log = UITestHelpers.findElement("log-medication-button", in: app)
+        UITestHelpers.waitForHittable(log).tap()
+        Thread.sleep(forTimeInterval: 1.0)
+        snapBoth("sheet-log-medication")
+        dismissSheet()
+    }
+
+    // MARK: - Episodes
+
+    func test04_EpisodesActiveDetail() throws {
+        navigate(to: "Episodes")
+        let cells = app.cells
+        _ = cells.firstMatch.waitForExistence(timeout: 5)
+        cells.firstMatch.tap()
+        Thread.sleep(forTimeInterval: 1.0)
+        snapBoth("episodes-active-detail")
+    }
+
+    func test05_EpisodesClosedDetail() throws {
+        navigate(to: "Episodes")
+        let cells = app.cells
+        _ = cells.firstMatch.waitForExistence(timeout: 5)
+        cells.element(boundBy: 1).tap()
+        Thread.sleep(forTimeInterval: 1.5)
+        snapBoth("episodes-closed-detail")
+
+        // Scroll the detail pane to capture the timeline body too.
+        let scroll = app.scrollViews.firstMatch
+        if scroll.exists {
+            scroll.swipeUp()
+            Thread.sleep(forTimeInterval: 0.8)
+            snapBoth("episodes-closed-detail-scrolled")
+        }
+    }
+
+    // MARK: - Medications
+
+    func test06_MedicationsDetail() throws {
+        navigate(to: "Medications")
+        let erenumab = app.staticTexts["Erenumab"]
+        UITestHelpers.waitForHittable(erenumab).tap()
+        Thread.sleep(forTimeInterval: 1.0)
+        snapBoth("medications-preventative-detail")
+
+        // A rescue/PRN med has different sections (cooldown, daily limits).
+        let rescue = app.staticTexts["Ibuprofen"]
+        if rescue.exists {
+            rescue.tap()
+            Thread.sleep(forTimeInterval: 1.0)
+            snapBoth("medications-rescue-detail")
+        }
+    }
+
+    func test07_AddMedicationSheet() throws {
+        navigate(to: "Medications")
+        let add = app.buttons["add-medication-button"].firstMatch
+        if add.waitForExistence(timeout: 3) {
+            add.tap()
+        } else {
+            // Toolbar "+" without identifier
+            let plus = app.navigationBars.buttons["Add"].firstMatch
+            if plus.waitForExistence(timeout: 2) {
+                plus.tap()
+            } else {
+                throw XCTSkip("No add-medication entry point found")
+            }
+        }
+        Thread.sleep(forTimeInterval: 1.0)
+        snapBoth("sheet-add-medication")
+        dismissSheet()
+    }
+
+    // MARK: - Trends
+
+    func test08_TrendsCalendar() throws {
+        navigate(to: "Trends")
+        Thread.sleep(forTimeInterval: 1.5)
+        snapBoth("trends-calendar")
+    }
+
+    func test09_TrendsInsights() throws {
+        navigate(to: "Trends")
+        let insights = app.buttons["Insights"]
+        if insights.waitForExistence(timeout: 3) {
+            insights.tap()
+            Thread.sleep(forTimeInterval: 1.0)
+        }
+        snapBoth("trends-insights-top")
+
+        let scroll = app.scrollViews.firstMatch
+        if scroll.exists {
+            scroll.swipeUp()
+            scroll.swipeUp()
+            Thread.sleep(forTimeInterval: 0.8)
+            snapBoth("trends-insights-mid")
+        }
+    }
+
+    // MARK: - Settings
+
+    func test10_Settings() throws {
+        navigate(to: "Dashboard")
+        let settings = UITestHelpers.findElement("settings-button", in: app)
+        UITestHelpers.waitForHittable(settings).tap()
+        Thread.sleep(forTimeInterval: 1.0)
+        snapBoth("settings-root")
+
+        let notif = UITestHelpers.findElement("notification-settings", in: app)
+        if notif.exists {
+            notif.tap()
+            Thread.sleep(forTimeInterval: 1.0)
+            snapBoth("settings-notifications")
+            app.navigationBars.buttons.firstMatch.tap()
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+
+        let safety = UITestHelpers.findElement("medication-safety-limits", in: app)
+        if safety.exists {
+            safety.tap()
+            Thread.sleep(forTimeInterval: 1.0)
+            snapBoth("settings-medication-safety")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Navigate to a top-level section (iPad top pill bar or iPhone tab bar).
+    private func navigate(to label: String) {
+        let tabBarButton = app.tabBars.buttons[label]
+        if tabBarButton.waitForExistence(timeout: 1) {
+            UITestHelpers.waitForHittable(tabBarButton).tap()
+        } else {
+            let button = app.buttons[label].firstMatch
+            UITestHelpers.waitForHittable(button).tap()
+        }
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+    }
+
+    /// Capture the current screen in portrait and landscape.
+    private func snapBoth(_ name: String) {
+        XCUIDevice.shared.orientation = .portrait
+        Thread.sleep(forTimeInterval: 1.2)
+        attachScreenshot(named: "\(name)--portrait")
+        XCUIDevice.shared.orientation = .landscapeLeft
+        Thread.sleep(forTimeInterval: 1.2)
+        attachScreenshot(named: "\(name)--landscape")
+        XCUIDevice.shared.orientation = .portrait
+        Thread.sleep(forTimeInterval: 0.8)
+    }
+
+    private func dismissSheet() {
+        let cancel = app.navigationBars.buttons["Cancel"].firstMatch
+        if cancel.waitForExistence(timeout: 2) {
+            cancel.tap()
+        }
+        Thread.sleep(forTimeInterval: 0.5)
+    }
+
+    private func attachScreenshot(named name: String) {
+        let screenshot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/mobile-apps/ios/MigraLogUITests/IPadLayoutAuditUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/IPadLayoutAuditUITests.swift
@@ -170,7 +170,64 @@ final class IPadLayoutAuditUITests: XCTestCase {
         }
     }
 
+    // MARK: - Dashboard cross-tab navigation (iPad)
+
+    /// Tapping an episode on the Dashboard should switch to the Episodes tab
+    /// with the episode preselected — list column visible, not a pushed
+    /// detail without the list.
+    func test11_DashboardEpisodeOpensEpisodesTab() throws {
+        try XCTSkipUnless(isIPad, "Cross-tab selection only applies to iPad")
+        navigate(to: "Dashboard")
+        let card = UITestHelpers.findElement("active-episode-card", in: app)
+        UITestHelpers.waitForHittable(card).tap()
+        Thread.sleep(forTimeInterval: 1.0)
+
+        XCTAssertTrue(
+            app.staticTexts["Episode Details"].waitForExistence(timeout: 5),
+            "Episode detail should be shown"
+        )
+        XCTAssertTrue(
+            app.cells.firstMatch.exists,
+            "Episodes list column should be visible alongside the detail"
+        )
+        snapBoth("dashboard-to-episode")
+    }
+
+    /// Same pattern for medications: tapping a medication name on the
+    /// Dashboard switches to the Medications tab with it preselected.
+    func test12_DashboardMedicationOpensMedicationsTab() throws {
+        try XCTSkipUnless(isIPad, "Cross-tab selection only applies to iPad")
+        navigate(to: "Dashboard")
+        // The plain-styled name button may surface as a non-button element
+        // type, so match any descendant by identifier (as findElement does).
+        let link = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier BEGINSWITH 'medication-name-link-'")
+        ).firstMatch
+        if !link.waitForExistence(timeout: 5) {
+            let dump = XCTAttachment(string: app.debugDescription)
+            dump.name = "accessibility-tree"
+            dump.lifetime = .keepAlways
+            add(dump)
+        }
+        UITestHelpers.waitForHittable(link).tap()
+        Thread.sleep(forTimeInterval: 1.0)
+
+        XCTAssertTrue(
+            app.staticTexts["Log Dose"].waitForExistence(timeout: 5),
+            "Medication detail should be shown"
+        )
+        XCTAssertTrue(
+            app.staticTexts["Preventative"].exists || app.staticTexts["Rescue"].exists,
+            "Medications list column should be visible alongside the detail"
+        )
+        snapBoth("dashboard-to-medication")
+    }
+
     // MARK: - Helpers
+
+    private var isIPad: Bool {
+        UIDevice.current.userInterfaceIdiom == .pad
+    }
 
     /// Navigate to a top-level section (iPad top pill bar or iPhone tab bar).
     private func navigate(to label: String) {


### PR DESCRIPTION
## Summary

Audit-driven iPad layout pass for #436 (both orientations, iPad Pro 13"), reviewed iteratively in the simulator:

- **Dashboard**: new "This Month" calendar card (reuses `MonthlyCalendarView`; tap a day to log status). Landscape becomes three balanced columns; portrait pairs the calendar with Recent Episodes. Wide-layout breakpoint raised to 1100pt so 13" portrait keeps the stacked grid.
- **Cross-tab selection**: tapping an episode or medication on the Dashboard switches to the Episodes/Medications tab with the item preselected, keeping the split-view list visible (iPhone keeps push navigation). Tab + split-view selection moved into `AppState`.
- **Trends calendar**: day cells grow to fill the pane height instead of floating a 44pt grid over empty space. Charts stay full width.
- **Detail screens**: `AdaptiveDetailLayout` footer actions join the primary column on wide panes instead of stretching across both columns.
- **Settings + add/edit medication**: `readableContentWidth()` caps forms at 700pt on wide layouts instead of edge-to-edge rows.
- **Selected-row chips**: type/category chips and the "Ongoing" pill keep their color identity on the selection highlight via opaque backgrounds + explicit label colors.

## Bug fixes found during the audit

- Stale split-view detail pane when switching list selection (`.task` now keyed on the selected id for episodes + medications).
- `todays-medications-card` accessibility identifier was clobbering the per-row `medication-name-link-*` identifiers.
- Dashboard now refreshes on `dailyStatusDataChanged` (posted on save/delete from the daily status prompt).

## Testing

- New `IPadLayoutAuditUITests`: a 12-test screenshot tour of every screen in both orientations, including cross-tab navigation assertions — all passing locally on iPad Pro 13" (M5).
- SwiftLint: no errors.
- Reviewed screen-by-screen in the simulator (portrait + landscape).

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)