### PR TITLE
fix(ios): disable Sentry App Hangs V2 tracking (#489)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/SentrySetup.swift
+++ b/mobile-apps/ios/MigraLog/Services/SentrySetup.swift
@@ -22,6 +22,13 @@ enum SentrySetup {
             options.attachScreenshot = true
             options.enableUserInteractionTracing = true
 
+            // App Hangs V2 (default-on since sentry-cocoa 9.0) reports app
+            // suspension as fully-blocked hangs — including unfilterable
+            // "fatal" hangs when iOS terminates the suspended app (#489).
+            // Watchdog termination tracking stays enabled and still catches
+            // real severe hangs.
+            options.enableAppHangTracking = false
+
             // HIPAA: Scrub sensitive health data before sending
             options.beforeSend = { event in
                 return scrubSensitiveData(from: event)


### PR DESCRIPTION
Fixes #489.

## What

One-line Sentry config change: `options.enableAppHangTracking = false`.

## Why

App Hangs V2 became default-on with the sentry-cocoa 8.58.3 → 9.16.1 bump (#482). Within ~24h it produced two false positives from app suspension, across two builds:

- **MIGRALOG-18** (build 1.1.181): "App Hang Fully Blocked" of ~3,940s (~66 min) whose claimed start predates process launch; main-thread stack is the idle run loop (`mach_msg2_trap` → `__CFRunLoopServiceMachPort`); 44 min of breadcrumb silence before the report — classic suspension signature.
- **MIGRALOG-19** (build 1.1.186, new since the issue was filed): *Fatal* App Hang Fully Blocked, same idle `mach_msg2_trap` stack, 15 minutes of breadcrumb silence between launch (18:17:26) and the report (18:32:33).

## Why disable rather than the other mitigations from #489

- **Upgrade to latest 9.x**: latest is 9.17.1; reviewed the 9.17.0/9.17.1 release notes — no app-hang fixes. The weekly dep-update workflow will pick it up regardless.
- **`beforeSend` duration guard (> 2 min)**: would catch MIGRALOG-18 but not MIGRALOG-19 — fatal app hangs report "at least 2000 ms" with no implausible duration to filter on.
- **`enableReportNonFullyBlockingAppHangs = false`**: both false positives are the *fully-blocking* type; doesn't help.
- Signal-to-noise is confirmed poor (2/2 bogus, one flagged fatal/high-priority), which is the condition #489 set for disabling. `enableWatchdogTerminationTracking` remains default-on, so real severe hangs that get the app killed still surface.

## 8→9 migration audit (issue task 2)

Checked 9.16.1 `Options.swift` defaults beyond app hangs:
- Session replay: `sessionSampleRate`/`onErrorSampleRate` both default **0** (off) — no new HIPAA exposure.
- `enableSigtermReporting`: default false.
- `enableWatchdogTerminationTracking`: default true (unchanged).
- Profiling API migration was already handled in #482 (`configureProfiling`).
- Observation (pre-existing, not a 9.0 change): we explicitly set `attachScreenshot = true`, which attaches app screenshots to error events — worth a separate HIPAA review.

## HIPAA scrubber (issue task 4)

The `beforeSend` scrubber operates on `event.extra` and `event.breadcrumbs`, both unchanged in the 9.x `Event` shape (compiles and runs against 9.16.1 since #482). With app-hang tracking disabled, the app-hang event shape question is moot.

## Verification

- `xcodebuild build` (iPhone 17 Pro sim): succeeded
- `xcodebuild test -only-testing:MigraLogTests`: all passed
- SwiftLint: 0 error-level violations
- UI tests not run: Sentry never starts in test builds (`#if DEBUG` + `SENTRY_ENABLED` guard), so they cannot be affected.

## Follow-up after deploy

Resolve MIGRALOG-18 and MIGRALOG-19 in Sentry once a build with this change ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)