### PR TITLE
feat(ios): Live Activities scaffolding + activity contract (#416 Phase 0)

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -152,15 +152,18 @@ jobs:
           security list-keychain -d user -s "$KEYCHAIN_PATH"
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
-      - name: Install provisioning profile
+      # Automatic signing (#416): xcodebuild manages the distribution profiles for
+      # both the app and the MigraLogWidgets extension using the App Store Connect
+      # API key. The key is set up BEFORE the archive so -allowProvisioningUpdates
+      # can register/download profiles on the fly — no hand-maintained
+      # per-bundle-id provisioning profile secret required.
+      - name: Setup App Store Connect API key
         env:
-          PROVISIONING_PROFILE: ${{ secrets.SWIFT_PROVISIONING_PROFILE }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
         run: |
-          PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
-          echo -n "$PROVISIONING_PROFILE" | base64 --decode -o "$PROFILE_PATH"
-          PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< $(security cms -D -i "$PROFILE_PATH"))
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp "$PROFILE_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/${PROFILE_UUID}.mobileprovision
+          mkdir -p ~/.private_keys
+          echo -n "$ASC_API_KEY_P8" > ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8
 
       # Patch-bump the marketing version + build number from the latest release
       # tag. We read both deploy/* (new scheme) and alpha-v* (the pre-existing
@@ -191,6 +194,8 @@ jobs:
       - name: Build archive
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: |
           security find-identity -v -p codesigning $RUNNER_TEMP/app-signing.keychain-db
           xcodebuild archive \
@@ -198,17 +203,14 @@ jobs:
             -project $PROJECT \
             -archivePath $ARCHIVE_PATH \
             -destination 'generic/platform=iOS' \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8 \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+            CODE_SIGN_STYLE=Automatic \
             MARKETING_VERSION="$APP_VERSION" \
             CURRENT_PROJECT_VERSION="$APP_BUILD"
-
-      - name: Setup App Store Connect API key
-        env:
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
-        run: |
-          mkdir -p ~/.private_keys
-          echo -n "$ASC_API_KEY_P8" > ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8
 
       - name: Export and upload to TestFlight
         env:
@@ -219,6 +221,7 @@ jobs:
             -archivePath $ARCHIVE_PATH \
             -exportOptionsPlist ExportOptions.plist \
             -exportPath $EXPORT_PATH \
+            -allowProvisioningUpdates \
             -authenticationKeyPath ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8 \
             -authenticationKeyID "$ASC_KEY_ID" \
             -authenticationKeyIssuerID "$ASC_ISSUER_ID"

--- a/mobile-apps/ios/.swiftlint.yml
+++ b/mobile-apps/ios/.swiftlint.yml
@@ -1,5 +1,6 @@
 included:
   - MigraLog
+  - MigraLogWidgets
   - MigraLogTests
 
 excluded:

--- a/mobile-apps/ios/ExportOptions.plist
+++ b/mobile-apps/ios/ExportOptions.plist
@@ -6,14 +6,14 @@
 	<string>app-store-connect</string>
 	<key>destination</key>
 	<string>upload</string>
+	<!-- Automatic signing: xcodebuild manages distribution profiles for the app
+	     and the MigraLogWidgets extension via the App Store Connect API key passed
+	     to -exportArchive (and -allowProvisioningUpdates at archive time). This
+	     replaces the per-bundle-id manual profile map, which could not cover the
+	     widget extension's bundle id. See #416. -->
 	<key>signingStyle</key>
-	<string>manual</string>
-	<key>signingCertificate</key>
-	<string>Apple Distribution</string>
-	<key>provisioningProfiles</key>
-	<dict>
-		<key>com.eff3.migralog</key>
-		<string>MigraLog App Store</string>
-	</dict>
+	<string>automatic</string>
+	<key>teamID</key>
+	<string>43DNX2P3T6</string>
 </dict>
 </plist>

--- a/mobile-apps/ios/MigraLog/App/Info.plist
+++ b/mobile-apps/ios/MigraLog/App/Info.plist
@@ -53,6 +53,8 @@
 	<string>MigraLog sends reminders for medications and daily check-ins.</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/mobile-apps/ios/MigraLog/LiveActivity/Shared/EpisodeActivityAttributes.swift
+++ b/mobile-apps/ios/MigraLog/LiveActivity/Shared/EpisodeActivityAttributes.swift
@@ -1,0 +1,41 @@
+import ActivityKit
+import Foundation
+
+/// ActivityKit contract for the "active migraine episode" Live Activity (#416).
+///
+/// This type is compiled into BOTH the MigraLog app target (which starts,
+/// updates and ends activities) and the MigraLogWidgets extension (which renders
+/// them on the Lock Screen and in the Dynamic Island). Keep it dependency-free —
+/// no app models, repositories or helpers — so it stays portable across targets.
+struct EpisodeActivityAttributes: ActivityAttributes {
+    /// The live, mutable portion of the activity. The app pushes a new value via
+    /// `Activity.update(...)` whenever the episode's surfaced state changes.
+    ///
+    /// Duration is intentionally NOT stored here: it is rendered live from
+    /// `startDate` with `Text(_:style:.timer)`, which ticks without an update.
+    struct ContentState: Codable, Hashable {
+        /// Last-logged pain intensity on the 0–10 scale, if any has been logged.
+        var currentIntensity: Double?
+
+        /// Display name of the most recent rescue-category dose, if any.
+        var lastRescueMedName: String?
+
+        /// When that most recent rescue dose was taken.
+        var lastRescueMedAt: Date?
+
+        /// Set once the episode ends. Drives the warm post-episode close state
+        /// that lingers briefly before the activity is dismissed.
+        var endedAt: Date?
+
+        var isEnded: Bool { endedAt != nil }
+
+        var hasRescueMed: Bool { lastRescueMedName != nil && lastRescueMedAt != nil }
+    }
+
+    /// Stable identifier of the episode this activity tracks. Used by deep links
+    /// so a tapped action routes back to the correct episode.
+    var episodeId: String
+
+    /// Episode start time. The duration badge counts up live from this value.
+    var startDate: Date
+}

--- a/mobile-apps/ios/MigraLog/LiveActivity/Shared/EpisodeActivityDeepLink.swift
+++ b/mobile-apps/ios/MigraLog/LiveActivity/Shared/EpisodeActivityDeepLink.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Builds the `migralog://` deep links used by the Live Activity quick actions.
+///
+/// Lives in shared sources so the widget extension (which builds the links) and
+/// the app (which parses them — see Phase 3 routing) agree on the URL shape. The
+/// links are inert until the app registers the `migralog` URL scheme and handles
+/// them in `onOpenURL`.
+enum EpisodeActivityDeepLink {
+    static let scheme = "migralog"
+
+    /// Log a rescue dose for the episode, pre-filtered to rescue categories.
+    static func logRescueMed(episodeId: String) -> URL {
+        build(host: "episode", path: episodeId, action: "log-med", query: ["category": "rescue"])
+    }
+
+    /// Open the intensity logger for the episode.
+    static func logIntensity(episodeId: String) -> URL {
+        build(host: "episode", path: episodeId, action: "log-intensity")
+    }
+
+    /// Open Episode Detail.
+    static func openEpisode(episodeId: String) -> URL {
+        build(host: "episode", path: episodeId, action: nil)
+    }
+
+    /// End the episode (the app presents a confirm before ending).
+    static func endEpisode(episodeId: String) -> URL {
+        build(host: "episode", path: episodeId, action: "end")
+    }
+
+    private static func build(host: String, path: String, action: String?, query: [String: String] = [:]) -> URL {
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = host
+        // Percent-encode the (untrusted-length) episode id path segment so an
+        // unexpected id never yields a nil URL that would crash the widget.
+        let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+        var fullPath = "/\(encoded)"
+        if let action { fullPath += "/\(action)" }
+        components.path = fullPath
+        if !query.isEmpty {
+            components.queryItems = query.map { URLQueryItem(name: $0.key, value: $0.value) }
+        }
+        // Fall back to a bare scheme URL rather than force-unwrapping, so a
+        // malformed component can never crash the extension.
+        return components.url ?? URL(string: "\(scheme)://\(host)")!
+    }
+}

--- a/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivity.swift
+++ b/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivity.swift
@@ -1,0 +1,116 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+/// Live Activity for an active migraine episode: Lock Screen banner plus the
+/// three Dynamic Island presentations (compact / expanded / minimal). The quick
+/// actions are `migralog://` deep links; they become functional once the app
+/// registers and routes the URL scheme (Phase 3).
+struct EpisodeLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: EpisodeActivityAttributes.self) { context in
+            EpisodeLockScreenView(context: context)
+                .activityBackgroundTint(Color.black.opacity(0.45))
+                .activitySystemActionForegroundColor(.white)
+        } dynamicIsland: { context in
+            dynamicIsland(for: context)
+        }
+    }
+
+    private func dynamicIsland(for context: ActivityViewContext<EpisodeActivityAttributes>) -> DynamicIsland {
+        DynamicIsland {
+            DynamicIslandExpandedRegion(.leading) {
+                ExpandedLeadingView(state: context.state)
+            }
+            DynamicIslandExpandedRegion(.trailing) {
+                ExpandedTrailingView(attributes: context.attributes, state: context.state)
+            }
+            DynamicIslandExpandedRegion(.center) {
+                LastMedLabel(state: context.state, alignment: .center)
+            }
+            DynamicIslandExpandedRegion(.bottom) {
+                if !context.state.isEnded {
+                    ActionRow(episodeId: context.attributes.episodeId)
+                }
+            }
+        } compactLeading: {
+            Image(systemName: "bolt.heart.fill")
+                .foregroundStyle(tint(for: context.state))
+        } compactTrailing: {
+            DurationText(attributes: context.attributes, state: context.state)
+                .font(.caption2.monospacedDigit())
+                .frame(maxWidth: 52)
+        } minimal: {
+            PulsingDot(color: tint(for: context.state))
+        }
+        .keylineTint(tint(for: context.state))
+    }
+
+    private func tint(for state: EpisodeActivityAttributes.ContentState) -> Color {
+        state.isEnded ? LiveActivityStyle.calmColor : LiveActivityStyle.activeColor
+    }
+}
+
+// MARK: - Lock Screen
+
+struct EpisodeLockScreenView: View {
+    let context: ActivityViewContext<EpisodeActivityAttributes>
+
+    var body: some View {
+        if context.state.isEnded {
+            EpisodeClosedView(attributes: context.attributes, state: context.state)
+                .padding()
+        } else {
+            activeBody
+                .padding()
+        }
+    }
+
+    private var activeBody: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                Label {
+                    Text("In migraine")
+                        .font(.subheadline.weight(.semibold))
+                } icon: {
+                    Image(systemName: "bolt.heart.fill")
+                        .foregroundStyle(LiveActivityStyle.activeColor)
+                }
+                Spacer()
+                DurationText(attributes: context.attributes, state: context.state)
+                    .font(.title3.monospacedDigit().weight(.semibold))
+                    .foregroundStyle(LiveActivityStyle.activeColor)
+            }
+            HStack(spacing: 12) {
+                if let intensity = LiveActivityStyle.intensityLabel(context.state.currentIntensity) {
+                    StatChip(systemImage: "gauge.with.dots.needle.50percent", text: intensity)
+                }
+                LastMedLabel(state: context.state, alignment: .leading)
+                Spacer()
+            }
+            ActionRow(episodeId: context.attributes.episodeId)
+        }
+    }
+}
+
+/// Warm post-episode close shown briefly before the activity is dismissed.
+struct EpisodeClosedView: View {
+    let attributes: EpisodeActivityAttributes
+    let state: EpisodeActivityAttributes.ContentState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(closingLine)
+                .font(.subheadline.weight(.semibold))
+            Text("Take care.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var closingLine: String {
+        guard let endedAt = state.endedAt else { return "Episode ended." }
+        let duration = LiveActivityStyle.durationLabel(from: attributes.startDate, to: endedAt)
+        return "Made it through \(duration)."
+    }
+}

--- a/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivityComponents.swift
+++ b/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivityComponents.swift
@@ -1,0 +1,145 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+// MARK: - Duration
+
+/// Live-ticking duration. While active it counts up from the episode start via
+/// `Text(_:style:.timer)`; once ended it shows the frozen total.
+struct DurationText: View {
+    let attributes: EpisodeActivityAttributes
+    let state: EpisodeActivityAttributes.ContentState
+
+    var body: some View {
+        if let endedAt = state.endedAt {
+            Text(LiveActivityStyle.durationLabel(from: attributes.startDate, to: endedAt))
+        } else {
+            Text(attributes.startDate, style: .timer)
+        }
+    }
+}
+
+// MARK: - Last rescue med
+
+struct LastMedLabel: View {
+    let state: EpisodeActivityAttributes.ContentState
+    var alignment: HorizontalAlignment = .leading
+
+    var body: some View {
+        if let name = state.lastRescueMedName, let takenAt = state.lastRescueMedAt {
+            VStack(alignment: alignment, spacing: 1) {
+                Text(name)
+                    .font(.caption.weight(.medium))
+                    .lineLimit(1)
+                Text(takenAt, style: .relative)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+// MARK: - Stat chip
+
+struct StatChip: View {
+    let systemImage: String
+    let text: String
+
+    var body: some View {
+        Label(text, systemImage: systemImage)
+            .font(.caption.weight(.medium))
+            .labelStyle(.titleAndIcon)
+    }
+}
+
+// MARK: - Quick actions
+
+/// The Log / Open / End deep-link action row shown on the Lock Screen and at the
+/// bottom of the expanded Dynamic Island.
+struct ActionRow: View {
+    let episodeId: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ActionLink(
+                title: "Log",
+                systemImage: "pills.fill",
+                url: EpisodeActivityDeepLink.logRescueMed(episodeId: episodeId)
+            )
+            ActionLink(
+                title: "Open",
+                systemImage: "chevron.right.circle.fill",
+                url: EpisodeActivityDeepLink.openEpisode(episodeId: episodeId)
+            )
+            ActionLink(
+                title: "End",
+                systemImage: "stop.circle.fill",
+                url: EpisodeActivityDeepLink.endEpisode(episodeId: episodeId),
+                tint: LiveActivityStyle.activeColor
+            )
+        }
+    }
+}
+
+struct ActionLink: View {
+    let title: String
+    let systemImage: String
+    let url: URL
+    var tint: Color = .secondary
+
+    var body: some View {
+        Link(destination: url) {
+            Label(title, systemImage: systemImage)
+                .font(.caption2.weight(.semibold))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 5)
+                .background(.quaternary, in: Capsule())
+                .foregroundStyle(tint == .secondary ? Color.primary : tint)
+        }
+    }
+}
+
+// MARK: - Dynamic Island expanded regions
+
+struct ExpandedLeadingView: View {
+    let state: EpisodeActivityAttributes.ContentState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Image(systemName: "bolt.heart.fill")
+                .foregroundStyle(state.isEnded ? LiveActivityStyle.calmColor : LiveActivityStyle.activeColor)
+            if let intensity = LiveActivityStyle.intensityLabel(state.currentIntensity) {
+                Text(intensity)
+                    .font(.caption.weight(.semibold))
+            }
+        }
+    }
+}
+
+struct ExpandedTrailingView: View {
+    let attributes: EpisodeActivityAttributes
+    let state: EpisodeActivityAttributes.ContentState
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            DurationText(attributes: attributes, state: state)
+                .font(.title3.monospacedDigit().weight(.semibold))
+                .foregroundStyle(state.isEnded ? LiveActivityStyle.calmColor : LiveActivityStyle.activeColor)
+            Text(state.isEnded ? "ended" : "elapsed")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Minimal
+
+struct PulsingDot: View {
+    let color: Color
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 8, height: 8)
+    }
+}

--- a/mobile-apps/ios/MigraLogWidgets/Info.plist
+++ b/mobile-apps/ios/MigraLogWidgets/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>MigraLog Widgets</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/mobile-apps/ios/MigraLogWidgets/LiveActivityStyle.swift
+++ b/mobile-apps/ios/MigraLogWidgets/LiveActivityStyle.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Shared visual constants and small formatting helpers for the episode Live
+/// Activity presentations. Kept local to the widget extension.
+enum LiveActivityStyle {
+    /// The "active episode" accent — a warm red used for the icon, keyline and
+    /// duration emphasis.
+    static let activeColor = Color(red: 0.84, green: 0.23, blue: 0.30)
+
+    /// A softer tint used for the post-episode close state.
+    static let calmColor = Color(red: 0.30, green: 0.55, blue: 0.50)
+
+    static func intensityLabel(_ intensity: Double?) -> String? {
+        guard let intensity else { return nil }
+        return "\(Int(intensity.rounded()))/10"
+    }
+
+    /// Whole-day/hour/minute label for a finished duration, e.g. "4h 20m".
+    static func durationLabel(from start: Date, to end: Date) -> String {
+        let seconds = max(0, Int(end.timeIntervalSince(start)))
+        let days = seconds / 86_400
+        let hours = (seconds % 86_400) / 3_600
+        let minutes = (seconds % 3_600) / 60
+        if days > 0 { return "\(days)d \(hours)h" }
+        if hours > 0 { return "\(hours)h \(minutes)m" }
+        return "\(minutes)m"
+    }
+}

--- a/mobile-apps/ios/MigraLogWidgets/MigraLogWidgetsBundle.swift
+++ b/mobile-apps/ios/MigraLogWidgets/MigraLogWidgetsBundle.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import WidgetKit
+
+/// Entry point for the MigraLog widget extension. For v1 it vends only the
+/// episode Live Activity; Home Screen / Lock Screen widgets are out of scope
+/// (#416).
+@main
+struct MigraLogWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        EpisodeLiveActivity()
+    }
+}

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -43,12 +43,16 @@ targets:
         TARGETED_DEVICE_FAMILY: "1,2"
       configs:
         Release:
-          CODE_SIGN_STYLE: Manual
+          # Automatic signing (App Store Connect API key, -allowProvisioningUpdates
+          # in release-pipeline.yml) so CI can manage profiles for both the app and
+          # the MigraLogWidgets extension without a hand-maintained profile per
+          # bundle id. See #416.
+          CODE_SIGN_STYLE: Automatic
           CODE_SIGN_IDENTITY: "Apple Distribution"
-          PROVISIONING_PROFILE_SPECIFIER: "MigraLog App Store"
     dependencies:
       - package: GRDB
       - package: Sentry
+      - target: MigraLogWidgets
     entitlements:
       path: MigraLog/App/MigraLog.entitlements
       properties:
@@ -58,6 +62,34 @@ targets:
           - CloudKit
         com.apple.developer.icloud-container-identifiers:
           - iCloud.com.eff3.migralog
+
+  MigraLogWidgets:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: MigraLogWidgets
+      # Shared ActivityKit contract — also compiled into the app target via its
+      # MigraLog/ source root. Both targets must see the same types.
+      - path: MigraLog/LiveActivity/Shared
+    settings:
+      base:
+        INFOPLIST_FILE: MigraLogWidgets/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: com.eff3.migralog.widgets
+        MARKETING_VERSION: "1.0.0"
+        CURRENT_PROJECT_VERSION: "1"
+        DEVELOPMENT_TEAM: "43DNX2P3T6"
+        CODE_SIGN_STYLE: Automatic
+        GENERATE_INFOPLIST_FILE: false
+        SWIFT_STRICT_CONCURRENCY: complete
+        TARGETED_DEVICE_FAMILY: "1,2"
+        SKIP_INSTALL: true
+      configs:
+        Release:
+          CODE_SIGN_STYLE: Automatic
+          CODE_SIGN_IDENTITY: "Apple Distribution"
+    dependencies:
+      - sdk: WidgetKit.framework
+      - sdk: SwiftUI.framework
 
   MigraLogTests:
     type: bundle.unit-test
@@ -89,6 +121,7 @@ schemes:
     build:
       targets:
         MigraLog: all
+        MigraLogWidgets: all
         MigraLogTests: [test]
         MigraLogUITests: [test]
     test:


### PR DESCRIPTION
## Phase 0+1 of #416 — Live Activities for active migraine episodes

First increment of the [v1 plan](https://github.com/vfilby/migralog/issues/416#issuecomment-4715226699). Scaffolds the widget extension and the ActivityKit contract; the activity is **not yet started by the app** (that's Phase 2) and the quick-action deep links are **inert until Phase 3** registers the URL scheme.

### What's here
- **`MigraLogWidgets` app-extension target** (XcodeGen), embedded in the app, with `NSSupportsLiveActivities` in the app Info.plist. No ActivityKit entitlement is required; no App Group (the widget only renders pushed `ContentState`).
- **Shared, dependency-free contract** — `EpisodeActivityAttributes` + `ContentState` (intensity, last rescue med, post-episode `endedAt`), compiled into both the app and the extension.
- **Live Activity views** — Lock Screen banner + Dynamic Island compact/expanded/minimal per the issue spec. Duration counts up live via `Text(_:style:.timer)`; warm post-episode close state ("Made it through 4h 20m. Take care.").
- **Quick-action deep-link builder** (`migralog://…`) used by the Log/Open/End buttons — shared so Phase 3's parser matches.

### Signing change (the notable bit)
A widget extension needs its own distribution provisioning profile, which the manual-signing release pipeline couldn't produce. Per the agreed approach, this **switches release signing to automatic** using the existing App Store Connect API key (`-allowProvisioningUpdates` on archive + export), so CI manages profiles for both the app and `com.eff3.migralog.widgets`. `ExportOptions.plist` and `project.yml` Release configs updated to match.

⚠️ The signing path can only be exercised by the **post-merge release pipeline** (PR CI builds the simulator unsigned). I'm watching that run to green after merge.

### Verification
- `xcodegen generate` + simulator build: **succeeds** (app + `MigraLogWidgets.appex` embedded).
- **Smoke** test plan (the PR gate): **passes** locally.
- Code-reviewed; review fixes applied (export-step `-allowProvisioningUpdates`, SwiftLint coverage for `MigraLogWidgets/`, crash-proofed URL builder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)