### PR TITLE
feat(ios): Live Activity privacy + VoiceOver polish (#416 Phase 5)

### DIFF
--- a/mobile-apps/ios/MigraLog/LiveActivity/LiveActivityManager.swift
+++ b/mobile-apps/ios/MigraLog/LiveActivity/LiveActivityManager.swift
@@ -128,6 +128,11 @@ final class LiveActivityManager: LiveActivityManaging {
         Activity<EpisodeActivityAttributes>.activities.first { $0.attributes.episodeId == episodeId }
     }
 
+    /// Generic stand-in shown instead of a medication's name when the user has
+    /// turned off "Show Medication Names" — keeps the Lock Screen from revealing
+    /// the specific drug while still surfacing that a rescue dose was taken.
+    static let genericRescueName = "Rescue medication"
+
     private func contentState(
         for episodeId: String,
         endedAt: Date?
@@ -135,12 +140,35 @@ final class LiveActivityManager: LiveActivityManaging {
         let readings = (try? episodeRepository.getReadingsByEpisodeId(episodeId)) ?? []
         let intensity = readings.max { $0.timestamp < $1.timestamp }?.intensity
         let lastRescue = latestRescueDose(episodeId: episodeId)
-        return EpisodeActivityAttributes.ContentState(
-            currentIntensity: intensity,
-            lastRescueMedName: lastRescue?.name,
-            lastRescueMedAt: lastRescue?.takenAt,
+        return Self.makeContentState(
+            intensity: intensity,
+            rescue: lastRescue,
+            showMedicationNames: showMedicationNames,
             endedAt: endedAt
         )
+    }
+
+    /// Pure assembly of the activity content, split out for testability. When
+    /// `showMedicationNames` is false the specific drug name is replaced with a
+    /// generic label, mirroring how medication notifications hide names.
+    static func makeContentState(
+        intensity: Double?,
+        rescue: (name: String, takenAt: Date)?,
+        showMedicationNames: Bool,
+        endedAt: Date?
+    ) -> EpisodeActivityAttributes.ContentState {
+        EpisodeActivityAttributes.ContentState(
+            currentIntensity: intensity,
+            lastRescueMedName: rescue.map { showMedicationNames ? $0.name : genericRescueName },
+            lastRescueMedAt: rescue?.takenAt,
+            endedAt: endedAt
+        )
+    }
+
+    /// Honour the existing "Show Medication Names" privacy setting on the Lock
+    /// Screen (shared key with medication notifications).
+    private var showMedicationNames: Bool {
+        UserDefaults.standard.object(forKey: "notification_show_medication_names") as? Bool ?? true
     }
 
     /// The most recent rescue-category dose taken during the episode, if any.

--- a/mobile-apps/ios/MigraLogTests/LiveActivity/LiveActivityContentStateTests.swift
+++ b/mobile-apps/ios/MigraLogTests/LiveActivity/LiveActivityContentStateTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import MigraLog
+
+/// Tests the pure content-state assembly that backs the episode Live Activity,
+/// focusing on the "Show Medication Names" privacy rule (#416 Phase 5).
+final class LiveActivityContentStateTests: XCTestCase {
+    private let takenAt = Date(timeIntervalSince1970: 1_000)
+
+    func testShowsMedicationNameWhenEnabled() {
+        let state = LiveActivityManager.makeContentState(
+            intensity: 7,
+            rescue: (name: "Sumatriptan", takenAt: takenAt),
+            showMedicationNames: true,
+            endedAt: nil
+        )
+        XCTAssertEqual(state.lastRescueMedName, "Sumatriptan")
+        XCTAssertEqual(state.lastRescueMedAt, takenAt)
+        XCTAssertEqual(state.currentIntensity, 7)
+        XCTAssertFalse(state.isEnded)
+    }
+
+    func testHidesMedicationNameWhenDisabled() {
+        let state = LiveActivityManager.makeContentState(
+            intensity: nil,
+            rescue: (name: "Sumatriptan", takenAt: takenAt),
+            showMedicationNames: false,
+            endedAt: nil
+        )
+        XCTAssertEqual(state.lastRescueMedName, LiveActivityManager.genericRescueName)
+        XCTAssertNotEqual(state.lastRescueMedName, "Sumatriptan")
+        // Timing is still surfaced even when the name is hidden.
+        XCTAssertEqual(state.lastRescueMedAt, takenAt)
+    }
+
+    func testNoRescueDoseYieldsNilNameRegardlessOfPrivacy() {
+        for show in [true, false] {
+            let state = LiveActivityManager.makeContentState(
+                intensity: 5,
+                rescue: nil,
+                showMedicationNames: show,
+                endedAt: nil
+            )
+            XCTAssertNil(state.lastRescueMedName)
+            XCTAssertNil(state.lastRescueMedAt)
+            XCTAssertEqual(state.currentIntensity, 5)
+        }
+    }
+
+    func testEndedAtPassedThrough() {
+        let endedAt = Date(timeIntervalSince1970: 5_000)
+        let state = LiveActivityManager.makeContentState(
+            intensity: nil,
+            rescue: nil,
+            showMedicationNames: true,
+            endedAt: endedAt
+        )
+        XCTAssertEqual(state.endedAt, endedAt)
+        XCTAssertTrue(state.isEnded)
+    }
+}

--- a/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivity.swift
+++ b/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivity.swift
@@ -36,7 +36,11 @@ struct EpisodeLiveActivity: Widget {
         } compactLeading: {
             Image(systemName: "bolt.heart.fill")
                 .foregroundStyle(tint(for: context.state))
+                .accessibilityHidden(true)
         } compactTrailing: {
+            // No accessibilityLabel here: it would override the live timer's
+            // spoken value. VoiceOver reads the elapsed time, and the minimal
+            // presentation already labels the activity as a migraine episode.
             DurationText(attributes: context.attributes, state: context.state)
                 .font(.caption2.monospacedDigit())
                 .frame(maxWidth: 52)
@@ -81,9 +85,12 @@ struct EpisodeLockScreenView: View {
                     .font(.title3.monospacedDigit().weight(.semibold))
                     .foregroundStyle(LiveActivityStyle.activeColor)
             }
+            // Read "In migraine, <elapsed>" as one element.
+            .accessibilityElement(children: .combine)
             HStack(spacing: 12) {
                 if let intensity = LiveActivityStyle.intensityLabel(context.state.currentIntensity) {
                     StatChip(systemImage: "gauge.with.dots.needle.50percent", text: intensity)
+                        .accessibilityLabel("Pain intensity \(intensity)")
                 }
                 LastMedLabel(state: context.state, alignment: .leading)
                 Spacer()

--- a/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivityComponents.swift
+++ b/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivityComponents.swift
@@ -35,6 +35,9 @@ struct LastMedLabel: View {
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
+            // Combine so VoiceOver reads the name together with the relative time
+            // (e.g. "Advil, 45 minutes") instead of two separate elements.
+            .accessibilityElement(children: .combine)
         }
     }
 }
@@ -141,5 +144,6 @@ struct PulsingDot: View {
         Circle()
             .fill(color)
             .frame(width: 8, height: 8)
+            .accessibilityLabel("Active migraine episode")
     }
 }


### PR DESCRIPTION
## Phase 5 of #416 — privacy + VoiceOver (final phase)

- **Lock-Screen privacy**: respects the existing "Show Medication Names" setting (`notification_show_medication_names`). When off, the rescue dose shows a generic "Rescue medication" label instead of the drug name (timing still shown). Content assembly is split into a pure, testable `LiveActivityManager.makeContentState`, and every `ContentState` is built through it (no leak path).
- **VoiceOver**: labels the minimal pulsing dot, the intensity chip, and combines the last-med name + relative time; hides the decorative compact icon. The compact duration deliberately keeps its live timer value spoken (no overriding label).
- **Tests**: 4 new content-state/privacy tests.

### Verification
- Build + **Smoke** plan green (incl. new tests). Code-reviewed; the one VoiceOver finding (compact-duration label suppressing the timer) is fixed.

Completes v1. Time-based nudges + post-episode recovery remain tracked for v1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)