### PR TITLE
feat(ios): allow editing dosage amount and unit on logged doses

### DIFF
--- a/mobile-apps/ios/MigraLog/Utils/DoseDosageInput.swift
+++ b/mobile-apps/ios/MigraLog/Utils/DoseDosageInput.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Parses the dosage amount/unit text fields on the dose edit screens.
+enum DoseDosageInput {
+    /// Returns the parsed dosage, or nil if the input is invalid.
+    /// Both fields empty is valid and yields (nil, nil) — doses logged before
+    /// dosage snapshots existed have no values to preserve.
+    static func parse(amount: String, unit: String) -> (amount: Double?, unit: String?)? {
+        let trimmedAmount = amount.trimmingCharacters(in: .whitespaces)
+        let trimmedUnit = unit.trimmingCharacters(in: .whitespaces)
+        if trimmedAmount.isEmpty && trimmedUnit.isEmpty {
+            return (nil, nil)
+        }
+        guard let value = Double(trimmedAmount), value > 0, !trimmedUnit.isEmpty else {
+            return nil
+        }
+        return (value, trimmedUnit)
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EditDoseFromTimelineScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EditDoseFromTimelineScreen.swift
@@ -2,18 +2,26 @@ import SwiftUI
 
 struct EditDoseFromTimelineScreen: View {
     let dose: MedicationDose
-    let medicationName: String
+    let medication: Medication
     @Bindable var viewModel: EpisodeDetailViewModel
     @Environment(\.dismiss) private var dismiss
 
+    @State private var quantity: String
+    @State private var dosageAmount: String
+    @State private var dosageUnit: String
     @State private var selectedDate: Date
     @State private var notes: String
+    @State private var showValidationAlert = false
+    @State private var validationMessage = ""
     @State private var isSaving = false
 
-    init(dose: MedicationDose, medicationName: String, viewModel: EpisodeDetailViewModel) {
+    init(dose: MedicationDose, medication: Medication, viewModel: EpisodeDetailViewModel) {
         self.dose = dose
-        self.medicationName = medicationName
+        self.medication = medication
         self.viewModel = viewModel
+        _quantity = State(initialValue: String(dose.quantity))
+        _dosageAmount = State(initialValue: String(dose.dosageAmount ?? medication.dosageAmount))
+        _dosageUnit = State(initialValue: dose.dosageUnit ?? medication.dosageUnit)
         _selectedDate = State(initialValue: Date(timeIntervalSince1970: Double(dose.timestamp) / 1000.0))
         _notes = State(initialValue: dose.notes ?? "")
     }
@@ -21,8 +29,26 @@ struct EditDoseFromTimelineScreen: View {
     var body: some View {
         Form {
             Section("Medication") {
-                Text(medicationName)
+                Text(medication.name)
                     .foregroundStyle(.secondary)
+            }
+
+            Section("Amount") {
+                TextField("Quantity", text: $quantity)
+                    .keyboardType(.decimalPad)
+                    .accessibilityIdentifier("dose-amount-input")
+            }
+
+            Section {
+                TextField("Amount", text: $dosageAmount)
+                    .keyboardType(.decimalPad)
+                    .accessibilityIdentifier("dose-dosage-amount-input")
+                TextField("Unit (mg, ml, tablets...)", text: $dosageUnit)
+                    .accessibilityIdentifier("dose-dosage-unit-input")
+            } header: {
+                Text("Dosage")
+            } footer: {
+                Text("Strength of a single dose. Edit this if the medication was configured incorrectly when this dose was logged.")
             }
 
             Section("Time") {
@@ -47,13 +73,32 @@ struct EditDoseFromTimelineScreen: View {
                 .disabled(isSaving)
             }
         }
+        .alert("Invalid Dose", isPresented: $showValidationAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(validationMessage)
+        }
     }
 
     private func save() async {
+        guard let qty = Double(quantity), EpisodeValidation.validateDoseQuantity(qty).isValid else {
+            validationMessage = "Please enter a valid amount greater than 0."
+            showValidationAlert = true
+            return
+        }
+        guard let parsed = DoseDosageInput.parse(amount: dosageAmount, unit: dosageUnit) else {
+            validationMessage = "Please enter a dosage amount greater than 0 and a unit."
+            showValidationAlert = true
+            return
+        }
+
         isSaving = true
         defer { isSaving = false }
 
         var updated = dose
+        updated.quantity = qty
+        updated.dosageAmount = parsed.amount
+        updated.dosageUnit = parsed.unit
         updated.timestamp = TimestampHelper.fromDate(selectedDate)
         updated.notes = notes.isEmpty ? nil : notes
         await viewModel.updateDose(updated)

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -146,7 +146,7 @@ struct EpisodeDetailScreen: View {
             NavigationStack {
                 EditDoseFromTimelineScreen(
                     dose: doseWithMed.dose,
-                    medicationName: doseWithMed.medication.name,
+                    medication: doseWithMed.medication,
                     viewModel: viewModel
                 )
             }

--- a/mobile-apps/ios/MigraLog/Views/Medications/EditDoseScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/EditDoseScreen.swift
@@ -6,16 +6,22 @@ struct EditDoseScreen: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var quantity: String
+    @State private var dosageAmount: String
+    @State private var dosageUnit: String
     @State private var timestamp: Date
     @State private var effectivenessRating: Double?
     @State private var notes: String
     @State private var showValidationAlert = false
+    @State private var validationMessage = ""
     @State private var isSaving = false
 
     init(dose: MedicationDose, viewModel: MedicationDetailViewModel) {
         self.dose = dose
         self.viewModel = viewModel
         _quantity = State(initialValue: String(dose.quantity))
+        let amount = dose.dosageAmount ?? viewModel.medication?.dosageAmount
+        _dosageAmount = State(initialValue: amount.map { String($0) } ?? "")
+        _dosageUnit = State(initialValue: dose.dosageUnit ?? viewModel.medication?.dosageUnit ?? "")
         _timestamp = State(initialValue: dose.date)
         _effectivenessRating = State(initialValue: dose.effectivenessRating)
         _notes = State(initialValue: dose.notes ?? "")
@@ -27,6 +33,18 @@ struct EditDoseScreen: View {
                 TextField("Quantity", text: $quantity)
                     .keyboardType(.decimalPad)
                     .accessibilityIdentifier("dose-amount-input")
+            }
+
+            Section {
+                TextField("Amount", text: $dosageAmount)
+                    .keyboardType(.decimalPad)
+                    .accessibilityIdentifier("dose-dosage-amount-input")
+                TextField("Unit (mg, ml, tablets...)", text: $dosageUnit)
+                    .accessibilityIdentifier("dose-dosage-unit-input")
+            } header: {
+                Text("Dosage")
+            } footer: {
+                Text("Strength of a single dose. Edit this if the medication was configured incorrectly when this dose was logged.")
             }
 
             Section("Time") {
@@ -74,20 +92,21 @@ struct EditDoseScreen: View {
                 .disabled(isSaving)
             }
         }
-        .alert("Invalid Amount", isPresented: $showValidationAlert) {
+        .alert("Invalid Dose", isPresented: $showValidationAlert) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text("Please enter a valid amount greater than 0.")
+            Text(validationMessage)
         }
     }
 
     private func save() async {
-        guard let qty = Double(quantity) else {
+        guard let qty = Double(quantity), EpisodeValidation.validateDoseQuantity(qty).isValid else {
+            validationMessage = "Please enter a valid amount greater than 0."
             showValidationAlert = true
             return
         }
-        let validation = EpisodeValidation.validateDoseQuantity(qty)
-        guard validation.isValid else {
+        guard let parsed = DoseDosageInput.parse(amount: dosageAmount, unit: dosageUnit) else {
+            validationMessage = "Please enter a dosage amount greater than 0 and a unit."
             showValidationAlert = true
             return
         }
@@ -97,6 +116,8 @@ struct EditDoseScreen: View {
 
         var updated = dose
         updated.quantity = qty
+        updated.dosageAmount = parsed.amount
+        updated.dosageUnit = parsed.unit
         updated.timestamp = TimestampHelper.fromDate(timestamp)
         updated.effectivenessRating = effectivenessRating
         updated.notes = notes.isEmpty ? nil : notes

--- a/mobile-apps/ios/MigraLogTests/Repositories/MedicationRepositoryTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Repositories/MedicationRepositoryTests.swift
@@ -310,11 +310,17 @@ final class MedicationRepositoryTests: XCTestCase {
 
         var toUpdate = dose
         toUpdate.quantity = 2.0
+        toUpdate.dosageAmount = 500.0
+        toUpdate.dosageUnit = "mcg"
         let updated = try repo.updateDose(toUpdate)
         XCTAssertEqual(updated.quantity, 2.0)
+        XCTAssertEqual(updated.dosageAmount, 500.0)
+        XCTAssertEqual(updated.dosageUnit, "mcg")
 
         let fetched = try repo.getDosesByMedicationId(med.id)
         XCTAssertEqual(fetched.first?.quantity, 2.0)
+        XCTAssertEqual(fetched.first?.dosageAmount, 500.0)
+        XCTAssertEqual(fetched.first?.dosageUnit, "mcg")
     }
 
     func testDeleteDose() throws {

--- a/mobile-apps/ios/MigraLogTests/Utils/DoseDosageInputTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Utils/DoseDosageInputTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import MigraLog
+
+final class DoseDosageInputTests: XCTestCase {
+    func testValidAmountAndUnit() {
+        let parsed = DoseDosageInput.parse(amount: "50", unit: "mg")
+        XCTAssertEqual(parsed?.amount, 50.0)
+        XCTAssertEqual(parsed?.unit, "mg")
+    }
+
+    func testDecimalAmount() {
+        let parsed = DoseDosageInput.parse(amount: "2.5", unit: "ml")
+        XCTAssertEqual(parsed?.amount, 2.5)
+        XCTAssertEqual(parsed?.unit, "ml")
+    }
+
+    func testTrimsWhitespace() {
+        let parsed = DoseDosageInput.parse(amount: " 50 ", unit: " mg ")
+        XCTAssertEqual(parsed?.amount, 50.0)
+        XCTAssertEqual(parsed?.unit, "mg")
+    }
+
+    func testBothEmptyIsValidAndClears() {
+        let parsed = DoseDosageInput.parse(amount: "", unit: "")
+        XCTAssertNotNil(parsed)
+        XCTAssertNil(parsed?.amount)
+        XCTAssertNil(parsed?.unit)
+    }
+
+    func testAmountWithoutUnitIsInvalid() {
+        XCTAssertNil(DoseDosageInput.parse(amount: "50", unit: ""))
+    }
+
+    func testUnitWithoutAmountIsInvalid() {
+        XCTAssertNil(DoseDosageInput.parse(amount: "", unit: "mg"))
+    }
+
+    func testNonNumericAmountIsInvalid() {
+        XCTAssertNil(DoseDosageInput.parse(amount: "abc", unit: "mg"))
+    }
+
+    func testZeroAmountIsInvalid() {
+        XCTAssertNil(DoseDosageInput.parse(amount: "0", unit: "mg"))
+    }
+
+    func testNegativeAmountIsInvalid() {
+        XCTAssertNil(DoseDosageInput.parse(amount: "-5", unit: "mg"))
+    }
+}

--- a/mobile-apps/ios/MigraLogUITests/MedicationDoseUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/MedicationDoseUITests.swift
@@ -96,14 +96,26 @@ final class MedicationDoseUITests: XCTestCase {
                     amountInput.clearAndTypeText("4")
                 }
 
+                // Step 3b: Change dosage strength and unit (e.g. medication was misconfigured)
+                let dosageAmountInput = app.textFields["dose-dosage-amount-input"]
+                if dosageAmountInput.waitForExistence(timeout: UITestHelpers.defaultTimeout) {
+                    dosageAmountInput.tap()
+                    dosageAmountInput.clearAndTypeText("100")
+                }
+                let dosageUnitInput = app.textFields["dose-dosage-unit-input"]
+                if dosageUnitInput.waitForExistence(timeout: UITestHelpers.defaultTimeout) {
+                    dosageUnitInput.tap()
+                    dosageUnitInput.clearAndTypeText("mcg")
+                }
+
                 // Step 4: Tap Save
                 let saveButton = app.buttons["Save"]
                 UITestHelpers.waitForHittable(saveButton)
                 saveButton.tap()
                 Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
 
-                // Step 5: Verify "4 x 50mg" visible
-                let updatedDose = app.staticTexts.matching(NSPredicate(format: "label CONTAINS '4'")).firstMatch
+                // Step 5: Verify "4 × 100mcg" visible
+                let updatedDose = app.staticTexts.matching(NSPredicate(format: "label CONTAINS '100mcg'")).firstMatch
                 UITestHelpers.waitForElement(updatedDose)
 
                 // Step 6: Navigate back to medications list, then away and back to verify persistence


### PR DESCRIPTION
## Summary
- Doses snapshot `dosage_amount`/`dosage_unit` at log time, but the edit screens only exposed quantity, time, and notes — so doses logged while a medication was configured with the wrong strength or unit could never be corrected.
- **EditDoseScreen** (medication detail): adds a Dosage section with amount + unit fields, pre-filled from the dose snapshot and falling back to the medication's configured values.
- **EditDoseFromTimelineScreen** (episode timeline): same dosage fields plus a quantity field (previously only time and notes were editable); now takes the full `Medication` instead of just its name.
- New shared `DoseDosageInput.parse` validates the fields: amount must be > 0 with a non-empty unit; both empty is allowed and preserves `nil` so legacy doses without snapshots still save.

No schema or repository changes — persistence already round-trips both fields, and both display paths already prefer the dose's own values over the medication's.

## Testing
- New `DoseDosageInputTests` unit suite (9 tests) covering valid/invalid/empty input.
- `MedicationRepositoryTests.testUpdateDose` extended to assert dosage amount/unit persist.
- `MedicationDoseUITests.testEditDoseAmount` extended to change strength to 100 mcg and verify the updated dose renders (not run locally — UI tests).
- Full unit suite: 921 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)