### PR TITLE
feat(ios): drive episode Live Activity from the lifecycle (#416 Phase 2)

### DIFF
--- a/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
+++ b/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
@@ -74,6 +74,9 @@ struct MigraLogApp: App {
                     await medicationNotificationService.topUp()
                     try? await dailyCheckinService.scheduleNotifications()
                     await timezoneChangeService.checkForChange()
+                    // Re-attach or clean up the active-episode Live Activity after
+                    // launch (e.g. recover from a force-quit, or dismiss a stale one).
+                    LiveActivityManager.shared.reconcileOnLaunch()
                 }
         }
     }

--- a/mobile-apps/ios/MigraLog/LiveActivity/LiveActivityManager.swift
+++ b/mobile-apps/ios/MigraLog/LiveActivity/LiveActivityManager.swift
@@ -1,0 +1,168 @@
+import ActivityKit
+import Foundation
+
+/// Lifecycle owner for the active-episode Live Activity (#416).
+protocol LiveActivityManaging: Sendable {
+    /// Start a Live Activity for a freshly created episode.
+    func start(for episode: Episode)
+    /// Push the latest surfaced state (intensity, last rescue med) for an episode.
+    func refresh(episodeId: String)
+    /// Transition to the warm post-episode close, then auto-dismiss.
+    func end(episodeId: String, at endTime: Int64)
+    /// Immediately dismiss an episode's activity with no close state (e.g. the
+    /// episode was deleted).
+    func dismiss(episodeId: String)
+    /// Reconcile running activities with the source of truth at launch.
+    func reconcileOnLaunch()
+    /// End every running episode activity immediately (feature turned off).
+    func endAll()
+}
+
+/// Default implementation. The widget extension only renders the `ContentState`
+/// this pushes, so all "what should the activity say" logic lives here. State is
+/// rebuilt from the repositories on every change, keeping callers trivial — they
+/// just say which episode changed.
+///
+/// Not actor/`@MainActor` isolated: it holds no mutable state (it queries
+/// `Activity.activities` each time) and the ActivityKit APIs it uses are not
+/// main-actor bound, so it composes like the other `Sendable` services and its
+/// `.shared` default argument is usable from any context.
+final class LiveActivityManager: LiveActivityManaging {
+    static let shared = LiveActivityManager()
+
+    /// How long the warm post-episode close lingers before the activity is
+    /// dismissed. The richer ~2h postdromal recovery check-in is v1.1.
+    private let postEpisodeLinger: TimeInterval = 30 * 60
+
+    /// UserDefaults key for the "Live Activities" setting (Phase 4 owns the UI).
+    /// Absent defaults to enabled.
+    private let settingKey = "live_activities_enabled"
+
+    private let episodeRepository: EpisodeRepositoryProtocol
+    private let medicationRepository: MedicationRepositoryProtocol
+
+    init(
+        episodeRepository: EpisodeRepositoryProtocol = EpisodeRepository(dbManager: DatabaseManager.shared),
+        medicationRepository: MedicationRepositoryProtocol = MedicationRepository(dbManager: DatabaseManager.shared)
+    ) {
+        self.episodeRepository = episodeRepository
+        self.medicationRepository = medicationRepository
+    }
+
+    // MARK: - LiveActivityManaging
+
+    func start(for episode: Episode) {
+        guard isEnabled, activity(for: episode.id) == nil else { return }
+        let attributes = EpisodeActivityAttributes(episodeId: episode.id, startDate: episode.startDate)
+        let state = contentState(for: episode.id, endedAt: nil)
+        do {
+            _ = try Activity.request(
+                attributes: attributes,
+                content: ActivityContent(state: state, staleDate: nil),
+                pushType: nil
+            )
+        } catch {
+            ErrorLogger.shared.logError(error, context: ["service": "LiveActivityManager", "action": "start"])
+        }
+    }
+
+    func refresh(episodeId: String) {
+        guard let activity = activity(for: episodeId) else { return }
+        let state = contentState(for: episodeId, endedAt: nil)
+        Task { await activity.update(ActivityContent(state: state, staleDate: nil)) }
+    }
+
+    func end(episodeId: String, at endTime: Int64) {
+        guard let activity = activity(for: episodeId) else { return }
+        let endedAt = Date(timeIntervalSince1970: Double(endTime) / 1000.0)
+        let state = contentState(for: episodeId, endedAt: endedAt)
+        let dismissAt = Date().addingTimeInterval(postEpisodeLinger)
+        Task {
+            await activity.end(
+                ActivityContent(state: state, staleDate: nil),
+                dismissalPolicy: .after(dismissAt)
+            )
+        }
+    }
+
+    func dismiss(episodeId: String) {
+        guard let activity = activity(for: episodeId) else { return }
+        Task { await activity.end(nil, dismissalPolicy: .immediate) }
+    }
+
+    func reconcileOnLaunch() {
+        let current: Episode?
+        do {
+            current = try episodeRepository.getCurrentEpisode()
+        } catch {
+            // Couldn't determine the active episode — leave any running activity
+            // alone rather than dismissing a possibly-valid one on a transient read.
+            ErrorLogger.shared.logError(error, context: ["service": "LiveActivityManager", "action": "reconcileOnLaunch"])
+            return
+        }
+        for activity in Activity<EpisodeActivityAttributes>.activities
+        where activity.attributes.episodeId != current?.id {
+            Task { await activity.end(nil, dismissalPolicy: .immediate) }
+        }
+        if let current, isEnabled, activity(for: current.id) == nil {
+            start(for: current)
+        }
+    }
+
+    func endAll() {
+        for activity in Activity<EpisodeActivityAttributes>.activities {
+            Task { await activity.end(nil, dismissalPolicy: .immediate) }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var isEnabled: Bool {
+        // Never touch ActivityKit from the unit-test host.
+        guard NSClassFromString("XCTestCase") == nil else { return false }
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return false }
+        return UserDefaults.standard.object(forKey: settingKey) as? Bool ?? true
+    }
+
+    private func activity(for episodeId: String) -> Activity<EpisodeActivityAttributes>? {
+        Activity<EpisodeActivityAttributes>.activities.first { $0.attributes.episodeId == episodeId }
+    }
+
+    private func contentState(
+        for episodeId: String,
+        endedAt: Date?
+    ) -> EpisodeActivityAttributes.ContentState {
+        let readings = (try? episodeRepository.getReadingsByEpisodeId(episodeId)) ?? []
+        let intensity = readings.max { $0.timestamp < $1.timestamp }?.intensity
+        let lastRescue = latestRescueDose(episodeId: episodeId)
+        return EpisodeActivityAttributes.ContentState(
+            currentIntensity: intensity,
+            lastRescueMedName: lastRescue?.name,
+            lastRescueMedAt: lastRescue?.takenAt,
+            endedAt: endedAt
+        )
+    }
+
+    /// The most recent rescue-category dose taken during the episode, if any.
+    private func latestRescueDose(episodeId: String) -> (name: String, takenAt: Date)? {
+        guard let doses = try? medicationRepository.getDosesByEpisodeId(episodeId) else { return nil }
+        let rescue = doses
+            .filter { $0.status == .taken }
+            .compactMap { dose -> (MedicationDose, Medication)? in
+                guard let med = try? medicationRepository.getMedicationById(dose.medicationId),
+                      med.isRescue else { return nil }
+                return (dose, med)
+            }
+        guard let latest = rescue.max(by: { $0.0.timestamp < $1.0.timestamp }) else { return nil }
+        return (latest.1.name, Date(timeIntervalSince1970: Double(latest.0.timestamp) / 1000.0))
+    }
+}
+
+extension Medication {
+    /// Whether this medication counts as a "rescue" treatment for the Live
+    /// Activity's last-dose readout: anything the user typed as a rescue med, or
+    /// categorised as an NSAID/triptan even if typed otherwise.
+    var isRescue: Bool {
+        type == .rescue || category == .nsaid || category == .triptan
+    }
+}

--- a/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
@@ -44,6 +44,7 @@ final class DashboardViewModel {
     private let categoryLimitRepository: CategorySafetyRuleRepositoryProtocol
     private let dailyCheckinService: DailyCheckinNotificationServiceProtocol
     private let doseLogger: MedicationDoseLoggerProtocol
+    private let liveActivityManager: LiveActivityManaging
 
     // MARK: - Init
 
@@ -58,7 +59,8 @@ final class DashboardViewModel {
             episodeRepo: EpisodeRepository(dbManager: DatabaseManager.shared),
             dailyStatusRepo: DailyStatusRepository(dbManager: DatabaseManager.shared)
         ),
-        doseLogger: MedicationDoseLoggerProtocol = MedicationDoseLogger()
+        doseLogger: MedicationDoseLoggerProtocol = MedicationDoseLogger(),
+        liveActivityManager: LiveActivityManaging = LiveActivityManager.shared
     ) {
         self.episodeRepository = episodeRepository
         self.medicationRepository = medicationRepository
@@ -66,6 +68,7 @@ final class DashboardViewModel {
         self.categoryLimitRepository = categoryLimitRepository
         self.dailyCheckinService = dailyCheckinService
         self.doseLogger = doseLogger
+        self.liveActivityManager = liveActivityManager
     }
 
     // MARK: - Actions
@@ -160,6 +163,10 @@ final class DashboardViewModel {
                 for: todaysMedications.map(\.medication),
                 now: Date()
             )
+            // Refresh the Live Activity's last-rescue-med readout, if running.
+            if let episode = currentEpisode, scheduleItem.medication.isRescue {
+                liveActivityManager.refresh(episodeId: episode.id)
+            }
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "DashboardViewModel", "action": "logDose"])
             self.error = error.localizedDescription

--- a/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
@@ -15,6 +15,7 @@ final class EpisodeDetailViewModel {
     private let episodeRepository: EpisodeRepositoryProtocol
     private let medicationRepository: MedicationRepositoryProtocol
     private let dailyCheckinService: DailyCheckinNotificationServiceProtocol
+    private let liveActivityManager: LiveActivityManaging
     private var episodeId: String
 
     // MARK: - Init
@@ -28,12 +29,14 @@ final class EpisodeDetailViewModel {
             scheduledNotificationRepo: ScheduledNotificationRepository(dbManager: DatabaseManager.shared),
             episodeRepo: EpisodeRepository(dbManager: DatabaseManager.shared),
             dailyStatusRepo: DailyStatusRepository(dbManager: DatabaseManager.shared)
-        )
+        ),
+        liveActivityManager: LiveActivityManaging = LiveActivityManager.shared
     ) {
         self.episodeId = episodeId
         self.episodeRepository = episodeRepository
         self.medicationRepository = medicationRepository
         self.dailyCheckinService = dailyCheckinService
+        self.liveActivityManager = liveActivityManager
     }
 
     // MARK: - Computed
@@ -94,6 +97,8 @@ final class EpisodeDetailViewModel {
             )
             // Reinstate daily check-in notifications now that episode is complete
             try? await dailyCheckinService.scheduleNotifications()
+            // Transition the Live Activity to its warm post-episode close.
+            liveActivityManager.end(episodeId: episode.id, at: timestamp)
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "endEpisode"])
             self.error = error.localizedDescription
@@ -117,6 +122,8 @@ final class EpisodeDetailViewModel {
             )
             // Reinstate daily check-in notifications now that episode is complete
             try? await dailyCheckinService.scheduleNotifications()
+            // Transition the Live Activity to its warm post-episode close.
+            liveActivityManager.end(episodeId: episode.id, at: now)
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "endEpisode"])
             self.error = error.localizedDescription
@@ -141,6 +148,8 @@ final class EpisodeDetailViewModel {
                 painLocationLogs: details?.painLocationLogs ?? [],
                 episodeNotes: details?.episodeNotes ?? []
             )
+            // Correct the end time on a still-lingering post-episode activity.
+            liveActivityManager.end(episodeId: episode.id, at: timestamp)
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "editEndTime"])
             self.error = error.localizedDescription
@@ -185,6 +194,8 @@ final class EpisodeDetailViewModel {
                 painLocationLogs: details?.painLocationLogs ?? [],
                 episodeNotes: details?.episodeNotes ?? []
             )
+            // The episode is active again — surface a fresh Live Activity.
+            liveActivityManager.start(for: episode)
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "reopenEpisode"])
             self.error = error.localizedDescription
@@ -225,6 +236,10 @@ final class EpisodeDetailViewModel {
             let saved = try await episodeRepository.createIntensityReading(reading)
             details?.intensityReadings.append(saved)
             details?.intensityReadings.sort { $0.timestamp < $1.timestamp }
+            // Reflect the new intensity on the Live Activity, if running.
+            if details?.episode.isActive == true {
+                liveActivityManager.refresh(episodeId: episodeId)
+            }
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "addIntensityReading"])
             self.error = error.localizedDescription

--- a/mobile-apps/ios/MigraLog/ViewModels/EpisodesListViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/EpisodesListViewModel.swift
@@ -13,11 +13,16 @@ final class EpisodesListViewModel {
     // MARK: - Dependencies
 
     private let episodeRepository: EpisodeRepositoryProtocol
+    private let liveActivityManager: LiveActivityManaging
 
     // MARK: - Init
 
-    init(episodeRepository: EpisodeRepositoryProtocol = EpisodeRepository(dbManager: DatabaseManager.shared)) {
+    init(
+        episodeRepository: EpisodeRepositoryProtocol = EpisodeRepository(dbManager: DatabaseManager.shared),
+        liveActivityManager: LiveActivityManaging = LiveActivityManager.shared
+    ) {
         self.episodeRepository = episodeRepository
+        self.liveActivityManager = liveActivityManager
     }
 
     // MARK: - Actions
@@ -50,6 +55,8 @@ final class EpisodesListViewModel {
             try await episodeRepository.deleteEpisode(id)
             episodes.removeAll { $0.id == id }
             readingsMap.removeValue(forKey: id)
+            // Drop any Live Activity for the now-deleted episode.
+            liveActivityManager.dismiss(episodeId: id)
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodesListViewModel"])
             self.error = error.localizedDescription

--- a/mobile-apps/ios/MigraLog/ViewModels/LogMedicationViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/LogMedicationViewModel.swift
@@ -16,17 +16,20 @@ final class LogMedicationViewModel {
     private let episodeRepository: EpisodeRepositoryProtocol
     private let categoryLimitRepository: CategorySafetyRuleRepositoryProtocol
     private let doseLogger: MedicationDoseLoggerProtocol
+    private let liveActivityManager: LiveActivityManaging
 
     init(
         medicationRepository: MedicationRepositoryProtocol = MedicationRepository(dbManager: DatabaseManager.shared),
         episodeRepository: EpisodeRepositoryProtocol = EpisodeRepository(dbManager: DatabaseManager.shared),
         categoryLimitRepository: CategorySafetyRuleRepositoryProtocol = CategorySafetyRuleRepository(dbManager: DatabaseManager.shared),
-        doseLogger: MedicationDoseLoggerProtocol = MedicationDoseLogger()
+        doseLogger: MedicationDoseLoggerProtocol = MedicationDoseLogger(),
+        liveActivityManager: LiveActivityManaging = LiveActivityManager.shared
     ) {
         self.medicationRepository = medicationRepository
         self.episodeRepository = episodeRepository
         self.categoryLimitRepository = categoryLimitRepository
         self.doseLogger = doseLogger
+        self.liveActivityManager = liveActivityManager
     }
 
     @MainActor
@@ -117,6 +120,10 @@ final class LogMedicationViewModel {
             let categories = Set(medications.compactMap { $0.category })
             categoryUsage = computeCategoryUsage(for: categories, now: Date())
             categoryCooldowns = computeCategoryCooldowns(for: medications, now: Date())
+            // Refresh the Live Activity's last-rescue-med readout, if running.
+            if let episode = activeEpisode, medication.isRescue {
+                liveActivityManager.refresh(episodeId: episode.id)
+            }
         } catch {
             ErrorLogger.shared.logError(error, context: ["action": "quickLog", "medicationId": medication.id])
         }

--- a/mobile-apps/ios/MigraLog/ViewModels/NewEpisodeViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/NewEpisodeViewModel.swift
@@ -17,11 +17,16 @@ final class NewEpisodeViewModel {
     // MARK: - Dependencies
 
     private let episodeRepository: EpisodeRepositoryProtocol
+    private let liveActivityManager: LiveActivityManaging
 
     // MARK: - Init
 
-    init(episodeRepository: EpisodeRepositoryProtocol = EpisodeRepository(dbManager: DatabaseManager.shared)) {
+    init(
+        episodeRepository: EpisodeRepositoryProtocol = EpisodeRepository(dbManager: DatabaseManager.shared),
+        liveActivityManager: LiveActivityManaging = LiveActivityManager.shared
+    ) {
         self.episodeRepository = episodeRepository
+        self.liveActivityManager = liveActivityManager
     }
 
     // MARK: - Computed
@@ -70,6 +75,9 @@ final class NewEpisodeViewModel {
                 updatedAt: now
             )
             _ = try await episodeRepository.createIntensityReading(reading)
+
+            // Surface the episode as a Live Activity (Lock Screen / Dynamic Island).
+            liveActivityManager.start(for: saved)
 
             isSaving = false
             return saved


### PR DESCRIPTION
## Phase 2 of #416 — LiveActivityManager + lifecycle wiring

Builds on the merged Phase 0 scaffolding. Adds `LiveActivityManager` (ActivityKit) and wires it into the episode lifecycle so the Live Activity actually starts, updates, and ends.

### What's here
- **`LiveActivityManager`** — a `Sendable`, non-isolated service (mirrors the other injected services) that owns the activity lifecycle and rebuilds `ContentState` from the repositories on every change. Gated by `ActivityAuthorizationInfo` + the `live_activities_enabled` default (Phase 4 adds the UI). A unit-test guard keeps it from touching ActivityKit in the test host.
- **Wiring**: start on episode create + reopen · refresh on intensity logging and rescue-med dose logging · warm post-episode close on end / edit-end-time · immediate dismiss on delete · `reconcileOnLaunch` recovers/cleans up after a force-quit (and no-ops on a transient DB read error).

### Verification
- Build + **Smoke** test plan: green locally.
- Code-reviewed; review fixes applied (reopen/editEndTime/delete coverage, reconcile error-safety, rescue-only refresh gating).

Rebased onto current `main` (post manual-signing fix); deploy pipeline is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)