### PR TITLE
feat(ios): hide Developer Tools behind 7-tap version row gesture

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/Settings/SettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/SettingsScreen.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsScreen: View {
     @Environment(AppState.self) private var appState
+    @AppStorage("developerModeEnabled") private var developerModeEnabled = false
 
     var body: some View {
         List {
@@ -64,18 +65,21 @@ struct SettingsScreen: View {
                 }
             }
 
-            // Developer Tools
-            Section("Developer") {
-                NavigationLink {
-                    DeveloperToolsScreen()
-                } label: {
-                    Label("Developer Tools", systemImage: "wrench.and.screwdriver")
+            // Developer Tools (unlocked by tapping the version row 7 times)
+            if developerModeEnabled {
+                Section("Developer") {
+                    NavigationLink {
+                        DeveloperToolsScreen()
+                    } label: {
+                        Label("Developer Tools", systemImage: "wrench.and.screwdriver")
+                    }
+                    .accessibilityIdentifier("developer-tools")
                 }
             }
 
             // Version
             Section {
-                VersionSectionView()
+                VersionSectionView(developerModeEnabled: $developerModeEnabled)
             }
         }
         .listStyle(.insetGrouped)
@@ -103,12 +107,46 @@ struct ThemeSectionView: View {
 // MARK: - Version Section
 
 struct VersionSectionView: View {
+    @Binding var developerModeEnabled: Bool
+    @State private var versionTapCount = 0
+    @State private var showDeveloperModeAlert = false
+
+    private static let tapsToToggle = 7
+
     var body: some View {
         HStack {
             Text("Version")
             Spacer()
+            if developerModeEnabled {
+                Image(systemName: "wrench.and.screwdriver")
+                    .font(.footnote)
+                    .foregroundStyle(.tint)
+                    .accessibilityIdentifier("developer-mode-indicator")
+            }
             Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0")
                 .foregroundStyle(.secondary)
         }
+        .contentShape(Rectangle())
+        .onTapGesture(perform: handleVersionTap)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("version-row")
+        .alert(
+            developerModeEnabled ? "Developer Mode Enabled" : "Developer Mode Disabled",
+            isPresented: $showDeveloperModeAlert
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(developerModeEnabled
+                ? "Developer tools are now visible in Settings."
+                : "Developer tools have been hidden.")
+        }
+    }
+
+    private func handleVersionTap() {
+        versionTapCount += 1
+        guard versionTapCount >= Self.tapsToToggle else { return }
+        versionTapCount = 0
+        developerModeEnabled.toggle()
+        showDeveloperModeAlert = true
     }
 }

--- a/mobile-apps/ios/MigraLogUITests/DeveloperModeUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/DeveloperModeUITests.swift
@@ -1,0 +1,102 @@
+import XCTest
+
+/// Tests for the hidden developer mode: the Developer Tools section is not
+/// visible by default and is toggled by tapping the version row in Settings
+/// 7 times (the same secret-activation pattern the pre-rewrite app used).
+final class DeveloperModeUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = UITestHelpers.launchCleanDashboard()
+        UITestHelpers.waitForDashboard(in: app)
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    func testSevenTapsTogglesDeveloperTools() throws {
+        openSettings()
+
+        // Hidden by default on a fresh install.
+        let developerTools = app.buttons["developer-tools"]
+        XCTAssertFalse(developerTools.exists,
+                       "Developer Tools should be hidden until developer mode is enabled")
+
+        // Enable: 7 taps on the version row.
+        tapVersionRow(times: 7)
+        dismissAlert(titled: "Developer Mode Enabled")
+        UITestHelpers.waitForElement(developerTools)
+
+        // Disable: 7 more taps.
+        tapVersionRow(times: 7)
+        dismissAlert(titled: "Developer Mode Disabled")
+        UITestHelpers.waitForElementToDisappear(developerTools)
+    }
+
+    func testFewerThanSevenTapsDoesNothing() throws {
+        openSettings()
+
+        tapVersionRow(times: 6)
+
+        XCTAssertFalse(app.alerts.firstMatch.exists,
+                       "No alert should appear before the 7th tap")
+        XCTAssertFalse(app.buttons["developer-tools"].exists,
+                       "Developer Tools should stay hidden before the 7th tap")
+    }
+
+    func testDeveloperModePersistsAcrossRelaunch() throws {
+        openSettings()
+        tapVersionRow(times: 7)
+        dismissAlert(titled: "Developer Mode Enabled")
+        UITestHelpers.waitForElement(app.buttons["developer-tools"])
+
+        // Relaunch WITHOUT --reset-database so UserDefaults survive.
+        app.terminate()
+        app = XCUIApplication()
+        app.launchArguments = ["--uitesting", "--skip-onboarding"]
+        app.launch()
+        UITestHelpers.waitForDashboard(in: app)
+
+        openSettings()
+        scrollToVersionRow()
+        UITestHelpers.waitForElement(app.buttons["developer-tools"])
+    }
+
+    // MARK: - Helpers
+
+    private func openSettings() {
+        let settingsButton = app.buttons["settings-button"]
+        UITestHelpers.waitForHittable(settingsButton)
+        settingsButton.tap()
+
+        let settingsTitle = app.navigationBars.staticTexts["Settings"]
+        UITestHelpers.waitForElement(settingsTitle)
+    }
+
+    @discardableResult
+    private func scrollToVersionRow() -> XCUIElement {
+        // The version row renders as a StaticText (combined accessibility element).
+        // Query the type directly: the List virtualizes off-screen rows, so a
+        // flexible find before scrolling would lock onto the wrong element type.
+        let versionRow = app.staticTexts["version-row"]
+        UITestHelpers.scrollToElement(versionRow, in: app.collectionViews.firstMatch)
+        return versionRow
+    }
+
+    private func tapVersionRow(times: Int) {
+        let versionRow = scrollToVersionRow()
+        UITestHelpers.waitForHittable(versionRow)
+        for _ in 0..<times {
+            versionRow.tap()
+        }
+    }
+
+    private func dismissAlert(titled title: String) {
+        let alert = app.alerts[title]
+        UITestHelpers.waitForElement(alert)
+        alert.buttons["OK"].tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+    }
+}


### PR DESCRIPTION
## Summary
- Ports the secret-activation pattern from the pre-rewrite app (issue #8, commit 1cbdd1f): the **Developer** section in Settings is hidden by default and toggled by tapping the **version row 7 times**.
- State persists via UserDefaults (`developerModeEnabled`); a confirmation alert announces each toggle and a wrench icon marks the version row while enabled.
- Previously the Swift app showed Developer Tools unconditionally — including TestFlight/release builds.

## Test plan
- [x] 912 unit tests pass locally
- [x] New `DeveloperModeUITests` (3 tests): 7-tap toggle on/off, <7 taps inert, persistence across relaunch
- [x] Full UI test plan run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)