### PR TITLE
fix(ios): apply the selected theme from Settings

### DIFF
--- a/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
+++ b/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
@@ -8,6 +8,7 @@ struct MigraLogApp: App {
     /// app finishes launching (BGTaskScheduler requires registration at launch — #462).
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var appState = AppState()
+    @AppStorage("selectedTheme") private var selectedTheme: ThemePreference = .system
 
     /// Notification response handler — must be retained for the lifetime of the app.
     private let notificationResponseHandler: NotificationResponseHandler
@@ -67,6 +68,7 @@ struct MigraLogApp: App {
                 .environment(appState)
                 .environment(timezoneChangeService)
                 .environment(appDelegate.syncService)
+                .preferredColorScheme(selectedTheme.colorScheme)
                 .task {
                     await reconciliationService.reconcile()
                     await medicationNotificationService.topUp()

--- a/mobile-apps/ios/MigraLog/Models/ThemePreference.swift
+++ b/mobile-apps/ios/MigraLog/Models/ThemePreference.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// User-selected appearance preference, persisted in UserDefaults under
+/// `selectedTheme`. Raw values match the strings the Settings picker has
+/// always stored, so existing selections carry over.
+enum ThemePreference: String, CaseIterable, Identifiable {
+    case light
+    case dark
+    case system
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .light: return "Light"
+        case .dark: return "Dark"
+        case .system: return "System"
+        }
+    }
+
+    /// The color scheme to force on the window, or nil to follow the system.
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .light: return .light
+        case .dark: return .dark
+        case .system: return nil
+        }
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Settings/SettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/SettingsScreen.swift
@@ -86,16 +86,14 @@ struct SettingsScreen: View {
 // MARK: - Theme Section
 
 struct ThemeSectionView: View {
-    @AppStorage("selectedTheme") private var selectedTheme: String = "system"
+    @AppStorage("selectedTheme") private var selectedTheme: ThemePreference = .system
 
     var body: some View {
         Picker("Theme", selection: $selectedTheme) {
-            Text("Light").tag("light")
-                .accessibilityIdentifier("theme-light")
-            Text("Dark").tag("dark")
-                .accessibilityIdentifier("theme-dark")
-            Text("System").tag("system")
-                .accessibilityIdentifier("theme-system")
+            ForEach(ThemePreference.allCases) { theme in
+                Text(theme.displayName).tag(theme)
+                    .accessibilityIdentifier("theme-\(theme.rawValue)")
+            }
         }
         .pickerStyle(.segmented)
     }

--- a/mobile-apps/ios/MigraLogTests/Models/ThemePreferenceTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Models/ThemePreferenceTests.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import XCTest
+@testable import MigraLog
+
+final class ThemePreferenceTests: XCTestCase {
+    func test_light_forcesLightColorScheme() {
+        XCTAssertEqual(ThemePreference.light.colorScheme, .light)
+    }
+
+    func test_dark_forcesDarkColorScheme() {
+        XCTAssertEqual(ThemePreference.dark.colorScheme, .dark)
+    }
+
+    func test_system_followsSystemColorScheme() {
+        XCTAssertNil(ThemePreference.system.colorScheme)
+    }
+
+    func test_rawValues_matchLegacyStoredStrings() {
+        // The Settings picker historically stored these exact strings under
+        // the `selectedTheme` key; the enum must keep decoding them.
+        XCTAssertEqual(ThemePreference(rawValue: "light"), .light)
+        XCTAssertEqual(ThemePreference(rawValue: "dark"), .dark)
+        XCTAssertEqual(ThemePreference(rawValue: "system"), .system)
+    }
+}

--- a/mobile-apps/ios/MigraLogUITests/ThemeSwitchingUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/ThemeSwitchingUITests.swift
@@ -1,0 +1,117 @@
+import XCTest
+
+/// Regression tests for the Settings theme picker. The picker used to persist
+/// `selectedTheme` without anything applying it (`preferredColorScheme` was
+/// never set), so switching themes had no visible effect. These tests assert
+/// the rendered appearance actually changes by comparing screen luminance —
+/// element-existence checks alone cannot catch that failure mode.
+final class ThemeSwitchingUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = UITestHelpers.launchCleanDashboard()
+        UITestHelpers.waitForDashboard(in: app)
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    func testSwitchingThemeChangesRenderedAppearance() throws {
+        openSettings()
+
+        tapTheme("theme-light")
+        let lightLuminance = meanScreenLuminance()
+
+        tapTheme("theme-dark")
+        let darkLuminance = meanScreenLuminance()
+
+        XCTAssertGreaterThan(lightLuminance, 0.5,
+                             "Light theme should render a predominantly light screen")
+        XCTAssertLessThan(darkLuminance, 0.5,
+                          "Dark theme should render a predominantly dark screen")
+        XCTAssertLessThan(darkLuminance, lightLuminance - 0.2,
+                          "Switching light → dark should visibly darken the screen")
+
+        // Back to system so the picker round-trips through every option.
+        tapTheme("theme-system")
+    }
+
+    func testThemeSelectionPersistsAcrossRelaunch() throws {
+        openSettings()
+        tapTheme("theme-dark")
+
+        // Relaunch WITHOUT --reset-database so UserDefaults survive.
+        app.terminate()
+        app = XCUIApplication()
+        app.launchArguments = ["--uitesting", "--skip-onboarding"]
+        app.launch()
+        UITestHelpers.waitForDashboard(in: app)
+
+        let luminance = meanScreenLuminance()
+        XCTAssertLessThan(luminance, 0.5,
+                          "Dark theme should still be applied after relaunch")
+    }
+
+    // MARK: - Helpers
+
+    private func openSettings() {
+        let settingsButton = app.buttons["settings-button"]
+        UITestHelpers.waitForHittable(settingsButton)
+        settingsButton.tap()
+
+        let settingsTitle = app.navigationBars.staticTexts["Settings"]
+        UITestHelpers.waitForElement(settingsTitle)
+    }
+
+    private func tapTheme(_ identifier: String) {
+        let segment = app.buttons[identifier]
+        UITestHelpers.waitForHittable(segment)
+        segment.tap()
+        // Allow the appearance transition to settle before screenshotting.
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+    }
+
+    /// Mean luminance (0 = black, 1 = white) of the app's current screenshot,
+    /// sampled on a sparse grid. Text and accent colors are a small minority of
+    /// pixels, so the mean cleanly separates light and dark appearances.
+    private func meanScreenLuminance(file: StaticString = #file, line: UInt = #line) -> Double {
+        guard let cgImage = app.screenshot().image.cgImage else {
+            XCTFail("Could not capture screenshot pixels", file: file, line: line)
+            return 0
+        }
+
+        let width = cgImage.width
+        let height = cgImage.height
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            XCTFail("Could not create bitmap context", file: file, line: line)
+            return 0
+        }
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        let stride = 16
+        var total = 0.0
+        var count = 0
+        for y in Swift.stride(from: 0, to: height, by: stride) {
+            for x in Swift.stride(from: 0, to: width, by: stride) {
+                let offset = (y * width + x) * 4
+                let red = Double(pixels[offset])
+                let green = Double(pixels[offset + 1])
+                let blue = Double(pixels[offset + 2])
+                total += (0.299 * red + 0.587 * green + 0.114 * blue) / 255.0
+                count += 1
+            }
+        }
+        return total / Double(count)
+    }
+}


### PR DESCRIPTION
## Summary
The Settings → Appearance picker persisted `selectedTheme` to UserDefaults, but nothing in the app ever read it back — `.preferredColorScheme` was never applied anywhere, so choosing Light/Dark saved the value but had no visible effect (the app always followed the system appearance).

## Changes
- New `ThemePreference` enum — raw values match the legacy stored strings (`light`/`dark`/`system`), so existing user selections carry over unchanged
- `MigraLogApp` now applies `.preferredColorScheme(selectedTheme.colorScheme)` at the window root
- Settings picker switched to the enum-backed `@AppStorage` binding (same key, same accessibility identifiers)

## Tests
- **Unit** (`ThemePreferenceTests`): ColorScheme mapping + legacy raw-value compatibility — 4/4 passing
- **UI regression** (`ThemeSwitchingUITests`): asserts the rendered screen luminance actually changes when switching Light → Dark (element-existence checks could never catch this bug), and that the selection persists across relaunch — 2/2 passing locally on iPhone 17 Pro / iOS 26.0. Both run in the nightly Full plan automatically (it uses `skippedTests`, not `selectedTests`).
- SwiftLint clean (no error-level violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)