### PR TITLE
feat(ios): log update from dashboard while an episode is ongoing

### DIFF
--- a/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
@@ -31,6 +31,7 @@ final class DashboardViewModel {
     var yesterdayStatus: DailyStatusLog?
     var shouldShowYesterdayPrompt: Bool = false
     var showNewEpisode = false
+    var showLogUpdate = false
     var showLogMedication = false
     var isLoading = false
     var error: String?

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -3,6 +3,9 @@ import SwiftUI
 struct DashboardScreen: View {
     @Environment(AppState.self) private var appState
     @State private var viewModel = DashboardViewModel()
+    /// Backs the Log Update flow shown in place of "Start Episode" while an
+    /// episode is ongoing; loaded on demand for the current episode.
+    @State private var detailViewModel = EpisodeDetailViewModel()
     /// Backs the iPad-only "This Month" calendar card; never fetched on iPhone.
     @State private var calendarViewModel = AnalyticsViewModel()
     @State private var refreshId = UUID()
@@ -38,6 +41,27 @@ struct DashboardScreen: View {
         }) {
             NavigationStack {
                 NewEpisodeScreen()
+            }
+        }
+        .sheet(isPresented: $viewModel.showLogUpdate, onDismiss: {
+            Task { await viewModel.loadData() }
+        }) {
+            NavigationStack {
+                // Gate on the detail view model having loaded the *current*
+                // episode so LogUpdateScreen prefills from real data rather
+                // than a stale or empty state.
+                if let episode = detailViewModel.episode,
+                   episode.id == viewModel.currentEpisode?.id {
+                    LogUpdateScreen(episodeId: episode.id, viewModel: detailViewModel)
+                } else {
+                    ProgressView()
+                        .accessibilityIdentifier("log-update-loading")
+                }
+            }
+            .task {
+                if let id = viewModel.currentEpisode?.id {
+                    await detailViewModel.loadEpisode(id)
+                }
             }
         }
         .sheet(isPresented: $viewModel.showLogMedication, onDismiss: {
@@ -151,11 +175,22 @@ struct DashboardScreen: View {
         .padding()
     }
 
+    /// While an episode is ongoing the primary action logs an update to it
+    /// rather than starting a second episode.
+    private var hasOngoingEpisode: Bool { viewModel.currentEpisode != nil }
+
     private var startEpisodeButton: some View {
         Button {
-            viewModel.showNewEpisode = true
+            if hasOngoingEpisode {
+                viewModel.showLogUpdate = true
+            } else {
+                viewModel.showNewEpisode = true
+            }
         } label: {
-            Label("Start Episode", systemImage: "plus.circle.fill")
+            Label(
+                hasOngoingEpisode ? "Log Update" : "Start Episode",
+                systemImage: "plus.circle.fill"
+            )
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
                 .fontWeight(.semibold)
@@ -165,8 +200,10 @@ struct DashboardScreen: View {
                 .foregroundStyle(.white)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
         }
-        .accessibilityIdentifier("start-episode-button")
-        .accessibilityHint("Start tracking a new migraine episode")
+        .accessibilityIdentifier(hasOngoingEpisode ? "log-update-button" : "start-episode-button")
+        .accessibilityHint(hasOngoingEpisode
+            ? "Log an update to the ongoing migraine episode"
+            : "Start tracking a new migraine episode")
     }
 
     private var logMedicationButton: some View {

--- a/mobile-apps/ios/MigraLogUITests/EpisodeLifecycleUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/EpisodeLifecycleUITests.swift
@@ -268,6 +268,43 @@ final class EpisodeLifecycleUITests: XCTestCase {
                        "Episode should still show Ongoing after canceling")
     }
 
+    // MARK: - 2.x Ongoing episode swaps the dashboard primary action
+
+    /// While an episode is ongoing the dashboard's primary button should be
+    /// "Log Update" (not "Start Episode") and follow the Log Update flow.
+    func testOngoingEpisodeDashboardButtonLogsUpdate() throws {
+        createActiveEpisode()
+
+        // Dashboard now shows the ongoing episode.
+        let activeEpisodeCard = app.buttons["active-episode-card"]
+        UITestHelpers.waitForElement(activeEpisodeCard)
+
+        // Start Episode is replaced by Log Update.
+        XCTAssertFalse(app.buttons["start-episode-button"].exists,
+                       "Start Episode should be hidden while an episode is ongoing")
+
+        let logUpdateButton = app.buttons["log-update-button"]
+        UITestHelpers.waitForHittable(logUpdateButton)
+        logUpdateButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // The Log Update flow presents the intensity slider; adjust and save.
+        let slider = app.sliders.firstMatch
+        XCTAssertTrue(slider.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+                      "Log Update flow should present the intensity slider")
+        slider.adjust(toNormalizedSliderPosition: 0.8)
+
+        let saveButton = app.buttons["Save"]
+        UITestHelpers.waitForHittable(saveButton)
+        saveButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // Back on the dashboard, the episode is still ongoing.
+        UITestHelpers.waitForElement(activeEpisodeCard)
+        XCTAssertTrue(app.buttons["log-update-button"].waitForExistence(timeout: UITestHelpers.defaultTimeout),
+                      "Primary action should remain Log Update while the episode stays ongoing")
+    }
+
     // MARK: - Helpers
 
     private func createActiveEpisode() {


### PR DESCRIPTION
## Summary
When an episode is ongoing, the dashboard's primary button now reads **"Log Update"** instead of "Start Episode" and opens the existing Log Update flow for the current episode — rather than letting the user start a second, overlapping episode.

## Behavior
- **No ongoing episode** → unchanged: "Start Episode" (`start-episode-button`) → `NewEpisodeScreen`.
- **Ongoing episode** → button switches label, accessibility identifier (`log-update-button`), and hint, and presents `LogUpdateScreen` backed by a dashboard-owned `EpisodeDetailViewModel` loaded on demand. The sheet gates rendering until the loaded view model matches the current episode, so the form prefills from real intensity/symptom/location data rather than stale or empty state.

## Testing
- `xcodebuild build` — succeeds.
- New UI test `testOngoingEpisodeDashboardButtonLogsUpdate`: with an ongoing episode, `start-episode-button` is gone, `log-update-button` drives the flow (slider → Save), episode stays ongoing. **Passes.**
- Existing `testCompleteEpisodeLifecycle` still passes (clean-dashboard tests are unaffected since the button stays `start-episode-button` with no ongoing episode).
- Verified live on the iPhone 17 Pro simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)