### PR TITLE
fix(ios): sign at export (unsigned archive) so the release pipeline needs no dev cert (#416)

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -191,11 +191,15 @@ jobs:
           echo "APP_VERSION=$MARKETING" >> "$GITHUB_ENV"
           echo "APP_BUILD=$BUILD" >> "$GITHUB_ENV"
 
-      - name: Build archive
+      # Archive WITHOUT signing. Automatic signing during `archive` would try to
+      # resolve an "Apple Development" identity (which CI doesn't have — only the
+      # distribution cert is imported), so all signing is deferred to the export
+      # step below, which signs with the distribution cert and lets
+      # -allowProvisioningUpdates create the App Store profiles for both the app
+      # and the MigraLogWidgets extension via the API key. See #416.
+      - name: Build archive (unsigned — signing happens at export)
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: |
           security find-identity -v -p codesigning $RUNNER_TEMP/app-signing.keychain-db
           xcodebuild archive \
@@ -203,12 +207,8 @@ jobs:
             -project $PROJECT \
             -archivePath $ARCHIVE_PATH \
             -destination 'generic/platform=iOS' \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8 \
-            -authenticationKeyID "$ASC_KEY_ID" \
-            -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
+            CODE_SIGNING_ALLOWED=NO \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-            CODE_SIGN_STYLE=Automatic \
             MARKETING_VERSION="$APP_VERSION" \
             CURRENT_PROJECT_VERSION="$APP_BUILD"
 


### PR DESCRIPTION
Third and (reasoned) final signing fix for the red **[iOS] Release Pipeline** after the Live Activities widget extension landed.

### Root cause (confirmed across two failed deploys)
- With `CODE_SIGN_STYLE=Automatic`, `xcodebuild archive` resolves an **Apple Development** identity, but CI only imports the **distribution** cert → `No signing certificate "iOS Development" found` (target `MigraLogWidgets`).
- Manual signing can't help either: `-allowProvisioningUpdates` only *downloads* profiles for manual targets, so it can't create the brand-new `com.eff3.migralog.widgets` App Store profile.

### Fix (no new credentials)
Archive **unsigned** (`CODE_SIGNING_ALLOWED=NO`), and let the existing `-exportArchive` step do all signing. Export uses the imported **distribution** cert + `-allowProvisioningUpdates` + the App Store Connect API key to register the App IDs and create the App Store provisioning profiles for **both** bundle IDs. This is a standard CI pattern and needs no development cert or hand-made profile.

Workflow-only; can only be validated by the post-merge run, which I'm watching to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)