### PR TITLE
ci(website): bump deploy-pipeline actions to Node 24 versions

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -59,7 +59,7 @@ jobs:
         env:
           CI: 'true'
         run: npm run test:ci
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-pr
@@ -79,7 +79,7 @@ jobs:
         with:
           node-version: '20'
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::483643755230:role/migralog-website-deploy-staging
           aws-region: us-east-1
@@ -120,7 +120,7 @@ jobs:
           CI: 'true'
           PLAYWRIGHT_BASE_URL: https://staging.migralog.app
         run: npm run test:ci
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-staging
@@ -141,7 +141,7 @@ jobs:
         with:
           node-version: '20'
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::483643755230:role/migralog-website-deploy-production
           aws-region: us-east-1
@@ -182,7 +182,7 @@ jobs:
           CI: 'true'
           PLAYWRIGHT_BASE_URL: https://migralog.app
         run: npm run test:ci
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-production


### PR DESCRIPTION
Clears the Node.js 20 deprecation warnings on the website deploy pipeline. GitHub force-migrates Actions to Node 24 on **2026-06-16** (and removes Node 20 on 2026-09-16), so the two remaining Node 20 actions are bumped:

- `aws-actions/configure-aws-credentials@v4` → `@v6` (v6.2.0, `using: node24`)
- `actions/upload-artifact@v4` → `@v7` (v7.0.1, `using: node24`)

Verified the inputs in use are unchanged across these majors (`role-to-assume`/`aws-region`; `name`/`path`/`retention-days`). `checkout@v6` and `setup-node@v6` already run on Node 24 and weren't flagged.

No behavior change — just runtime/version bumps. The PR's local Playwright job exercises `upload-artifact@v7`; `configure-aws-credentials@v6` is exercised on the next deploy to staging after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)