### PR TITLE
fix(ios): backfill synced columns added by schema migrations (#469)

### DIFF
--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -4,7 +4,7 @@ import GRDB
 /// Central database manager. Owns the DatabaseQueue and handles schema creation/migration.
 final class DatabaseManager: Sendable {
     /// The current schema version
-    static let schemaVersion = 35
+    static let schemaVersion = 36
 
     /// Shared singleton for the app's main database
     static let shared = DatabaseManager()
@@ -184,6 +184,14 @@ final class DatabaseManager: Sendable {
             try DatabaseManager.createSyncCaptureTriggers(in: db, includePayload: true)
         }
 
+        // v36 (#469): add `last_synced_schema` to sync_zone_state — the synced-column
+        // manifest stamped after each completed pull, so the sync engine can detect
+        // that a migration added synced columns and force a one-time full re-pull to
+        // backfill rows synced before the upgrade.
+        migrator.registerMigration("v36") { db in
+            try DatabaseManager.addLastSyncedSchemaColumn(in: db)
+        }
+
         return migrator
     }
 
@@ -276,7 +284,7 @@ final class DatabaseManager: Sendable {
     }
 
     /// Create the v25 baseline schema. Later registered migrations evolve it to the
-    /// current version; see spec/schemas/sqlite/schema-v35.sql for the current end-state.
+    /// current version; see spec/schemas/sqlite/schema-v36.sql for the current end-state.
     // swiftlint:disable:next function_body_length
     static func createSchema(in db: Database) throws {
         // Episodes table
@@ -537,7 +545,8 @@ final class DatabaseManager: Sendable {
                 server_change_token BLOB,
                 last_sync_at INTEGER CHECK(last_sync_at IS NULL OR last_sync_at > 0),
                 last_error TEXT,
-                last_error_at INTEGER CHECK(last_error_at IS NULL OR last_error_at > 0)
+                last_error_at INTEGER CHECK(last_error_at IS NULL OR last_error_at > 0),
+                last_synced_schema TEXT
             )
             """)
         try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_sync_pending_created ON sync_pending_changes(created_at)")
@@ -578,6 +587,19 @@ final class DatabaseManager: Sendable {
             }
         }
         try DatabaseManager.createSyncCaptureTriggers(in: db, includePayload: true)
+    }
+
+    /// v36 (#469): add the nullable `last_synced_schema` column (the synced-column
+    /// manifest, see SyncedSchemaManifest) to sync_zone_state when missing. Fresh
+    /// installs already create it in createSyncStateTables.
+    static func addLastSyncedSchemaColumn(in db: Database) throws {
+        let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(sync_zone_state)")
+        let hasColumn = columns.contains { (row: Row) in
+            (row["name"] as String?) == "last_synced_schema"
+        }
+        if !hasColumn {
+            try db.execute(sql: "ALTER TABLE sync_zone_state ADD COLUMN last_synced_schema TEXT")
+        }
     }
 
     /// Create `tracking_options` (v35): user customization of the pain-quality /

--- a/mobile-apps/ios/MigraLog/Services/Sync/LWWResolver.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/LWWResolver.swift
@@ -34,4 +34,40 @@ enum LWWResolver {
         }
         return .local
     }
+
+    /// How an exact-timestamp tie between two *differing* payloads should be handled
+    /// when the difference may be schema richness rather than a competing edit (#469).
+    enum TieMerge: Equatable, Sendable {
+        /// Remote offers nothing the local row lacks — keep local untouched.
+        case keepLocal
+        /// The payloads agree on every column both sides hold a value for; remote
+        /// additionally has non-null values for these locally missing/NULL columns.
+        /// It's the same logical version — one side just knows more columns.
+        case fillColumns([String])
+        /// Some column carries different values on the two sides — a genuine
+        /// same-timestamp conflict; fall back to the payload-byte tiebreak.
+        case conflictingValues
+    }
+
+    /// Classify an exact-timestamp tie for a non-destructive column merge (#469): a row
+    /// re-pulled after a schema upgrade carries the same `updated_at` as the local copy
+    /// but may hold columns that migrate-on-read dropped before the upgrade. Remote
+    /// NULLs never overwrite local values and local-only columns are always kept, so a
+    /// `.fillColumns` merge can only add data. Convergent: both devices end at the
+    /// column-union of the two payloads.
+    static func tieMerge(
+        localPayload: [String: SyncPayloadCodec.Value],
+        remotePayload: [String: SyncPayloadCodec.Value]
+    ) -> TieMerge {
+        var fill: [String] = []
+        for (column, remoteValue) in remotePayload where remoteValue != .null {
+            let localValue = localPayload[column] ?? .null
+            if localValue == .null {
+                fill.append(column)
+            } else if localValue != remoteValue {
+                return .conflictingValues
+            }
+        }
+        return fill.isEmpty ? .keepLocal : .fillColumns(fill.sorted())
+    }
 }

--- a/mobile-apps/ios/MigraLog/Services/Sync/RemoteChangeApplier.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/RemoteChangeApplier.swift
@@ -17,6 +17,7 @@ final class RemoteChangeApplier: Sendable {
         case noopTombstone      // a tombstone for a row we don't have
         case appliedRemoteWin   // remote newer → local upserted or deleted
         case keptLocalWin       // local newer → remote ignored (engine re-pushes local)
+        case backfilledColumns  // timestamp tie → remote filled locally-NULL columns (#469)
     }
 
     private let dbManager: DatabaseManager
@@ -53,8 +54,38 @@ final class RemoteChangeApplier: Sendable {
             }
 
             let localPayload = try SyncPayloadCodec.encodePayload(row: localRow, table: table)
+            let localUpdatedAt = Self.lwwTimestamp(of: localRow)
+
+            // An exact-timestamp tie between differing payloads is usually not a
+            // competing edit but the same version seen through different schemas —
+            // e.g. the one-time re-pull after a migration added synced columns (#469),
+            // where the remote payload holds columns migrate-on-read dropped before
+            // the upgrade. Merge non-destructively when the shared columns agree;
+            // only a genuine value disagreement falls through to the byte tiebreak.
+            if !record.deleted, record.updatedAt == localUpdatedAt, record.payload != localPayload {
+                let local = try SyncPayloadCodec.decodePayload(localPayload)
+                let remote = try SyncPayloadCodec.decodePayload(record.payload)
+                switch LWWResolver.tieMerge(localPayload: local, remotePayload: remote) {
+                case .keepLocal:
+                    return .keptLocalWin
+                case .fillColumns(let columns):
+                    let existing = try Self.columnNames(of: table.tableName, in: db)
+                    let fillable = columns.filter { existing.contains($0) }
+                    guard !fillable.isEmpty else { return .keptLocalWin }
+                    let assignments = fillable.map { "\($0) = ?" }.joined(separator: ", ")
+                    try db.execute(
+                        sql: "UPDATE \(table.tableName) SET \(assignments) WHERE \(table.primaryKeyColumn) = ?",
+                        arguments: StatementArguments(fillable.map { remote[$0]?.databaseValue ?? .null }
+                            + [record.recordId.databaseValue])
+                    )
+                    return .backfilledColumns
+                case .conflictingValues:
+                    break
+                }
+            }
+
             let winner = LWWResolver.resolve(
-                localUpdatedAt: Self.lwwTimestamp(of: localRow), localPayload: localPayload,
+                localUpdatedAt: localUpdatedAt, localPayload: localPayload,
                 remoteUpdatedAt: record.updatedAt, remotePayload: record.payload
             )
 

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
@@ -133,8 +133,22 @@ actor SyncEngine {
     @discardableResult
     func pull(now: Int64) async throws -> Int {
         var applied = 0
-        var token = try zoneStore.state(zoneName: Self.zoneName)?.serverChangeToken
+        let zoneState = try zoneStore.state(zoneName: Self.zoneName)
+        var token = zoneState?.serverChangeToken
         var didResetToken = false
+
+        // #469: if a migration added synced columns since the last pull, already-synced
+        // rows are locally missing those columns (migrate-on-read dropped them) and the
+        // incremental cursor will never redeliver them — the source rows haven't
+        // changed. Drop the cursor once to re-pull the whole zone; the applier's tie
+        // merge backfills the missing columns without touching anything the local rows
+        // legitimately own.
+        let schemaManifest = SyncedSchemaManifest.current
+        if token != nil,
+           SyncedSchemaManifest.addsSyncedColumns(from: zoneState?.lastSyncedSchema, to: schemaManifest) {
+            token = nil
+            try zoneStore.saveChangeToken(nil, zoneName: Self.zoneName, syncedAt: now)
+        }
 
         while true {
             let batch: SyncChangeBatch
@@ -162,6 +176,11 @@ actor SyncEngine {
             token = batch.newToken
             try zoneStore.saveChangeToken(token, zoneName: Self.zoneName, syncedAt: now)
             if !batch.moreComing { break }
+        }
+        // Stamp the manifest only after the pull completed — if a re-pull fails midway
+        // the stored manifest stays stale and the next sync resets the cursor again.
+        if zoneState?.lastSyncedSchema != schemaManifest {
+            try zoneStore.saveSyncedSchema(schemaManifest, zoneName: Self.zoneName)
         }
         return applied
     }

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncZoneStateStore.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncZoneStateStore.swift
@@ -11,6 +11,10 @@ struct SyncZoneState: Equatable, Sendable {
     let lastSyncAt: Int64?
     let lastError: String?
     let lastErrorAt: Int64?
+    /// The `SyncedSchemaManifest` in effect when this zone last completed a pull (#469).
+    /// When a migration adds synced columns, the stored manifest goes stale and the
+    /// engine forces a one-time full re-pull to backfill them.
+    let lastSyncedSchema: String?
 }
 
 /// Persists the incremental-pull cursor (the `CKServerChangeToken`) per zone, plus
@@ -30,7 +34,8 @@ final class SyncZoneStateStore: Sendable {
             let row = try Row.fetchOne(
                 db,
                 sql: """
-                    SELECT zone_name, server_change_token, last_sync_at, last_error, last_error_at
+                    SELECT zone_name, server_change_token, last_sync_at, last_error, last_error_at,
+                           last_synced_schema
                     FROM sync_zone_state WHERE zone_name = ?
                     """,
                 arguments: [zoneName]
@@ -55,6 +60,22 @@ final class SyncZoneStateStore: Sendable {
                         last_error_at = NULL
                     """,
                 arguments: [zoneName, token, syncedAt]
+            )
+        }
+    }
+
+    /// Persist the synced-schema manifest after a completed pull (#469), without
+    /// disturbing the change token or sync/error bookkeeping.
+    func saveSyncedSchema(_ manifest: String, zoneName: String) throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO sync_zone_state (zone_name, last_synced_schema)
+                    VALUES (?, ?)
+                    ON CONFLICT(zone_name) DO UPDATE SET
+                        last_synced_schema = excluded.last_synced_schema
+                    """,
+                arguments: [zoneName, manifest]
             )
         }
     }
@@ -85,7 +106,8 @@ final class SyncZoneStateStore: Sendable {
             serverChangeToken: row["server_change_token"] as Data?,
             lastSyncAt: row["last_sync_at"] as Int64?,
             lastError: row["last_error"] as String?,
-            lastErrorAt: row["last_error_at"] as Int64?
+            lastErrorAt: row["last_error_at"] as Int64?,
+            lastSyncedSchema: row["last_synced_schema"] as String?
         )
     }
 }

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncedSchemaManifest.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncedSchemaManifest.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// A canonical fingerprint of the synced-column schema (#469): which columns of which
+/// tables replicate to CloudKit. Persisted per zone (`sync_zone_state.last_synced_schema`)
+/// after each successful pull, so the engine can detect that a schema migration has
+/// ADDED synced columns since the device last pulled.
+///
+/// Why that matters: `RemoteChangeApplier` drops payload columns the local schema
+/// doesn't know (migrate-on-read). A record pulled before the upgrade is therefore
+/// missing those columns locally, and the incremental cursor never redelivers it —
+/// the source row hasn't changed. A manifest mismatch is what triggers the one-time
+/// full re-pull that backfills the gap.
+///
+/// Comparing manifests — rather than `DatabaseManager.schemaVersion` — means only
+/// migrations that actually change the synced column set cost a re-pull, and there is
+/// no per-version bookkeeping to keep in lockstep: the manifest derives from
+/// `SyncableTable.syncedColumns`, which `SyncableTableSyncedColumnsTests` already
+/// pins to the live schema.
+enum SyncedSchemaManifest {
+    /// The current manifest: `{tableName: [syncedColumn, …]}` as canonical JSON
+    /// (sorted keys, sorted columns) so equal schemas always compare equal as strings.
+    static var current: String {
+        let tables = Dictionary(
+            uniqueKeysWithValues: SyncableTable.allCases.map { ($0.tableName, $0.syncedColumns.sorted()) }
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = (try? encoder.encode(tables)) ?? Data("{}".utf8)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// Whether `new` contains synced columns (or whole tables) absent from `old` — the
+    /// condition that opens the migrate-on-read backfill gap. A nil or unreadable `old`
+    /// (first sync after this feature shipped, or corrupted state) counts as "unknown,
+    /// assume added" so an existing gap heals instead of persisting silently. Pure
+    /// column/table removals return false: nothing was dropped on read, so no re-pull
+    /// is needed.
+    static func addsSyncedColumns(from old: String?, to new: String) -> Bool {
+        guard let old, let oldTables = decode(old), let newTables = decode(new) else {
+            return true
+        }
+        return newTables.contains { tableName, columns in
+            let known = Set(oldTables[tableName] ?? [])
+            return columns.contains { !known.contains($0) }
+        }
+    }
+
+    private static func decode(_ manifest: String) -> [String: [String]]? {
+        guard let data = manifest.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode([String: [String]].self, from: data)
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
@@ -189,7 +189,7 @@ final class DatabaseManagerTests: XCTestCase {
     // MARK: - Schema Version
 
     func testSchemaVersionIsTracked() throws {
-        XCTAssertEqual(DatabaseManager.schemaVersion, 35)
+        XCTAssertEqual(DatabaseManager.schemaVersion, 36)
     }
 
     func testMigrationIsRecordedInGRDB() throws {

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/LWWResolverTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/LWWResolverTests.swift
@@ -43,4 +43,56 @@ final class LWWResolverTests: XCTestCase {
         XCTAssertEqual(deviceA, .remote, "device A keeps remote 'y'")
         XCTAssertEqual(deviceB, .local, "device B keeps local 'y'")
     }
+
+    // MARK: - Timestamp-tie column merge (#469)
+
+    func testTieMergeFillsLocallyMissingAndNullColumns() {
+        let result = LWWResolver.tieMerge(
+            localPayload: ["id": .text("m1"), "name": .text("Med"), "notes": .null],
+            remotePayload: ["id": .text("m1"), "name": .text("Med"),
+                            "notes": .text("rich"), "strength": .int(50)]
+        )
+        XCTAssertEqual(result, .fillColumns(["notes", "strength"]),
+                       "remote fills the locally-NULL and locally-missing columns")
+    }
+
+    func testTieMergeKeepsLocalWhenRemoteIsSubset() {
+        let result = LWWResolver.tieMerge(
+            localPayload: ["id": .text("m1"), "name": .text("Med"), "notes": .text("mine")],
+            remotePayload: ["id": .text("m1"), "name": .text("Med")]
+        )
+        XCTAssertEqual(result, .keepLocal, "remote offers nothing new")
+    }
+
+    func testTieMergeRemoteNullNeverOverwritesLocalValue() {
+        let result = LWWResolver.tieMerge(
+            localPayload: ["id": .text("m1"), "notes": .text("mine")],
+            remotePayload: ["id": .text("m1"), "notes": .null]
+        )
+        XCTAssertEqual(result, .keepLocal)
+    }
+
+    func testTieMergeConflictingValuesFallBackToTiebreak() {
+        let result = LWWResolver.tieMerge(
+            localPayload: ["id": .text("m1"), "name": .text("Mine")],
+            remotePayload: ["id": .text("m1"), "name": .text("Theirs"), "notes": .text("x")]
+        )
+        XCTAssertEqual(result, .conflictingValues,
+                       "a genuine value disagreement is not a schema-richness merge")
+    }
+
+    /// Mirror-image merge converges: each device fills the column it lacks, both end
+    /// at the column-union.
+    func testTieMergeConvergesAcrossDevices() {
+        let base: [String: SyncPayloadCodec.Value] = ["id": .text("m1"), "name": .text("Med")]
+        var withNotes = base
+        withNotes["notes"] = .text("n")
+        var withStrength = base
+        withStrength["strength"] = .int(50)
+
+        XCTAssertEqual(LWWResolver.tieMerge(localPayload: withNotes, remotePayload: withStrength),
+                       .fillColumns(["strength"]))
+        XCTAssertEqual(LWWResolver.tieMerge(localPayload: withStrength, remotePayload: withNotes),
+                       .fillColumns(["notes"]))
+    }
 }

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/RemoteChangeApplierTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/RemoteChangeApplierTests.swift
@@ -201,6 +201,124 @@ final class RemoteChangeApplierTests: XCTestCase {
         }
     }
 
+    // MARK: - Timestamp-tie column merge (#469)
+
+    /// The signature #469 case: a re-pulled record carries the same `updated_at` as the
+    /// local row but holds a column (`notes`) that migrate-on-read dropped before the
+    /// schema upgrade. The applier must fill that column and leave the rest untouched.
+    func testTieFillsLocallyNullColumnFromRicherRemote() throws {
+        try insertMedication("m1", name: "Med", updatedAt: 1000) // notes is NULL
+        let remote = SyncRecord(
+            tableName: "medications", recordId: "m1",
+            payload: makePayload([
+                "id": "m1", "name": "Med", "type": "rescue", "dosage_amount": 1.0,
+                "dosage_unit": "mg", "active": Int64(1), "notes": "From newer device",
+                "created_at": Int64(1000), "updated_at": Int64(1000),
+            ]),
+            schemaVersion: 36, updatedAt: 1000, deleted: false
+        )
+
+        XCTAssertEqual(try applier.apply(remote, now: 10), .backfilledColumns)
+        try dbManager.dbQueue.read { db in
+            let notes = try String.fetchOne(db, sql: "SELECT notes FROM medications WHERE id = 'm1'")
+            XCTAssertEqual(notes, "From newer device", "missing column backfilled")
+            let name = try String.fetchOne(db, sql: "SELECT name FROM medications WHERE id = 'm1'")
+            XCTAssertEqual(name, "Med", "owned columns untouched")
+        }
+        XCTAssertEqual(try conflicts().count, 0, "a fill loses no data, so nothing to archive")
+    }
+
+    /// The mirror case: local is the richer side. The column-deficient remote must not
+    /// displace it (the old byte tiebreak could have).
+    func testTieKeepsLocalWhenRemoteIsColumnDeficient() throws {
+        try insertMedication("m1", name: "Med", updatedAt: 1000)
+        try dbManager.dbQueue.write { db in
+            try db.execute(sql: "UPDATE medications SET notes = 'Local detail' WHERE id = 'm1'")
+        }
+        let remote = SyncRecord(
+            tableName: "medications", recordId: "m1",
+            payload: makePayload([
+                "id": "m1", "name": "Med", "type": "rescue", "dosage_amount": 1.0,
+                "dosage_unit": "mg", "active": Int64(1),
+                "created_at": Int64(1000), "updated_at": Int64(1000),
+            ]),
+            schemaVersion: 31, updatedAt: 1000, deleted: false
+        )
+
+        XCTAssertEqual(try applier.apply(remote, now: 10), .keptLocalWin)
+        try dbManager.dbQueue.read { db in
+            let notes = try String.fetchOne(db, sql: "SELECT notes FROM medications WHERE id = 'm1'")
+            XCTAssertEqual(notes, "Local detail", "richer local row kept")
+        }
+    }
+
+    /// An explicit remote NULL at the same timestamp must not wipe a local value —
+    /// the merge only ever adds data.
+    func testTieRemoteNullDoesNotOverwriteLocalValue() throws {
+        try insertMedication("m1", name: "Med", updatedAt: 1000)
+        try dbManager.dbQueue.write { db in
+            try db.execute(sql: "UPDATE medications SET notes = 'Keep me' WHERE id = 'm1'")
+        }
+        let remote = SyncRecord(
+            tableName: "medications", recordId: "m1",
+            payload: makePayload([
+                "id": "m1", "name": "Med", "type": "rescue", "dosage_amount": 1.0,
+                "dosage_unit": "mg", "active": Int64(1), "notes": nil,
+                "created_at": Int64(1000), "updated_at": Int64(1000),
+            ]),
+            schemaVersion: 31, updatedAt: 1000, deleted: false
+        )
+
+        XCTAssertEqual(try applier.apply(remote, now: 10), .keptLocalWin)
+        try dbManager.dbQueue.read { db in
+            let notes = try String.fetchOne(db, sql: "SELECT notes FROM medications WHERE id = 'm1'")
+            XCTAssertEqual(notes, "Keep me")
+        }
+    }
+
+    /// A genuine same-timestamp conflict (a shared column with two different values)
+    /// still resolves through the deterministic byte tiebreak, not the merge.
+    func testTieWithConflictingValuesFallsBackToByteTiebreak() throws {
+        try insertMedication("m1", name: "AAA", updatedAt: 1000)
+        // Mirror the full local column set so the payloads differ only in `name`, making
+        // the lexicographic outcome unambiguous: "ZZZ" > "AAA" → remote wins.
+        let remote = SyncRecord(
+            tableName: "medications", recordId: "m1",
+            payload: makePayload([
+                "id": "m1", "name": "ZZZ", "type": "rescue", "dosage_amount": 1.0,
+                "dosage_unit": "mg", "default_quantity": nil, "schedule_frequency": nil,
+                "photo_uri": nil, "active": Int64(1), "notes": nil, "category": nil,
+                "created_at": Int64(1000), "updated_at": Int64(1000), "min_interval_hours": nil,
+            ]),
+            schemaVersion: 31, updatedAt: 1000, deleted: false
+        )
+
+        XCTAssertEqual(try applier.apply(remote, now: 10), .appliedRemoteWin)
+        XCTAssertEqual(try medicationName("m1"), "ZZZ")
+    }
+
+    /// A fill column the local schema doesn't know yet (remote is *two* schema versions
+    /// ahead) is dropped from the merge — migrate-on-read still applies.
+    func testTieFillSkipsColumnsUnknownToLocalSchema() throws {
+        try insertMedication("m1", name: "Med", updatedAt: 1000)
+        let remote = SyncRecord(
+            tableName: "medications", recordId: "m1",
+            payload: makePayload([
+                "id": "m1", "name": "Med", "type": "rescue", "dosage_amount": 1.0,
+                "dosage_unit": "mg", "active": Int64(1), "notes": "fillable",
+                "future_column": "not yet known locally",
+                "created_at": Int64(1000), "updated_at": Int64(1000),
+            ]),
+            schemaVersion: 99, updatedAt: 1000, deleted: false
+        )
+
+        XCTAssertEqual(try applier.apply(remote, now: 10), .backfilledColumns)
+        try dbManager.dbQueue.read { db in
+            let notes = try String.fetchOne(db, sql: "SELECT notes FROM medications WHERE id = 'm1'")
+            XCTAssertEqual(notes, "fillable", "known column still fills")
+        }
+    }
+
     /// A payload column the local schema doesn't have (newer remote schema) is dropped,
     /// not an error — basic forward-compatible migrate-on-read.
     func testUnknownPayloadColumnIsDropped() throws {

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
@@ -195,6 +195,69 @@ final class SyncEngineTests: XCTestCase {
         XCTAssertEqual(secondApplied, 0, "nothing new since the saved token")
     }
 
+    // MARK: - Schema-upgrade backfill (#469)
+
+    /// Every completed pull stamps the synced-schema manifest, so later pulls can tell
+    /// whether a migration has added synced columns since.
+    func testPullStampsSyncedSchemaManifest() async throws {
+        _ = try await engine.pull(now: 10)
+        XCTAssertEqual(
+            try zoneStore.state(zoneName: SyncEngine.zoneName)?.lastSyncedSchema,
+            SyncedSchemaManifest.current
+        )
+    }
+
+    /// The #469 end-to-end scenario: a record was pulled while this device's schema
+    /// lacked a synced column (`notes`), so the column is NULL locally and the cursor
+    /// is past the record — incremental pulls will never redeliver it. When the stored
+    /// manifest goes stale (the upgrade added the column), the engine must reset the
+    /// cursor once, re-pull the zone, and backfill the column via the tie merge.
+    func testPullBackfillsMissingColumnsAfterSchemaUpgrade() async throws {
+        let rich = SyncRecord(
+            tableName: "medications", recordId: "m1",
+            payload: payload([
+                "id": "m1", "name": "Sumatriptan", "type": "rescue", "dosage_amount": 1.0,
+                "dosage_unit": "mg", "active": Int64(1), "notes": "Take with food",
+                "created_at": Int64(1000), "updated_at": Int64(1000),
+            ]),
+            schemaVersion: 36, updatedAt: 1000, deleted: false
+        )
+        try await transport.push([rich])
+        _ = try await engine.pull(now: 10)
+
+        // Simulate the pre-upgrade state: the older schema dropped `notes` on read…
+        try await dbManager.dbQueue.write { db in
+            try db.execute(sql: "UPDATE medications SET notes = NULL WHERE id = 'm1'")
+        }
+        // …and the stamped manifest predates the column.
+        try zoneStore.saveSyncedSchema("{}", zoneName: SyncEngine.zoneName)
+
+        let applied = try await engine.pull(now: 20)
+        XCTAssertEqual(applied, 1, "stale manifest reset the cursor and redelivered the record")
+        let notes = try await dbManager.dbQueue.read { db in
+            try String.fetchOne(db, sql: "SELECT notes FROM medications WHERE id = 'm1'")
+        }
+        XCTAssertEqual(notes, "Take with food", "dropped column backfilled from the re-pulled record")
+
+        // The manifest is current again: the next pull must be incremental, not a re-pull.
+        let third = try await engine.pull(now: 30)
+        XCTAssertEqual(third, 0, "no second reset once the manifest is stamped")
+    }
+
+    /// An unchanged manifest must never reset the cursor — pulls stay incremental.
+    func testPullDoesNotResetCursorWhenManifestUnchanged() async throws {
+        try await transport.push([remoteMedication("m1", name: "X", updatedAt: 1000)])
+        _ = try await engine.pull(now: 10)
+
+        let tokenBefore = try zoneStore.state(zoneName: SyncEngine.zoneName)?.serverChangeToken
+        let applied = try await engine.pull(now: 20)
+        XCTAssertEqual(applied, 0)
+        XCTAssertEqual(
+            try zoneStore.state(zoneName: SyncEngine.zoneName)?.serverChangeToken, tokenBefore,
+            "cursor untouched when no synced columns were added"
+        )
+    }
+
     // MARK: - Full cycle
 
     func testSyncEnsuresZonePushesAndPulls() async throws {

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncZoneStateStoreTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncZoneStateStoreTests.swift
@@ -60,6 +60,30 @@ final class SyncZoneStateStoreTests: XCTestCase {
         XCTAssertNil(state?.lastErrorAt)
     }
 
+    func testSaveSyncedSchemaPersists() throws {
+        try store.saveSyncedSchema(#"{"medications":["id"]}"#, zoneName: zone)
+        XCTAssertEqual(try store.state(zoneName: zone)?.lastSyncedSchema, #"{"medications":["id"]}"#)
+    }
+
+    func testSaveSyncedSchemaDoesNotDisturbTokenOrStatus() throws {
+        try store.saveChangeToken(Data([0x07]), zoneName: zone, syncedAt: 1000)
+        try store.saveSyncedSchema("{}", zoneName: zone)
+
+        let state = try store.state(zoneName: zone)
+        XCTAssertEqual(state?.serverChangeToken, Data([0x07]), "manifest save must not wipe the cursor")
+        XCTAssertEqual(state?.lastSyncAt, 1000)
+        XCTAssertEqual(state?.lastSyncedSchema, "{}")
+    }
+
+    func testTokenSaveAndErrorPreserveSyncedSchema() throws {
+        try store.saveSyncedSchema("{}", zoneName: zone)
+        try store.saveChangeToken(Data([0x01]), zoneName: zone, syncedAt: 2000)
+        try store.recordError("boom", zoneName: zone, at: 3000)
+
+        XCTAssertEqual(try store.state(zoneName: zone)?.lastSyncedSchema, "{}",
+                       "token saves and errors must not clear the stamped manifest")
+    }
+
     func testRecordErrorOnFreshZone() throws {
         try store.recordError("first failure", zoneName: zone, at: 1000)
 

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncedSchemaManifestTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncedSchemaManifestTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import MigraLog
+
+final class SyncedSchemaManifestTests: XCTestCase {
+
+    private func manifest(_ tables: [String: [String]]) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        // swiftlint:disable:next force_try
+        return String(decoding: try! encoder.encode(tables), as: UTF8.self)
+    }
+
+    func testCurrentCoversEverySyncableTable() throws {
+        let decoded = try JSONDecoder().decode(
+            [String: [String]].self, from: Data(SyncedSchemaManifest.current.utf8)
+        )
+        for table in SyncableTable.allCases {
+            XCTAssertEqual(
+                decoded[table.tableName], table.syncedColumns.sorted(),
+                "manifest must list \(table.tableName)'s synced columns"
+            )
+        }
+        XCTAssertEqual(decoded.count, SyncableTable.allCases.count)
+    }
+
+    func testCurrentIsDeterministic() {
+        XCTAssertEqual(SyncedSchemaManifest.current, SyncedSchemaManifest.current)
+    }
+
+    func testUnknownOldManifestAssumesColumnsAdded() {
+        // First sync after this feature ships (nil) or corrupted state (garbage): the
+        // device may carry a pre-existing backfill gap, so it must re-pull once.
+        XCTAssertTrue(SyncedSchemaManifest.addsSyncedColumns(from: nil, to: SyncedSchemaManifest.current))
+        XCTAssertTrue(SyncedSchemaManifest.addsSyncedColumns(from: "not json", to: SyncedSchemaManifest.current))
+    }
+
+    func testIdenticalManifestAddsNothing() {
+        let current = SyncedSchemaManifest.current
+        XCTAssertFalse(SyncedSchemaManifest.addsSyncedColumns(from: current, to: current))
+    }
+
+    func testAddedColumnIsDetected() {
+        let old = manifest(["medications": ["id", "name"]])
+        let new = manifest(["medications": ["id", "name", "strength"]])
+        XCTAssertTrue(SyncedSchemaManifest.addsSyncedColumns(from: old, to: new))
+    }
+
+    func testAddedTableIsDetected() {
+        // A whole new synced table: its records were skippedUnknownTable before the
+        // upgrade, so they too need a re-pull.
+        let old = manifest(["medications": ["id", "name"]])
+        let new = manifest(["medications": ["id", "name"], "tracking_options": ["id", "value"]])
+        XCTAssertTrue(SyncedSchemaManifest.addsSyncedColumns(from: old, to: new))
+    }
+
+    func testRemovedColumnDoesNotForceRepull() {
+        // Removals never dropped data on read — nothing to backfill.
+        let old = manifest(["medications": ["id", "name", "legacy"]])
+        let new = manifest(["medications": ["id", "name"]])
+        XCTAssertFalse(SyncedSchemaManifest.addsSyncedColumns(from: old, to: new))
+    }
+
+    func testRemovedTableDoesNotForceRepull() {
+        let old = manifest(["medications": ["id"], "legacy_table": ["id"]])
+        let new = manifest(["medications": ["id"]])
+        XCTAssertFalse(SyncedSchemaManifest.addsSyncedColumns(from: old, to: new))
+    }
+}

--- a/spec/ios/icloud-sync.md
+++ b/spec/ios/icloud-sync.md
@@ -65,6 +65,14 @@ CloudKit's built-in `modificationDate` reflects upload time, not edit time, so w
 
 The losing payload is **never discarded** — see Data Safety below.
 
+**Timestamp ties merge, not pick (#469):** when two versions carry the *same* `updatedAt` but different payloads, that is usually the same logical version seen through different schemas, not a competing edit. If every column both sides hold a value for agrees, the applier performs a non-destructive column merge — remote non-null values fill locally missing/NULL columns, remote NULLs never overwrite, local-only columns are kept — so both devices converge on the column-union. Only a genuine value disagreement falls back to the deterministic payload-byte tiebreak.
+
+## Schema Evolution (#469)
+
+Payloads are column dictionaries and the applier is column-tolerant: incoming columns the local schema doesn't know are dropped (**migrate-on-read**), so a newer device can always sync to an older one. New synced columns MUST be nullable or have a default, or applying an older payload would fail a NOT NULL constraint.
+
+Migrate-on-read leaves a backfill gap: rows pulled *before* a schema upgrade are missing the dropped columns, and the incremental cursor never redelivers them (the source rows haven't changed). To close it, the engine stamps `sync_zone_state.last_synced_schema` with the synced-column manifest (`SyncedSchemaManifest`, canonical JSON of table → synced columns) after each completed pull. When a migration **adds** synced columns or tables, the stored manifest goes stale and the next pull resets the zone change token once, re-pulling the zone; the timestamp-tie merge above backfills the missing columns. Removals don't trigger a re-pull — nothing was dropped on read.
+
 ## Data Safety
 
 Data loss prevention has three layers:

--- a/spec/schemas/sqlite/schema-v36.sql
+++ b/spec/schemas/sqlite/schema-v36.sql
@@ -1,4 +1,4 @@
--- MigraLog SQLite Schema v35
+-- MigraLog SQLite Schema v36
 -- Canonical schema definition for the migraine tracking database.
 -- Source of truth: mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
 --   (createSchema + registered migrations). This .sql is a formal mirror and
@@ -23,6 +23,11 @@
 --   (recoverable tombstones). See sync-schema-v1.sql.
 -- v35: added tracking_options — user customization of the pain-quality / symptom /
 --   trigger pick lists (custom additions + hidden built-ins). Synced.
+-- v36 (#469): added the nullable `last_synced_schema` column to sync_zone_state — the
+--   synced-column manifest (SyncedSchemaManifest, canonical JSON of table → synced
+--   columns) stamped after each completed pull. A mismatch (a migration added synced
+--   columns) makes the sync engine reset the zone change token once and re-pull,
+--   backfilling columns that migrate-on-read dropped before the upgrade.
 --
 -- Conventions:
 --   - All IDs are TEXT (UUIDs)
@@ -306,7 +311,8 @@ CREATE TABLE IF NOT EXISTS sync_zone_state (
   server_change_token BLOB,
   last_sync_at INTEGER CHECK(last_sync_at IS NULL OR last_sync_at > 0),
   last_error TEXT,
-  last_error_at INTEGER CHECK(last_error_at IS NULL OR last_error_at > 0)
+  last_error_at INTEGER CHECK(last_error_at IS NULL OR last_error_at > 0),
+  last_synced_schema TEXT  -- v36 (#469): synced-column manifest at last completed pull
 );
 
 CREATE INDEX IF NOT EXISTS idx_sync_pending_created ON sync_pending_changes(created_at);

--- a/spec/schemas/sqlite/sync-schema-v1.sql
+++ b/spec/schemas/sqlite/sync-schema-v1.sql
@@ -29,7 +29,11 @@ CREATE TABLE IF NOT EXISTS sync_zone_state (
   server_change_token BLOB,                       -- CKServerChangeToken (opaque, NSKeyedArchiver'd)
   last_sync_at INTEGER CHECK(last_sync_at IS NULL OR last_sync_at > 0),
   last_error TEXT,
-  last_error_at INTEGER CHECK(last_error_at IS NULL OR last_error_at > 0)
+  last_error_at INTEGER CHECK(last_error_at IS NULL OR last_error_at > 0),
+  last_synced_schema TEXT                         -- v36 (#469): synced-column manifest (canonical JSON of
+                                                  -- table → synced columns) at the last completed pull; a
+                                                  -- mismatch (a migration added synced columns) forces a
+                                                  -- one-time full re-pull that backfills the new columns
 );
 
 -- Pending changes queue (outbound changes waiting to be pushed to CloudKit)


### PR DESCRIPTION
Closes #469.

## Problem

Sync payloads are generic `{column: value}` dictionaries and `RemoteChangeApplier` is column-tolerant: it drops payload columns the local schema doesn't know (migrate-on-read). That keeps newer → older sync safe, but rows pulled *before* a schema upgrade are missing the new columns locally and the incremental cursor never redelivers them — the source rows haven't changed. The gap only closed lazily when a row happened to be re-edited. A naive full re-pull doesn't fix it either: the re-fetched record ties on `updated_at` and the byte tiebreak may keep the column-deficient local row.

## Fix (the two pieces from the issue)

**1. Detect the bump → one-time re-pull.** After each completed pull, the engine stamps `sync_zone_state.last_synced_schema` (new column, migration **v36**) with `SyncedSchemaManifest.current` — canonical JSON of `table → syncedColumns`. When a migration **adds** synced columns or tables, the stored manifest goes stale and the next pull resets the zone change token once (reusing the proven `changeTokenExpired` reset path) and re-pulls the zone.

Why a manifest instead of the literal `lastSyncedSchemaVersion` integer: comparing manifests implements the issue's condition — "schema bumped *and* the migration added synced columns" — exactly, with no hand-maintained per-version bookkeeping to forget. It derives from `SyncableTable.syncedColumns`, which `SyncableTableSyncedColumnsTests` already pins to the live schema. Version-only bumps (no synced-column change) cost no re-pull; removals cost no re-pull. A nil/unreadable stored manifest with an existing cursor (first sync after this update ships) re-pulls once, healing **pre-existing** gaps — including records of tables that were `skippedUnknownTable` before their table existed locally (e.g. `tracking_options` pulled by a ≤v34 app).

**2. Make apply fill, not just pick.** On an exact `updated_at` tie where every column both sides hold a value for agrees, the applier now does a non-destructive column merge (`LWWResolver.tieMerge`): remote non-null values fill locally missing/NULL columns, remote NULLs never overwrite local values, local-only columns are kept. Both devices converge on the column-union. A genuine value disagreement (same column, two different values) still falls back to the deterministic payload-byte tiebreak. A fill archives no conflict (nothing is lost), doesn't bump `updated_at`, doesn't drop a pending local push, and capture-trigger suppression keeps it from echoing back to CloudKit.

## Schema / spec

- v36 migration adds nullable `last_synced_schema TEXT` to `sync_zone_state` (idempotent PRAGMA-checked ALTER; fresh installs get it from `createSyncStateTables`).
- `spec/schemas/sqlite/schema-v35.sql` → `schema-v36.sql`, `sync-schema-v1.sql` updated, new *Schema Evolution* section in `spec/ios/icloud-sync.md` (also documents the invariant: new synced columns must be nullable or defaulted).

## Tests

- `SyncedSchemaManifestTests` (new): manifest covers every table; added column/table detected; removals and identical manifests don't re-pull; nil/garbage treated as unknown → re-pull.
- `LWWResolverTests`: tie-merge fill/keep-local/null-never-overwrites/conflict cases + cross-device convergence.
- `RemoteChangeApplierTests`: backfills a locally-NULL column on tie; column-deficient remote can't displace a richer local row; explicit remote NULL doesn't wipe a local value; conflicting tie still resolves via byte tiebreak; fill respects migrate-on-read for still-unknown columns.
- `SyncEngineTests`: end-to-end #469 scenario (stale manifest → cursor reset → re-pull → backfill → next pull incremental again); manifest stamped after pull; unchanged manifest never resets the cursor.

Local verification: full `MigraLogTests` suite green (952 tests), Smoke test plan green (incl. UI launch smoke over the v36 migration), SwiftLint 0 error-level violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)