### PR TITLE
feat(ios): route Live Activity deep links into the app (#416 Phase 3)

### DIFF
--- a/mobile-apps/ios/MigraLog/App/ContentView.swift
+++ b/mobile-apps/ios/MigraLog/App/ContentView.swift
@@ -43,6 +43,11 @@ struct ContentView: View {
             )
         }
         .task { syncService.startAutoSync() }
+        .onOpenURL { url in
+            // Live Activity quick actions open migralog:// URLs; route them into
+            // navigation state. AppState ignores anything it doesn't recognize.
+            appState.handle(url: url)
+        }
         .onChange(of: scenePhase) { _, phase in
             switch phase {
             case .active:

--- a/mobile-apps/ios/MigraLog/App/Info.plist
+++ b/mobile-apps/ios/MigraLog/App/Info.plist
@@ -20,6 +20,20 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<!-- Custom URL scheme for Live Activity quick-action deep links (#416).
+	     The widget builds migralog:// URLs (see EpisodeActivityDeepLink); the app
+	     parses them in ContentView.onOpenURL via DeepLinkParser. -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.eff3.migralog.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>migralog</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
+++ b/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
@@ -114,6 +114,12 @@ final class AppState {
     /// Selection for the Medications split view (iPad regular width).
     var selectedMedicationId: String?
 
+    /// A surface an open Episode Detail should present once it loads, set when a
+    /// Live Activity deep link asks for more than just opening the episode
+    /// (log a rescue med, log intensity, or end the episode). `EpisodeDetailScreen`
+    /// consumes and clears this so it fires once per link.
+    var pendingEpisodeAction: PendingEpisodeAction?
+
     /// Switch to the Episodes tab with the given episode selected.
     func showEpisode(_ episodeId: String) {
         selectedEpisodeId = episodeId
@@ -124,6 +130,33 @@ final class AppState {
     func showMedication(_ medicationId: String) {
         selectedMedicationId = medicationId
         selectedTab = .medications
+    }
+
+    // MARK: - Deep links
+
+    /// Route an incoming `migralog://` URL (from a Live Activity quick action).
+    /// Non-`migralog` or malformed URLs are ignored. Every recognized target
+    /// selects the episode in the Episodes tab; sub-actions additionally queue a
+    /// surface for `EpisodeDetailScreen` to present.
+    func handle(url: URL) {
+        guard let target = DeepLinkParser.parse(url) else { return }
+        route(to: target)
+    }
+
+    /// Apply a parsed deep-link target to navigation state. Split out from
+    /// `handle(url:)` so tests can exercise routing without constructing URLs.
+    func route(to target: DeepLinkTarget) {
+        showEpisode(target.episodeId)
+        switch target {
+        case .openEpisode:
+            pendingEpisodeAction = nil
+        case .logRescueMed:
+            pendingEpisodeAction = .logMedication
+        case .logIntensity:
+            pendingEpisodeAction = .logIntensity
+        case .endEpisode:
+            pendingEpisodeAction = .endConfirm
+        }
     }
 
     private let onboardingKey = "isOnboardingComplete"

--- a/mobile-apps/ios/MigraLog/LiveActivity/DeepLinkRouter.swift
+++ b/mobile-apps/ios/MigraLog/LiveActivity/DeepLinkRouter.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// A typed destination parsed from an incoming `migralog://` deep link.
+///
+/// The Live Activity quick actions (see `EpisodeActivityDeepLink`) emit URLs
+/// that the app receives via `onOpenURL`. `DeepLinkParser` converts those URLs
+/// into one of these cases so the UI can route without string-matching in a view.
+enum DeepLinkTarget: Equatable, Sendable {
+    /// Open the Log Medication surface for the episode, filtered to rescue meds.
+    case logRescueMed(episodeId: String)
+    /// Open the intensity logger (`LogUpdateScreen`) for the episode.
+    case logIntensity(episodeId: String)
+    /// Open Episode Detail.
+    case openEpisode(episodeId: String)
+    /// Open Episode Detail and present the end-episode confirm.
+    case endEpisode(episodeId: String)
+
+    /// The episode the target acts on. Every case carries one.
+    var episodeId: String {
+        switch self {
+        case let .logRescueMed(episodeId),
+             let .logIntensity(episodeId),
+             let .openEpisode(episodeId),
+             let .endEpisode(episodeId):
+            return episodeId
+        }
+    }
+}
+
+/// A surface `EpisodeDetailScreen` should present after a deep link selects an
+/// episode. Kept distinct from `DeepLinkTarget` (which still carries the episode
+/// id and is the parser's output) so the detail screen only observes the small
+/// "what to show" decision.
+enum PendingEpisodeAction: Equatable, Sendable {
+    /// Present the rescue-filtered Log Medication sheet.
+    case logMedication
+    /// Present the intensity logger (`LogUpdateScreen`).
+    case logIntensity
+    /// Present the end-episode confirmation.
+    case endConfirm
+}
+
+/// Pure, `Sendable` parser for `migralog://` deep links.
+///
+/// Kept free of any view/state so it is trivially unit-testable. Malformed,
+/// non-`migralog`, or unrecognized URLs return `nil` rather than throwing, so the
+/// caller can ignore them silently.
+enum DeepLinkParser {
+    /// Parse an incoming URL into a `DeepLinkTarget`, or `nil` if it is not a
+    /// link we recognize.
+    ///
+    /// Recognized shapes (host `episode`):
+    /// - `migralog://episode/<id>/log-med?category=rescue` → `.logRescueMed`
+    /// - `migralog://episode/<id>/log-intensity`           → `.logIntensity`
+    /// - `migralog://episode/<id>`                         → `.openEpisode`
+    /// - `migralog://episode/<id>/end`                     → `.endEpisode`
+    static func parse(_ url: URL) -> DeepLinkTarget? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              components.scheme == EpisodeActivityDeepLink.scheme,
+              components.host == "episode" else {
+            return nil
+        }
+
+        // Split on "/" and drop empties so the leading slash and any trailing
+        // slash don't produce blank segments; first segment is the episode id.
+        let segments = components.path
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+
+        guard let episodeId = segments.first, !episodeId.isEmpty else {
+            return nil
+        }
+
+        // No action segment → open detail.
+        guard segments.count > 1 else {
+            return .openEpisode(episodeId: episodeId)
+        }
+
+        switch segments[1] {
+        case "log-med":
+            // Only the rescue category is supported today; ignore an unexpected
+            // `category` value gracefully and still open the rescue surface.
+            return .logRescueMed(episodeId: episodeId)
+        case "log-intensity":
+            return .logIntensity(episodeId: episodeId)
+        case "end":
+            return .endEpisode(episodeId: episodeId)
+        default:
+            return nil
+        }
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/AdaptiveNavigation.swift
+++ b/mobile-apps/ios/MigraLog/Views/AdaptiveNavigation.swift
@@ -84,10 +84,24 @@ struct EpisodesTab: View {
                 }
             }
         } else {
-            NavigationStack {
+            // iPhone: a path-bound stack so taps push detail and a Live Activity
+            // deep link (which sets `selectedEpisodeId`) pushes it programmatically.
+            NavigationStack(path: episodePath(appState: appState)) {
                 EpisodesScreen()
+                    .navigationDestination(for: String.self) { episodeId in
+                        EpisodeDetailScreen(episodeId: episodeId)
+                    }
             }
         }
+    }
+
+    /// Bridges `appState.selectedEpisodeId` to a `NavigationPath`-style binding:
+    /// a non-nil id means the detail is pushed; popping clears the selection.
+    private func episodePath(appState: AppState) -> Binding<[String]> {
+        Binding(
+            get: { appState.selectedEpisodeId.map { [$0] } ?? [] },
+            set: { appState.selectedEpisodeId = $0.last }
+        )
     }
 }
 

--- a/mobile-apps/ios/MigraLog/Views/AdaptiveNavigation.swift
+++ b/mobile-apps/ios/MigraLog/Views/AdaptiveNavigation.swift
@@ -74,7 +74,7 @@ struct EpisodesTab: View {
                     )
             } detail: {
                 if let episodeId = appState.selectedEpisodeId {
-                    EpisodeDetailScreen(episodeId: episodeId)
+                    EpisodeDetailScreen(episodeId: episodeId, consumesDeepLinks: true)
                 } else {
                     ContentUnavailableView(
                         "No Episode Selected",
@@ -89,7 +89,7 @@ struct EpisodesTab: View {
             NavigationStack(path: episodePath(appState: appState)) {
                 EpisodesScreen()
                     .navigationDestination(for: String.self) { episodeId in
-                        EpisodeDetailScreen(episodeId: episodeId)
+                        EpisodeDetailScreen(episodeId: episodeId, consumesDeepLinks: true)
                     }
             }
         }

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -2,11 +2,13 @@ import SwiftUI
 
 struct EpisodeDetailScreen: View {
     let episodeId: String
+    @Environment(AppState.self) private var appState
     @State private var viewModel = EpisodeDetailViewModel()
     @State private var showEndTimePicker = false
     @State private var showEditSheet = false
     @State private var showLogUpdate = false
     @State private var showLogMedication = false
+    @State private var showEndConfirm = false
     @State private var customEndTime = Date()
 
     // Timeline editing state
@@ -161,8 +163,36 @@ struct EpisodeDetailScreen: View {
         } message: {
             Text("This cannot be undone.")
         }
+        .confirmationDialog("End this episode?", isPresented: $showEndConfirm, titleVisibility: .visible) {
+            Button("End Episode", role: .destructive) {
+                Task { await viewModel.endEpisode(episodeId, at: TimestampHelper.now) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This marks the episode as ended now.")
+        }
         .task(id: episodeId) {
             await viewModel.loadEpisode(episodeId)
+        }
+        // A Live Activity deep link may queue a surface to present. Fire it once the
+        // episode is loaded, and again if a new link arrives while we're on screen.
+        .onChange(of: viewModel.details?.episode.id) { _, _ in consumePendingAction() }
+        .onChange(of: appState.pendingEpisodeAction) { _, _ in consumePendingAction() }
+    }
+
+    /// Present the surface a deep link requested, then clear the request so it
+    /// doesn't re-fire. Only acts when the loaded episode matches this screen.
+    private func consumePendingAction() {
+        guard let action = appState.pendingEpisodeAction,
+              viewModel.details?.episode.id == episodeId else { return }
+        appState.pendingEpisodeAction = nil
+        switch action {
+        case .logMedication:
+            showLogMedication = true
+        case .logIntensity:
+            showLogUpdate = true
+        case .endConfirm:
+            showEndConfirm = true
         }
     }
 

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 struct EpisodeDetailScreen: View {
     let episodeId: String
+    /// Whether this instance should consume Live Activity deep-link actions
+    /// (`pendingEpisodeAction`). Only the Episodes-tab instances set this true so
+    /// a same-episode detail alive in another tab can't steal the action. See #416.
+    var consumesDeepLinks: Bool = false
     @Environment(AppState.self) private var appState
     @State private var viewModel = EpisodeDetailViewModel()
     @State private var showEndTimePicker = false
@@ -173,6 +177,11 @@ struct EpisodeDetailScreen: View {
         }
         .task(id: episodeId) {
             await viewModel.loadEpisode(episodeId)
+            // If a deep link targeted an episode that no longer exists, clear the
+            // queued action so it can't linger and fire on an unrelated screen.
+            if consumesDeepLinks, viewModel.details == nil {
+                appState.pendingEpisodeAction = nil
+            }
         }
         // A Live Activity deep link may queue a surface to present. Fire it once the
         // episode is loaded, and again if a new link arrives while we're on screen.
@@ -181,10 +190,13 @@ struct EpisodeDetailScreen: View {
     }
 
     /// Present the surface a deep link requested, then clear the request so it
-    /// doesn't re-fire. Only acts when the loaded episode matches this screen.
+    /// doesn't re-fire. Only the Episodes-tab instance acts (`consumesDeepLinks`),
+    /// and only when the loaded episode matches this screen.
     private func consumePendingAction() {
-        guard let action = appState.pendingEpisodeAction,
-              viewModel.details?.episode.id == episodeId else { return }
+        guard consumesDeepLinks,
+              let action = appState.pendingEpisodeAction,
+              let episode = viewModel.details?.episode,
+              episode.id == episodeId else { return }
         appState.pendingEpisodeAction = nil
         switch action {
         case .logMedication:
@@ -192,7 +204,9 @@ struct EpisodeDetailScreen: View {
         case .logIntensity:
             showLogUpdate = true
         case .endConfirm:
-            showEndConfirm = true
+            // Only offer to end an episode that is still active — matches the in-app
+            // End buttons, which only render for an active episode.
+            if episode.isActive { showEndConfirm = true }
         }
     }
 

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodesScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodesScreen.swift
@@ -15,9 +15,9 @@ struct EpisodesScreen: View {
                 ScrollView {
                     LazyVStack(spacing: 12) {
                         ForEach(viewModel.episodes) { episode in
-                            NavigationLink {
-                                EpisodeDetailScreen(episodeId: episode.id)
-                            } label: {
+                            // Value-based link so taps drive the same path binding
+                            // (selectedEpisodeId) that deep links use — one nav system.
+                            NavigationLink(value: episode.id) {
                                 EpisodeCardView(episode: episode, readings: viewModel.readingsMap[episode.id] ?? [])
                             }
                             .buttonStyle(.plain)

--- a/mobile-apps/ios/MigraLogTests/Utils/DeepLinkParserTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Utils/DeepLinkParserTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import MigraLog
+
+/// Unit tests for `DeepLinkParser`, which turns incoming `migralog://` URLs from
+/// the Live Activity quick actions into typed `DeepLinkTarget` cases.
+final class DeepLinkParserTests: XCTestCase {
+
+    private let episodeId = "episode-123"
+
+    private func url(_ string: String) -> URL {
+        guard let url = URL(string: string) else {
+            preconditionFailure("Invalid URL literal in test: \(string)")
+        }
+        return url
+    }
+
+    // MARK: - Recognized shapes
+
+    func testParsesLogRescueMed() {
+        let target = DeepLinkParser.parse(url("migralog://episode/\(episodeId)/log-med?category=rescue"))
+        XCTAssertEqual(target, .logRescueMed(episodeId: episodeId))
+    }
+
+    func testParsesLogIntensity() {
+        let target = DeepLinkParser.parse(url("migralog://episode/\(episodeId)/log-intensity"))
+        XCTAssertEqual(target, .logIntensity(episodeId: episodeId))
+    }
+
+    func testParsesOpenEpisode() {
+        let target = DeepLinkParser.parse(url("migralog://episode/\(episodeId)"))
+        XCTAssertEqual(target, .openEpisode(episodeId: episodeId))
+    }
+
+    func testParsesEndEpisode() {
+        let target = DeepLinkParser.parse(url("migralog://episode/\(episodeId)/end"))
+        XCTAssertEqual(target, .endEpisode(episodeId: episodeId))
+    }
+
+    // MARK: - Round-trip with the builder the widget uses
+
+    func testRoundTripsAllBuilderURLs() {
+        XCTAssertEqual(
+            DeepLinkParser.parse(EpisodeActivityDeepLink.logRescueMed(episodeId: episodeId)),
+            .logRescueMed(episodeId: episodeId)
+        )
+        XCTAssertEqual(
+            DeepLinkParser.parse(EpisodeActivityDeepLink.logIntensity(episodeId: episodeId)),
+            .logIntensity(episodeId: episodeId)
+        )
+        XCTAssertEqual(
+            DeepLinkParser.parse(EpisodeActivityDeepLink.openEpisode(episodeId: episodeId)),
+            .openEpisode(episodeId: episodeId)
+        )
+        XCTAssertEqual(
+            DeepLinkParser.parse(EpisodeActivityDeepLink.endEpisode(episodeId: episodeId)),
+            .endEpisode(episodeId: episodeId)
+        )
+    }
+
+    // MARK: - Rejected / malformed input
+
+    func testRejectsGarbageURL() {
+        XCTAssertNil(DeepLinkParser.parse(url("https://example.com/episode/123/end")))
+    }
+
+    func testRejectsWrongScheme() {
+        XCTAssertNil(DeepLinkParser.parse(url("notmigralog://episode/\(episodeId)/end")))
+    }
+
+    func testRejectsWrongHost() {
+        XCTAssertNil(DeepLinkParser.parse(url("migralog://medication/\(episodeId)")))
+    }
+
+    func testRejectsUnknownAction() {
+        XCTAssertNil(DeepLinkParser.parse(url("migralog://episode/\(episodeId)/teleport")))
+    }
+
+    func testRejectsMissingEpisodeId() {
+        XCTAssertNil(DeepLinkParser.parse(url("migralog://episode")))
+        XCTAssertNil(DeepLinkParser.parse(url("migralog://episode/")))
+    }
+}


### PR DESCRIPTION
## Phase 3 of #416 — deep-link routing

Makes the Live Activity's `migralog://` quick actions functional. Builds on Phases 0–2.

### What's here
- **URL scheme** `migralog` registered in the app Info.plist.
- **`DeepLinkParser`** (pure, `Sendable`, unit-tested) → typed `DeepLinkTarget` for the four shapes (log rescue med / log intensity / open episode / end episode); malformed/foreign URLs return nil.
- **`AppState.handle(url:)` / `route(to:)`** + `.onOpenURL` in ContentView → selects the episode in the Episodes tab and queues a `PendingEpisodeAction`.
- **`EpisodeDetailScreen`** presents the right surface (rescue-filtered Log Medication, intensity logger, or end-confirm) once the episode loads.
- iPhone Episodes tab converted to a path-bound `NavigationStack` (value-based links) so deep links push detail the same way taps do; iPad split-view unchanged.

### Review fixes applied
- Only the Episodes-tab detail instance consumes the queued action (`consumesDeepLinks`), so a same-episode screen alive in another tab can't steal it.
- End-confirm only fires for an episode that is still active (matches the in-app End buttons).
- A queued action is cleared if the deep-linked episode no longer exists.

### Verification
- 10 new parser tests + full **Smoke** plan (971 unit + 2 UI) green; integrated build on top of Phase 2 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)