### PR TITLE
fix(ios): repair UI tests broken by dashboard accessibility containment (#490)

### DIFF
--- a/mobile-apps/ios/MigraLogUITests/AccessibilityUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/AccessibilityUITests.swift
@@ -128,13 +128,16 @@ final class AccessibilityUITests: XCTestCase {
         app = UITestHelpers.launchWithFixtures()
         UITestHelpers.waitForDashboard(in: app)
 
-        // Step 3: Medication log/skip buttons are tappable
-        let logButton = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Log'")).firstMatch
+        // Step 3: Medication log/skip buttons are tappable. Scoped to the card so
+        // the queries hit the dose-row buttons, not the "Log Medication" action
+        // button (the card contains its accessibility children since #490).
+        let medsCard = app.otherElements["todays-medications-card"]
+        let logButton = medsCard.buttons.matching(NSPredicate(format: "label CONTAINS 'Log'")).firstMatch
         if logButton.waitForExistence(timeout: UITestHelpers.defaultTimeout) {
             XCTAssertTrue(logButton.isHittable, "Log button should be tappable")
         }
 
-        let skipButton = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Skip'")).firstMatch
+        let skipButton = medsCard.buttons.matching(NSPredicate(format: "label CONTAINS 'Skip'")).firstMatch
         if skipButton.waitForExistence(timeout: UITestHelpers.defaultTimeout) {
             XCTAssertTrue(skipButton.isHittable, "Skip button should be tappable")
         }

--- a/mobile-apps/ios/MigraLogUITests/IPadLayoutAuditUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/IPadLayoutAuditUITests.swift
@@ -15,6 +15,13 @@ final class IPadLayoutAuditUITests: XCTestCase {
     private var app: XCUIApplication!
 
     override func setUpWithError() throws {
+        // Layout-audit tour of iPad layouts; on iPhone the screens it drives
+        // don't exist in this form (e.g. Episodes has no split-view list cells),
+        // so the suite only runs on an iPad destination.
+        try XCTSkipUnless(
+            UIDevice.current.userInterfaceIdiom == .pad,
+            "iPad layout audit requires an iPad destination"
+        )
         continueAfterFailure = false
         XCUIDevice.shared.orientation = .portrait
         app = XCUIApplication()

--- a/mobile-apps/ios/MigraLogUITests/MedicationArchivingUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/MedicationArchivingUITests.swift
@@ -112,13 +112,16 @@ final class MedicationArchivingUITests: XCTestCase {
         let medsCard = app.staticTexts["Today's Medications"]
         UITestHelpers.waitForElement(medsCard)
 
-        // Step 11: Log a dose
-        let logButton = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Log'")).firstMatch
+        // Step 11: Log a dose. Scope to the card — an app-level 'Log' firstMatch
+        // resolves to the "Log Medication" action button since the card contains
+        // its accessibility children (#490).
+        let medsCardContainer = app.otherElements["todays-medications-card"]
+        let logButton = medsCardContainer.buttons.matching(NSPredicate(format: "label CONTAINS 'Log'")).firstMatch
         if logButton.waitForExistence(timeout: UITestHelpers.defaultTimeout) {
             logButton.tap()
             Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
 
-            let takenLabel = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Taken at'")).firstMatch
+            let takenLabel = medsCardContainer.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Taken at'")).firstMatch
             UITestHelpers.waitForElement(takenLabel)
         }
     }

--- a/mobile-apps/ios/MigraLogUITests/MedicationTrackingUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/MedicationTrackingUITests.swift
@@ -26,10 +26,16 @@ final class MedicationTrackingUITests: XCTestCase {
         let medsCardTitle = app.staticTexts["Today's Medications"]
         UITestHelpers.waitForElement(medsCardTitle)
 
+        // Scope queries to the card: an app-level `label CONTAINS 'Log'` firstMatch
+        // resolves to the "Log Medication" action button now that the card contains
+        // its accessibility children (#490), and 'Undo' would match the daily-status
+        // widget's Undo.
+        let medsCard = app.otherElements["todays-medications-card"]
+
         // === Phase 2: Log medication ===
 
         // Step 2-3: Find medication with Log/Skip buttons and tap Log
-        let logButton = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Log'")).firstMatch
+        let logButton = medsCard.buttons.matching(NSPredicate(format: "label CONTAINS 'Log'")).firstMatch
         UITestHelpers.waitForHittable(logButton)
         logButton.tap()
         Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
@@ -37,11 +43,11 @@ final class MedicationTrackingUITests: XCTestCase {
         // === Phase 3: Verify UI ===
 
         // Step 4: "Taken at" label appears
-        let takenLabel = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Taken at'")).firstMatch
+        let takenLabel = medsCard.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Taken at'")).firstMatch
         UITestHelpers.waitForElement(takenLabel)
 
         // Step 5: Undo button visible
-        let undoButton = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Undo'")).firstMatch
+        let undoButton = medsCard.buttons.matching(NSPredicate(format: "label CONTAINS 'Undo'")).firstMatch
         XCTAssertTrue(undoButton.waitForExistence(timeout: UITestHelpers.defaultTimeout),
                        "Undo button should be visible after logging")
 
@@ -52,10 +58,10 @@ final class MedicationTrackingUITests: XCTestCase {
         Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
 
         // Step 8: Log and Skip buttons reappear
-        let logButtonAfterUndo = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Log'")).firstMatch
+        let logButtonAfterUndo = medsCard.buttons.matching(NSPredicate(format: "label CONTAINS 'Log'")).firstMatch
         UITestHelpers.waitForElement(logButtonAfterUndo)
 
-        let skipButton = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Skip'")).firstMatch
+        let skipButton = medsCard.buttons.matching(NSPredicate(format: "label CONTAINS 'Skip'")).firstMatch
         XCTAssertTrue(skipButton.waitForExistence(timeout: UITestHelpers.defaultTimeout),
                        "Skip button should reappear after undo")
 
@@ -66,7 +72,7 @@ final class MedicationTrackingUITests: XCTestCase {
         Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
 
         // Step 10: "Skipped" label appears
-        let skippedLabel = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Skipped'")).firstMatch
+        let skippedLabel = medsCard.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Skipped'")).firstMatch
         UITestHelpers.waitForElement(skippedLabel)
     }
 
@@ -106,8 +112,11 @@ final class MedicationTrackingUITests: XCTestCase {
     // MARK: - 4.3 Status sync between Dashboard and Medications screen
 
     func testStatusSyncBetweenScreens() throws {
+        // Scoped to the card for the same reason as testPreventativeMedicationLogging.
+        let medsCard = app.otherElements["todays-medications-card"]
+
         // Step 1: Verify unlogged medication on dashboard
-        let skipButton = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Skip'")).firstMatch
+        let skipButton = medsCard.buttons.matching(NSPredicate(format: "label CONTAINS 'Skip'")).firstMatch
         UITestHelpers.waitForElement(skipButton)
 
         // Step 2: Navigate to Medications tab
@@ -117,13 +126,13 @@ final class MedicationTrackingUITests: XCTestCase {
 
         // Step 3: Return to Dashboard, skip medication
         UITestHelpers.navigateTo(tab: .dashboard, in: app)
-        let skipButtonDash = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Skip'")).firstMatch
+        let skipButtonDash = medsCard.buttons.matching(NSPredicate(format: "label CONTAINS 'Skip'")).firstMatch
         UITestHelpers.waitForHittable(skipButtonDash)
         skipButtonDash.tap()
         Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
 
         // Verify skipped status
-        let skippedLabel = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Skipped'")).firstMatch
+        let skippedLabel = medsCard.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Skipped'")).firstMatch
         UITestHelpers.waitForElement(skippedLabel)
 
         // Step 4: Navigate to Medications tab, verify sync
@@ -132,20 +141,20 @@ final class MedicationTrackingUITests: XCTestCase {
 
         // Step 5: Return to Dashboard, undo skip
         UITestHelpers.navigateTo(tab: .dashboard, in: app)
-        let undoButton = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Undo'")).firstMatch
+        let undoButton = medsCard.buttons.matching(NSPredicate(format: "label CONTAINS 'Undo'")).firstMatch
         if undoButton.waitForExistence(timeout: UITestHelpers.defaultTimeout) {
             undoButton.tap()
             Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
         }
 
         // Step 6: Log the medication
-        let logButton = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Log'")).firstMatch
+        let logButton = medsCard.buttons.matching(NSPredicate(format: "label CONTAINS 'Log'")).firstMatch
         UITestHelpers.waitForHittable(logButton)
         logButton.tap()
         Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
 
         // Verify taken status
-        let takenLabel = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Taken at'")).firstMatch
+        let takenLabel = medsCard.staticTexts.matching(NSPredicate(format: "label CONTAINS 'Taken at'")).firstMatch
         UITestHelpers.waitForElement(takenLabel)
 
         // Step 7: Navigate to Medications, verify sync


### PR DESCRIPTION
## Summary
The first nightly run including #490 ([run 27365726473](https://github.com/vfilby/migralog/actions/runs/27365726473)) failed 5 UI tests. Two independent causes, both introduced by #490:

### 1. Dashboard card accessibility containment changed query resolution
`.accessibilityElement(children: .contain)` on the Today's Medications card (added in #490 to stop the card identifier clobbering per-row ids) reordered XCUITest element traversal. App-level `label CONTAINS 'Log'` → `firstMatch` queries now resolve to the **Log Medication** action button instead of a dose row's "Log 400mg" button — confirmed in the xcresult activity log (`Find the Button (First Match)` → `Tap "log-medication-button"`). The tests opened the log-medication sheet instead of logging the dose, so "Taken at…" never appeared.

**Fix:** scope the dose-row Log/Skip/Undo/Taken-at queries to the `todays-medications-card` container (which the containment change makes cleanly addressable) in:
- `MedicationTrackingUITests.testPreventativeMedicationLogging`
- `MedicationTrackingUITests.testStatusSyncBetweenScreens`
- `MedicationArchivingUITests.testArchiveAndRestoreWorkflow`
- `AccessibilityUITests.testMedicationButtonTouchTargets` (latent — same ambiguity)

### 2. iPad audit suite runs on iPhone in the nightly
`IPadLayoutAuditUITests` (added by #490) is documented as an iPad-destination screenshot tour, but the nightly Full plan runs every test on iPhone 17 Pro, where the Episodes split-view list cells don't exist — test04/test05 can never pass there.

**Fix:** class-level `XCTSkipUnless(… == .pad)` in `setUpWithError`.

## Testing
- All four previously failing tests pass locally on iPhone 17 Pro / iOS 26; test04/test05 now skip (0.05s each).
- `testArchiveMedicationWithReminders` (#488) passed in the nightly rerun — that fix is unaffected.
- Full-project SwiftLint: no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)