### PR TITLE
feat(ios): Live Activities settings toggle (#416 Phase 4)

### DIFF
--- a/mobile-apps/ios/MigraLog/ViewModels/NotificationSettingsViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/NotificationSettingsViewModel.swift
@@ -19,6 +19,7 @@ final class NotificationSettingsViewModel {
     var timeSensitiveEnabled: Bool = false
     var followUpDelay: Int = 30 // minutes
     var criticalAlertsEnabled: Bool = false
+    var liveActivitiesEnabled: Bool = true
     var showMedicationNames: Bool = true
     var dailyCheckinEnabled: Bool = true
     var dailyCheckinTime: Date = {
@@ -37,6 +38,7 @@ final class NotificationSettingsViewModel {
         static let timeSensitiveEnabled = "notification_time_sensitive_enabled"
         static let followUpDelay = "notification_follow_up_delay"
         static let criticalAlertsEnabled = "notification_critical_alerts_enabled"
+        static let liveActivitiesEnabled = "live_activities_enabled"
         static let medicationOverrides = "notification_medication_overrides"
         static let showMedicationNames = "notification_show_medication_names"
         static let dailyCheckinEnabled = "daily_checkin_enabled"
@@ -49,6 +51,7 @@ final class NotificationSettingsViewModel {
     private let dailyCheckinService: DailyCheckinNotificationServiceProtocol
     private let notificationService: NotificationServiceProtocol
     private let medicationNotificationService: MedicationNotificationServiceProtocol?
+    private let liveActivityManager: LiveActivityManaging
 
     // MARK: - Init
 
@@ -65,12 +68,14 @@ final class NotificationSettingsViewModel {
             notificationService: NotificationService.shared,
             scheduledNotificationRepo: ScheduledNotificationRepository(dbManager: DatabaseManager.shared),
             medicationRepo: MedicationRepository(dbManager: DatabaseManager.shared)
-        )
+        ),
+        liveActivityManager: LiveActivityManaging = LiveActivityManager.shared
     ) {
         self.defaults = defaults
         self.dailyCheckinService = dailyCheckinService
         self.notificationService = notificationService
         self.medicationNotificationService = medicationNotificationService
+        self.liveActivityManager = liveActivityManager
     }
 
     // MARK: - Actions
@@ -80,6 +85,7 @@ final class NotificationSettingsViewModel {
         timeSensitiveEnabled = defaults.bool(forKey: Keys.timeSensitiveEnabled)
         followUpDelay = defaults.object(forKey: Keys.followUpDelay) as? Int ?? 30
         criticalAlertsEnabled = defaults.bool(forKey: Keys.criticalAlertsEnabled)
+        liveActivitiesEnabled = defaults.object(forKey: Keys.liveActivitiesEnabled) as? Bool ?? true
         showMedicationNames = defaults.object(forKey: Keys.showMedicationNames) as? Bool ?? true
         dailyCheckinEnabled = defaults.object(forKey: Keys.dailyCheckinEnabled) as? Bool ?? true
 
@@ -99,6 +105,7 @@ final class NotificationSettingsViewModel {
         defaults.set(timeSensitiveEnabled, forKey: Keys.timeSensitiveEnabled)
         defaults.set(followUpDelay, forKey: Keys.followUpDelay)
         defaults.set(criticalAlertsEnabled, forKey: Keys.criticalAlertsEnabled)
+        defaults.set(liveActivitiesEnabled, forKey: Keys.liveActivitiesEnabled)
         defaults.set(showMedicationNames, forKey: Keys.showMedicationNames)
         defaults.set(dailyCheckinEnabled, forKey: Keys.dailyCheckinEnabled)
         defaults.set(dailyCheckinTime.timeIntervalSinceReferenceDate, forKey: Keys.dailyCheckinTime)
@@ -166,6 +173,15 @@ final class NotificationSettingsViewModel {
     func applyMedicationNotificationSettingChange() async {
         _ = await notificationService.requestPermission()
         await syncMedicationNotifications()
+    }
+
+    /// Apply a change to the Live Activities setting. Turning it off ends any
+    /// running episode activity immediately; turning it on does nothing now (the
+    /// next episode starts one). Call after `liveActivitiesEnabled` changes.
+    func applyLiveActivitiesSettingChange() {
+        if !liveActivitiesEnabled {
+            liveActivityManager.endAll()
+        }
     }
 
     func updateMedicationSettings(_ override: MedicationNotificationOverride) {

--- a/mobile-apps/ios/MigraLog/Views/Settings/NotificationSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/NotificationSettingsScreen.swift
@@ -80,6 +80,17 @@ struct NotificationSettingsScreen: View {
                     }
                 }
             }
+
+            Section {
+                Toggle("Live Activities", isOn: $viewModel.liveActivitiesEnabled)
+                    .onChange(of: viewModel.liveActivitiesEnabled) { _, _ in
+                        viewModel.saveSettings()
+                        viewModel.applyLiveActivitiesSettingChange()
+                    }
+                    .accessibilityIdentifier("live-activities-toggle")
+            } footer: {
+                Text("Show live episode status on the Lock Screen and in the Dynamic Island while an episode is active.")
+            }
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Notification Settings")

--- a/mobile-apps/ios/MigraLogTests/ViewModels/NotificationSettingsViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/NotificationSettingsViewModelTests.swift
@@ -66,6 +66,20 @@ private final class MockMedNotifService: MedicationNotificationServiceProtocol, 
     func rebalance() async {}
 }
 
+private final class MockLiveActivityManager: LiveActivityManaging, @unchecked Sendable {
+    var endAllCallCount = 0
+
+    func start(for episode: Episode) {}
+    func refresh(episodeId: String) {}
+    func end(episodeId: String, at endTime: Int64) {}
+    func dismiss(episodeId: String) {}
+    func reconcileOnLaunch() {}
+
+    func endAll() {
+        endAllCallCount += 1
+    }
+}
+
 // MARK: - Tests
 
 @MainActor
@@ -74,6 +88,7 @@ final class NotificationSettingsViewModelTests: XCTestCase {
     private var mockCheckinService: MockDailyCheckinService!
     private var mockNotifService: MockNotifService!
     private var mockMedNotifService: MockMedNotifService!
+    private var mockLiveActivityManager: MockLiveActivityManager!
     private var sut: NotificationSettingsViewModel!
 
     private let suiteName = "NotificationSettingsViewModelTests"
@@ -85,11 +100,13 @@ final class NotificationSettingsViewModelTests: XCTestCase {
         mockCheckinService = MockDailyCheckinService()
         mockNotifService = MockNotifService()
         mockMedNotifService = MockMedNotifService()
+        mockLiveActivityManager = MockLiveActivityManager()
         sut = NotificationSettingsViewModel(
             defaults: defaults,
             dailyCheckinService: mockCheckinService,
             notificationService: mockNotifService,
-            medicationNotificationService: mockMedNotifService
+            medicationNotificationService: mockMedNotifService,
+            liveActivityManager: mockLiveActivityManager
         )
     }
 
@@ -100,6 +117,7 @@ final class NotificationSettingsViewModelTests: XCTestCase {
         mockCheckinService = nil
         mockNotifService = nil
         mockMedNotifService = nil
+        mockLiveActivityManager = nil
         super.tearDown()
     }
 
@@ -118,6 +136,7 @@ final class NotificationSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.followUpDelay, 30)
         XCTAssertFalse(vm.criticalAlertsEnabled)
         XCTAssertTrue(vm.dailyCheckinEnabled)
+        XCTAssertTrue(vm.liveActivitiesEnabled)
         XCTAssertTrue(vm.medicationOverrides.isEmpty)
         XCTAssertNil(vm.error)
     }
@@ -152,6 +171,37 @@ final class NotificationSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(sut.followUpDelay, 30)
         XCTAssertFalse(sut.criticalAlertsEnabled)
         XCTAssertTrue(sut.dailyCheckinEnabled)
+    }
+
+    // MARK: - Live Activities setting
+
+    func testLiveActivities_defaultsEnabledWhenKeyAbsent() {
+        sut.loadSettings()
+        XCTAssertTrue(sut.liveActivitiesEnabled)
+    }
+
+    func testLiveActivities_loadReadsStoredValue() {
+        defaults.set(false, forKey: "live_activities_enabled")
+        sut.loadSettings()
+        XCTAssertFalse(sut.liveActivitiesEnabled)
+    }
+
+    func testLiveActivities_saveRoundTripsKey() {
+        sut.liveActivitiesEnabled = false
+        sut.saveSettings()
+        XCTAssertEqual(defaults.object(forKey: "live_activities_enabled") as? Bool, false)
+    }
+
+    func testLiveActivities_disablingEndsRunningActivities() {
+        sut.liveActivitiesEnabled = false
+        sut.applyLiveActivitiesSettingChange()
+        XCTAssertEqual(mockLiveActivityManager.endAllCallCount, 1)
+    }
+
+    func testLiveActivities_enablingDoesNotEndActivities() {
+        sut.liveActivitiesEnabled = true
+        sut.applyLiveActivitiesSettingChange()
+        XCTAssertEqual(mockLiveActivityManager.endAllCallCount, 0)
     }
 
     func testLoadSettings_loadsMedicationOverrides() {


### PR DESCRIPTION
## Phase 4 of #416 — settings toggle

Adds a **"Live Activities"** toggle (ON by default) under Notification settings.

- Backed by the `live_activities_enabled` UserDefaults key that `LiveActivityManager` already reads to gate starting activities (Phase 2).
- Turning it **off** calls `LiveActivityManager.endAll()` to dismiss any running episode activity immediately; turning it **on** takes effect on the next episode.
- Follows the existing settings persistence pattern exactly; injects a mockable `LiveActivityManaging`.

### Verification
- Build + **Smoke** plan green; new unit tests cover default-on, load/save round-trip, and end-all-on-disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)