### PR TITLE
fix(ios): manual signing with per-bundle-id distribution profiles (#416) [BLOCKED on secret]

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -152,11 +152,26 @@ jobs:
           security list-keychain -d user -s "$KEYCHAIN_PATH"
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
-      # Automatic signing (#416): xcodebuild manages the distribution profiles for
-      # both the app and the MigraLogWidgets extension using the App Store Connect
-      # API key. The key is set up BEFORE the archive so -allowProvisioningUpdates
-      # can register/download profiles on the fly — no hand-maintained
-      # per-bundle-id provisioning profile secret required.
+      # Manual signing (#416): install the pre-created App Store distribution
+      # profiles for both bundle ids. The ASC API key cannot create profiles via
+      # cloud signing, so each is supplied as a base64-encoded secret.
+      - name: Install provisioning profiles
+        env:
+          APP_PROFILE: ${{ secrets.SWIFT_PROVISIONING_PROFILE }}
+          WIDGET_PROFILE: ${{ secrets.SWIFT_WIDGET_PROVISIONING_PROFILE }}
+        run: |
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          install_profile() {
+            local path="$RUNNER_TEMP/$2.mobileprovision"
+            echo -n "$1" | base64 --decode -o "$path"
+            local uuid
+            uuid=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< "$(security cms -D -i "$path")")
+            cp "$path" ~/Library/MobileDevice/Provisioning\ Profiles/${uuid}.mobileprovision
+          }
+          install_profile "$APP_PROFILE" app
+          install_profile "$WIDGET_PROFILE" widget
+
+      # The API key authenticates the TestFlight upload at export time.
       - name: Setup App Store Connect API key
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
@@ -191,13 +206,10 @@ jobs:
           echo "APP_VERSION=$MARKETING" >> "$GITHUB_ENV"
           echo "APP_BUILD=$BUILD" >> "$GITHUB_ENV"
 
-      # Archive WITHOUT signing. Automatic signing during `archive` would try to
-      # resolve an "Apple Development" identity (which CI doesn't have — only the
-      # distribution cert is imported), so all signing is deferred to the export
-      # step below, which signs with the distribution cert and lets
-      # -allowProvisioningUpdates create the App Store profiles for both the app
-      # and the MigraLogWidgets extension via the API key. See #416.
-      - name: Build archive (unsigned — signing happens at export)
+      # Archive with manual signing using the installed distribution profiles
+      # (project.yml pins CODE_SIGN_STYLE=Manual + the profile specifiers per
+      # target). See #416.
+      - name: Build archive
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
@@ -207,7 +219,6 @@ jobs:
             -project $PROJECT \
             -archivePath $ARCHIVE_PATH \
             -destination 'generic/platform=iOS' \
-            CODE_SIGNING_ALLOWED=NO \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
             MARKETING_VERSION="$APP_VERSION" \
             CURRENT_PROJECT_VERSION="$APP_BUILD"
@@ -221,7 +232,6 @@ jobs:
             -archivePath $ARCHIVE_PATH \
             -exportOptionsPlist ExportOptions.plist \
             -exportPath $EXPORT_PATH \
-            -allowProvisioningUpdates \
             -authenticationKeyPath ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8 \
             -authenticationKeyID "$ASC_KEY_ID" \
             -authenticationKeyIssuerID "$ASC_ISSUER_ID"

--- a/mobile-apps/ios/ExportOptions.plist
+++ b/mobile-apps/ios/ExportOptions.plist
@@ -6,14 +6,21 @@
 	<string>app-store-connect</string>
 	<key>destination</key>
 	<string>upload</string>
-	<!-- Automatic signing: xcodebuild manages distribution profiles for the app
-	     and the MigraLogWidgets extension via the App Store Connect API key passed
-	     to -exportArchive (and -allowProvisioningUpdates at archive time). This
-	     replaces the per-bundle-id manual profile map, which could not cover the
-	     widget extension's bundle id. See #416. -->
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>manual</string>
+	<key>signingCertificate</key>
+	<string>Apple Distribution</string>
 	<key>teamID</key>
 	<string>43DNX2P3T6</string>
+	<!-- Manual App Store distribution profiles, one per bundle id (the ASC API key
+	     cannot create them via cloud signing). Both are installed in CI from
+	     secrets. See #416. -->
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.eff3.migralog</key>
+		<string>MigraLog App Store</string>
+		<key>com.eff3.migralog.widgets</key>
+		<string>MigraLog Widgets App Store</string>
+	</dict>
 </dict>
 </plist>

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -43,14 +43,13 @@ targets:
         TARGETED_DEVICE_FAMILY: "1,2"
       configs:
         Release:
-          # Automatic signing (App Store Connect API key, -allowProvisioningUpdates
-          # in release-pipeline.yml) so CI can manage profiles for both the app and
-          # the MigraLogWidgets extension without a hand-maintained profile per
-          # bundle id. Do NOT pin CODE_SIGN_IDENTITY here: with automatic signing
-          # the archive action resolves the distribution identity itself, and a
-          # pinned "Apple Distribution" conflicts with automatic ("conflicting
-          # provisioning settings"). See #416.
-          CODE_SIGN_STYLE: Automatic
+          # Manual signing with pre-created App Store distribution profiles
+          # installed in CI (release-pipeline.yml). The App Store Connect API key
+          # cannot do cloud signing, so each bundle id needs its own profile. See
+          # #416.
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: "Apple Distribution"
+          PROVISIONING_PROFILE_SPECIFIER: "MigraLog App Store"
     dependencies:
       - package: GRDB
       - package: Sentry
@@ -87,7 +86,9 @@ targets:
         SKIP_INSTALL: true
       configs:
         Release:
-          CODE_SIGN_STYLE: Automatic
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: "Apple Distribution"
+          PROVISIONING_PROFILE_SPECIFIER: "MigraLog Widgets App Store"
     dependencies:
       - sdk: WidgetKit.framework
       - sdk: SwiftUI.framework


### PR DESCRIPTION
⛔️ **DO NOT MERGE until the `SWIFT_WIDGET_PROVISIONING_PROFILE` repo secret is added** (an App Store distribution profile named exactly `MigraLog Widgets App Store` for `com.eff3.migralog.widgets`). Merging before then will fail the release pipeline again.

### Why
The ASC API key can upload builds but **cannot create signing profiles** (cloud signing), which is why automatic signing failed for the new widget bundle id. This reverts to **manual signing with pre-created App Store distribution profiles**, one per bundle id — exactly how the app target was already signed.

### Changes
- `project.yml`: both targets' Release config → `Manual` + `Apple Distribution` + profile specifier (`MigraLog App Store` for the app, `MigraLog Widgets App Store` for the widget).
- `ExportOptions.plist`: manual, mapping both bundle ids to their profiles.
- `release-pipeline.yml`: install **both** profiles from secrets (`SWIFT_PROVISIONING_PROFILE` + new `SWIFT_WIDGET_PROVISIONING_PROFILE`); manual archive + export; the API key now only authenticates the TestFlight upload.

### To unblock (one-time)
1. Apple Developer portal → register App ID `com.eff3.migralog.widgets`.
2. Create an **App Store** distribution provisioning profile for it named `MigraLog Widgets App Store`.
3. `base64 -i MigraLog_Widgets_App_Store.mobileprovision | pbcopy` → add as repo secret `SWIFT_WIDGET_PROVISIONING_PROFILE`.
4. Tell me, and I'll enable auto-merge and watch it deploy green.

Simulator build is green locally; the signing path is validated only by the post-merge release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)