### PR TITLE
fix(ios): unblock automatic-signing archive (drop pinned identity) (#416)

### DIFF
--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -46,9 +46,11 @@ targets:
           # Automatic signing (App Store Connect API key, -allowProvisioningUpdates
           # in release-pipeline.yml) so CI can manage profiles for both the app and
           # the MigraLogWidgets extension without a hand-maintained profile per
-          # bundle id. See #416.
+          # bundle id. Do NOT pin CODE_SIGN_IDENTITY here: with automatic signing
+          # the archive action resolves the distribution identity itself, and a
+          # pinned "Apple Distribution" conflicts with automatic ("conflicting
+          # provisioning settings"). See #416.
           CODE_SIGN_STYLE: Automatic
-          CODE_SIGN_IDENTITY: "Apple Distribution"
     dependencies:
       - package: GRDB
       - package: Sentry
@@ -86,7 +88,6 @@ targets:
       configs:
         Release:
           CODE_SIGN_STYLE: Automatic
-          CODE_SIGN_IDENTITY: "Apple Distribution"
     dependencies:
       - sdk: WidgetKit.framework
       - sdk: SwiftUI.framework


### PR DESCRIPTION
Hotfix for the red **[iOS] Release Pipeline** on `main` after #509.

Phase 0 switched release signing to automatic but left `CODE_SIGN_IDENTITY: "Apple Distribution"` pinned on both targets' Release configs. Xcode rejects automatic-signing + a manually pinned distribution identity at archive time:

> MigraLog has conflicting provisioning settings. MigraLog is automatically signed for development, but a conflicting code signing identity Apple Distribution has been manually specified.

With automatic signing the **archive** action resolves the distribution identity on its own, and `-allowProvisioningUpdates` creates the App Store profiles for both `com.eff3.migralog` and `com.eff3.migralog.widgets`. Removing the pin clears the conflict.

Config-only; simulator build still green locally. The fix can only be fully validated by the post-merge release pipeline (PR CI is unsigned) — watching it to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)