### PR TITLE
fix(ios): sync updates and deletes of already-synced records (#434)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/Sync/CloudKitSyncTransport.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/CloudKitSyncTransport.swift
@@ -99,12 +99,18 @@ final class CloudKitSyncTransport: CloudKitTransport, @unchecked Sendable {
         // Last resort after repeated conflicts on the same hot record: force-save what
         // remains so our edit isn't silently lost. Bounded by maxPushAttempts above.
         if !toSave.isEmpty {
+            let results: [CKRecord.ID: Result<CKRecord, Error>]
             do {
-                _ = try await database.modifyRecords(
+                (results, _) = try await database.modifyRecords(
                     saving: toSave, deleting: [], savePolicy: .allKeys, atomically: false
                 )
             } catch {
                 throw Self.mapError(error)
+            }
+            // Even a force-save can fail per-record (quota, size, …) — surface the first
+            // failure so the engine keeps the queue and retries, rather than dropping it.
+            for case .failure(let itemError) in results.values {
+                throw Self.mapError(itemError)
             }
         }
         return serverWon
@@ -113,29 +119,42 @@ final class CloudKitSyncTransport: CloudKitTransport, @unchecked Sendable {
     /// One optimistic-concurrency save pass. Returns the records the server rejected
     /// because it holds a changed version, paired with that server record. Throws (mapped)
     /// for any other failure so the engine keeps the queue and retries.
+    ///
+    /// With `atomically: false`, `modifyRecords` does NOT throw for per-record failures —
+    /// only whole-operation ones. Per-record `.serverRecordChanged` rejections arrive in
+    /// the returned `saveResults` tuple, so reading that tuple is load-bearing: every save
+    /// of an already-existing server record is rejected there (our CKRecords carry no
+    /// change tag) and discarding it loses the update.
     private func saveResolvingConflicts(_ ckRecords: [CKRecord]) async throws -> [(CKRecord.ID, CKRecord)] {
+        let saveResults: [CKRecord.ID: Result<CKRecord, Error>]
         do {
-            _ = try await database.modifyRecords(
+            (saveResults, _) = try await database.modifyRecords(
                 saving: ckRecords, deleting: [], savePolicy: .ifServerRecordUnchanged, atomically: false
             )
-            return []
         } catch {
-            guard let ckError = error as? CKError, ckError.code == .partialFailure,
-                  let perItem = ckError.partialErrorsByItemID else {
-                throw Self.mapError(error)
-            }
-            var conflicts: [(CKRecord.ID, CKRecord)] = []
-            for (key, itemError) in perItem {
-                guard let itemCK = itemError as? CKError, itemCK.code == .serverRecordChanged else {
-                    // A non-conflict per-item failure (zone gone, quota, …) — surface it.
-                    throw Self.mapError(error)
-                }
-                if let id = key as? CKRecord.ID, let server = itemCK.serverRecord {
-                    conflicts.append((id, server))
-                }
-            }
-            return conflicts
+            throw Self.mapError(error)
         }
+        return try Self.conflictedSaves(saveResults)
+    }
+
+    /// Partition per-record save results: successes are dropped, `.serverRecordChanged`
+    /// rejections become conflicts paired with the server's current record, and anything
+    /// else (zone gone, quota, a conflict missing its server record, …) throws so the
+    /// engine keeps the pending queue and retries later — never drop silently. Internal
+    /// for unit testing; the CloudKit round-trip itself can't run in CI.
+    static func conflictedSaves(
+        _ saveResults: [CKRecord.ID: Result<CKRecord, Error>]
+    ) throws -> [(CKRecord.ID, CKRecord)] {
+        var conflicts: [(CKRecord.ID, CKRecord)] = []
+        for (id, result) in saveResults {
+            guard case .failure(let itemError) = result else { continue }
+            guard let itemCK = itemError as? CKError, itemCK.code == .serverRecordChanged,
+                  let server = itemCK.serverRecord else {
+                throw Self.mapError(itemError)
+            }
+            conflicts.append((id, server))
+        }
+        return conflicts
     }
 
     /// Fetch changes since `token` (nil for a first full sync), mapping each changed

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncService.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncService.swift
@@ -87,6 +87,19 @@ final class SyncService {
         try? await syncNow()
     }
 
+    /// Re-enqueue every row in every synced table and run a sync, so devices reconverge
+    /// after a missed window (e.g. changes dropped by an earlier defect). Safe to run
+    /// any time: pushes resolve by last-write-wins, and rows already queued — including
+    /// pending deletes — are left as-is. A no-op while sync is disabled (enabling later
+    /// backfills anyway). Returns the number of rows enqueued.
+    @discardableResult
+    func forceFullResync() async throws -> Int {
+        guard isEnabled else { return 0 }
+        let enqueued = try pendingStore.backfillExistingRows(at: TimestampHelper.now)
+        try await syncNow()
+        return enqueued
+    }
+
     // MARK: - Automatic triggers
 
     /// Start watching the pending queue so a local edit triggers an automatic sync.

--- a/mobile-apps/ios/MigraLog/Views/Settings/DeveloperToolsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DeveloperToolsScreen.swift
@@ -2,7 +2,10 @@ import SwiftUI
 
 struct DeveloperToolsScreen: View {
     @Environment(AppState.self) private var appState
+    @Environment(SyncService.self) private var syncService
     @State private var showResetConfirm = false
+    @State private var showResyncConfirm = false
+    @State private var resyncResult: String?
 
     var body: some View {
         List {
@@ -36,6 +39,34 @@ struct DeveloperToolsScreen: View {
                 }
             }
 
+            Section {
+                Button {
+                    showResyncConfirm = true
+                } label: {
+                    if syncService.isSyncing {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                            Text("Re-syncing…")
+                        }
+                    } else {
+                        Label("Force Re-sync All Data", systemImage: "arrow.triangle.2.circlepath.icloud")
+                    }
+                }
+                .disabled(!syncService.isEnabled || syncService.isSyncing)
+                if let resyncResult {
+                    Text(resyncResult)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("Sync")
+            } footer: {
+                Text(syncService.isEnabled
+                    ? "Re-uploads every local record to iCloud. Devices reconverge by "
+                        + "last-write-wins; run it on each device that has unsynced edits."
+                    : "Enable iCloud Sync in Settings first.")
+            }
+
             Section("Onboarding") {
                 Button("Reset Onboarding") {
                     appState.resetOnboarding()
@@ -45,6 +76,15 @@ struct DeveloperToolsScreen: View {
         .listStyle(.insetGrouped)
         .navigationTitle("Developer Tools")
         .readableContentWidth()
+        .alert("Force Re-sync All Data", isPresented: $showResyncConfirm) {
+            Button("Re-sync") {
+                Task { await forceResync() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Queues every local record for upload and syncs now. "
+                + "Existing data is merged by last-write-wins; nothing is deleted.")
+        }
         .alert("Reset Database", isPresented: $showResetConfirm) {
             Button("Reset", role: .destructive) {
                 try? DatabaseManager.shared.resetDatabase()
@@ -52,6 +92,15 @@ struct DeveloperToolsScreen: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This will delete all data. This action cannot be undone.")
+        }
+    }
+
+    private func forceResync() async {
+        do {
+            let enqueued = try await syncService.forceFullResync()
+            resyncResult = "Re-queued \(enqueued) records and synced."
+        } catch {
+            resyncResult = "Re-sync failed: \(error.localizedDescription)"
         }
     }
 }

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/CloudKitSyncTransportTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/CloudKitSyncTransportTests.swift
@@ -1,0 +1,73 @@
+import CloudKit
+import XCTest
+@testable import MigraLog
+
+/// Tests the per-record save-result handling of the real transport. The CloudKit
+/// round-trip itself can't run in CI, but `conflictedSaves` is where the silent-loss
+/// hazard lives: with `atomically: false`, `modifyRecords` reports per-record failures
+/// in its returned tuple instead of throwing, and every save of an already-existing
+/// server record is rejected there as `.serverRecordChanged`.
+final class CloudKitSyncTransportTests: XCTestCase {
+
+    private func recordID(_ name: String) -> CKRecord.ID {
+        CKRecord.ID(
+            recordName: name,
+            zoneID: CKRecordZone.ID(zoneName: SyncEngine.zoneName, ownerName: CKCurrentUserDefaultName)
+        )
+    }
+
+    private func record(_ name: String) -> CKRecord {
+        CKRecord(recordType: CloudKitSyncTransport.recordType, recordID: recordID(name))
+    }
+
+    func testSuccessfulSavesYieldNoConflicts() throws {
+        let results: [CKRecord.ID: Result<CKRecord, Error>] = [
+            recordID("episodes:a"): .success(record("episodes:a")),
+            recordID("episodes:b"): .success(record("episodes:b")),
+        ]
+
+        XCTAssertTrue(try CloudKitSyncTransport.conflictedSaves(results).isEmpty)
+    }
+
+    func testServerRecordChangedBecomesConflictPairedWithServerRecord() throws {
+        let server = record("episodes:a")
+        server["updatedAt"] = Int64(123)
+        let rejection = CKError(.serverRecordChanged, userInfo: [CKRecordChangedErrorServerRecordKey: server])
+        let results: [CKRecord.ID: Result<CKRecord, Error>] = [
+            recordID("episodes:a"): .failure(rejection),
+            recordID("episodes:b"): .success(record("episodes:b")),
+        ]
+
+        let conflicts = try CloudKitSyncTransport.conflictedSaves(results)
+
+        XCTAssertEqual(conflicts.count, 1)
+        XCTAssertEqual(conflicts.first?.0, recordID("episodes:a"))
+        XCTAssertEqual(conflicts.first?.1["updatedAt"] as? Int64, 123)
+    }
+
+    func testNonConflictPerRecordFailureThrows() {
+        let results: [CKRecord.ID: Result<CKRecord, Error>] = [
+            recordID("episodes:a"): .failure(CKError(.quotaExceeded)),
+        ]
+
+        XCTAssertThrowsError(try CloudKitSyncTransport.conflictedSaves(results))
+    }
+
+    func testServerRecordChangedWithoutServerRecordThrows() {
+        let results: [CKRecord.ID: Result<CKRecord, Error>] = [
+            recordID("episodes:a"): .failure(CKError(.serverRecordChanged)),
+        ]
+
+        XCTAssertThrowsError(try CloudKitSyncTransport.conflictedSaves(results))
+    }
+
+    func testPerRecordZoneNotFoundMapsToTransportError() {
+        let results: [CKRecord.ID: Result<CKRecord, Error>] = [
+            recordID("episodes:a"): .failure(CKError(.zoneNotFound)),
+        ]
+
+        XCTAssertThrowsError(try CloudKitSyncTransport.conflictedSaves(results)) { error in
+            XCTAssertEqual(error as? SyncTransportError, .zoneNotFound)
+        }
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncServiceTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncServiceTests.swift
@@ -75,6 +75,40 @@ final class SyncServiceTests: XCTestCase {
         }
         XCTAssertNotNil(service.lastError, "failure recorded for the UI")
     }
+
+    func testForceFullResyncRepushesEditWhosePendingChangeWasLost() async throws {
+        let db = try DatabaseManager(inMemory: true)
+        try insertMedication(db, "m1")
+        let transport = InMemoryCloudKitTransport()
+        let service = SyncService(dbManager: db, transport: transport, backupService: SpyBackupService())
+        try await service.enable()
+
+        // Edit the row, then drop the captured pending change — simulating an edit whose
+        // push was lost, so only a full re-sync can get it to the server.
+        try await db.dbQueue.write {
+            try $0.execute(sql: "UPDATE medications SET name = 'Renamed', updated_at = 2000 WHERE id = 'm1'")
+            try $0.execute(sql: "DELETE FROM sync_pending_changes")
+        }
+
+        let enqueued = try await service.forceFullResync()
+
+        XCTAssertGreaterThan(enqueued, 0)
+        let pushed = transport.record(named: "medications:m1")
+        XCTAssertEqual(pushed?.updatedAt, 2000, "edited row re-pushed with its real LWW timestamp")
+        XCTAssertTrue(pushed?.payload.contains("Renamed") == true)
+    }
+
+    func testForceFullResyncIsNoOpWhenDisabled() async throws {
+        let db = try DatabaseManager(inMemory: true)
+        try insertMedication(db, "m1")
+        let transport = InMemoryCloudKitTransport()
+        let service = SyncService(dbManager: db, transport: transport, backupService: SpyBackupService())
+
+        let enqueued = try await service.forceFullResync()
+
+        XCTAssertEqual(enqueued, 0)
+        XCTAssertNil(transport.record(named: "medications:m1"), "nothing pushed while sync is off")
+    }
 }
 
 private final class SpyBackupService: BackupServiceProtocol {


### PR DESCRIPTION
## Problem

Reported on-device: an episode closed (and later reopened) on the iPhone showed as **two ongoing episodes** on the iPad. The iPad DB showed the real scope: **no record in any table had ever received an update after initial sync** — inserts synced, updates and deletes silently never did.

## Root cause

`CKDatabase.modifyRecords(..., atomically: false)` does **not throw** for per-record failures — it reports them in the returned `saveResults` tuple (only whole-operation failures throw). `CloudKitSyncTransport.saveResolvingConflicts` expected per-record conflicts as a thrown `CKError.partialFailure` and discarded the tuple (`_ = try await …`).

Because pushed `CKRecord`s are built fresh (no server change tag), **every** save of a record CloudKit already holds is rejected per-record with `.serverRecordChanged` under `.ifServerRecordUnchanged`. Those rejections were swallowed, `push()` reported success, and the engine drained the pending queue — the change was lost with no error anywhere. The unit-test fake (`InMemoryCloudKitTransport`) models LWW at the storage layer, so it could never catch the CKError-plumbing mismatch (the transport is flagged device-verify-only).

## Fix

- **Transport**: read `saveResults`; `.serverRecordChanged` rejections feed the existing LWW resolve-and-retry path (re-save into the server record, which carries the change tag); any other per-record error throws so the engine keeps the queue and retries. The final `.allKeys` force-save pass now surfaces per-record failures too.
- **Repair**: `SyncService.forceFullResync()` re-enqueues every row (`backfillExistingRows`, which never downgrades pending deletes) and syncs. Exposed as **Developer Tools → Sync → Force Re-sync All Data** with a confirmation alert; staying in dev tools for the foreseeable future. Run it on each device that made edits while the bug was live, devices reconverge by LWW.

## Tests

- New `CloudKitSyncTransportTests` cover the extracted `conflictedSaves` partitioning with constructed `CKError`s: success, conflict-with-server-record, non-conflict failure throws, conflict-missing-server-record throws, zoneNotFound maps to the transport error.
- `SyncServiceTests`: force re-sync re-pushes an edit whose pending change was lost (the exact failure shape of this bug); no-op when sync disabled.
- Local runs: full unit target 915/915 passed; Smoke plan UI tests passed; SwiftLint clean at error level.

⚠️ Device verification still required for the real CloudKit round-trip (close an episode on one device, watch it close on the other; then Force Re-sync to heal the historical divergence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)