### PR TITLE
feat(ci): auto-fill TestFlight "What to Test" from commit history

### DIFF
--- a/.github/scripts/asc-client.mjs
+++ b/.github/scripts/asc-client.mjs
@@ -144,6 +144,35 @@ export async function attachBuildToGroup(buildId, groupId) {
   });
 }
 
+// TestFlight "What to Test" lives on betaBuildLocalizations (one row per locale
+// per build). Create the locale row if it doesn't exist yet, otherwise patch
+// whatsNew on the existing one.
+export async function setBetaBuildNotes(buildId, whatsNew, locale = 'en-US') {
+  const existing = await ascFetch(
+    `/builds/${buildId}/betaBuildLocalizations?fields[betaBuildLocalizations]=locale,whatsNew&limit=50`,
+  );
+  const row = (existing.data || []).find((l) => l.attributes?.locale === locale);
+  if (row) {
+    await ascFetch(`/betaBuildLocalizations/${row.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        data: { type: 'betaBuildLocalizations', id: row.id, attributes: { whatsNew } },
+      }),
+    });
+  } else {
+    await ascFetch('/betaBuildLocalizations', {
+      method: 'POST',
+      body: JSON.stringify({
+        data: {
+          type: 'betaBuildLocalizations',
+          attributes: { locale, whatsNew },
+          relationships: { build: { data: { type: 'builds', id: buildId } } },
+        },
+      }),
+    });
+  }
+}
+
 export async function submitForBetaReview(buildId) {
   await ascFetch('/betaAppReviewSubmissions', {
     method: 'POST',

--- a/.github/scripts/set-beta-notes.mjs
+++ b/.github/scripts/set-beta-notes.mjs
@@ -1,0 +1,155 @@
+// Generates TestFlight "What to Test" notes from the commits since the previous
+// release and writes them to the just-uploaded build's betaBuildLocalizations.
+//
+// Notes are built deterministically from conventional-commit subjects — no LLM,
+// no extra secret. `feat:` commits become a "New" list, `fix:` commits a "Fixed"
+// list; trailing PR refs like "(#486)" are stripped for tester-facing prose.
+//
+// To keep the notes focused on changes a tester would care about, two classes of
+// commit are dropped: those whose scope is in EXCLUDE_SCOPES (default "ci"), and
+// those whose subject matches EXCLUDE_PATTERN (default: test-infrastructure
+// churn — UI/unit test fixes, nightly/flaky stabilization, etc.).
+//
+// Non-fatal by design: "What to Test" is cosmetic, so any failure (ASC hiccup,
+// build slow to process) logs a warning and exits 0 — it never blocks a deploy.
+//
+// Env:
+//   APP_BUNDLE_ID     — bundle id of the app (e.g. com.eff3.migralog)
+//   APP_VERSION       — marketing version of the build just uploaded (e.g. 1.1.200)
+//   APP_BUILD         — build number (CFBundleVersion) of that build
+//   PREVIOUS_VERSION  — marketing version of the previous release; lower bound for
+//                       the changelog range. Empty on the very first release.
+//   MAX_WAIT_SECONDS  — optional; how long to poll for the build to appear (default 1200)
+//   EXCLUDE_SCOPES    — optional; comma-separated scopes to drop (default "ci")
+//   EXCLUDE_PATTERN   — optional; JS regex (case-insensitive); subjects matching it
+//                       are dropped. Defaults to a test-infrastructure filter.
+//   ASC_*             — via asc-client
+
+import { execSync } from 'node:child_process';
+import { required, getAppId, getBuild, setBetaBuildNotes } from './asc-client.mjs';
+
+const CHAR_LIMIT = 4000; // App Store Connect whatsNew max length
+
+// Subjects that are real commits but not tester-facing: test scaffolding,
+// flaky-test stabilization, snapshot/UI/unit test repair, CI plumbing wording.
+const DEFAULT_EXCLUDE_PATTERN =
+  '\\b(ui|unit|snapshot)\\s+tests?\\b|\\bnightly\\b|\\bflaky\\b|waitfor\\w+|\\btest\\s+(suite|harness|plan)\\b';
+
+const excludeScopes = new Set(
+  (process.env.EXCLUDE_SCOPES ?? 'ci')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean),
+);
+const excludePattern = new RegExp(process.env.EXCLUDE_PATTERN || DEFAULT_EXCLUDE_PATTERN, 'i');
+
+function capitalize(s) {
+  // Leave camelCase / brand tokens like iCloud, iPad, iOS untouched.
+  if (/^[a-z][A-Z]/.test(s)) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// Resolve the previous release's marketing version to an existing tag ref. The
+// pipeline tags new releases deploy/<version>; the pre-existing scheme used
+// alpha-v<version>. Try both.
+function resolveLowerBound(prev) {
+  if (!prev) return null;
+  for (const ref of [`deploy/${prev}`, `alpha-v${prev}`]) {
+    try {
+      execSync(`git rev-parse --verify --quiet "${ref}^{commit}"`, { stdio: 'pipe' });
+      return ref;
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}
+
+function generateNotes(lowerRef) {
+  const range = lowerRef ? `${lowerRef}..HEAD` : 'HEAD';
+  const raw = execSync(`git log --no-merges --format=%s ${range}`, { encoding: 'utf8' });
+  const subjects = raw.split('\n').map((s) => s.trim()).filter(Boolean);
+
+  const features = [];
+  const fixes = [];
+  for (const s of subjects) {
+    const m = s.match(/^(feat|fix)(?:\(([^)]*)\))?!?:\s*(.+)$/i);
+    if (!m) continue;
+    const type = m[1].toLowerCase();
+    const scope = (m[2] || '').toLowerCase();
+    // Strip trailing PR refs like " (#486)" or " (#486) (#500)".
+    const text = m[3].replace(/\s*\(#\d+\)/g, '').trim();
+    if (!text) continue;
+    // Drop non-tester-facing noise: excluded scopes (e.g. ci) and test churn.
+    if (excludeScopes.has(scope)) continue;
+    if (excludePattern.test(text)) continue;
+    (type === 'feat' ? features : fixes).push(capitalize(text));
+  }
+
+  if (features.length === 0 && fixes.length === 0) return null;
+
+  const lines = [];
+  if (features.length) {
+    lines.push('New:');
+    for (const f of features) lines.push(`• ${f}`);
+  }
+  if (fixes.length) {
+    if (lines.length) lines.push('');
+    lines.push('Fixed:');
+    for (const f of fixes) lines.push(`• ${f}`);
+  }
+  let notes = lines.join('\n');
+  if (notes.length > CHAR_LIMIT) notes = `${notes.slice(0, CHAR_LIMIT - 1)}…`;
+  return notes;
+}
+
+async function pollForBuild(appId, version, buildNumber, maxWaitSeconds) {
+  const deadline = Date.now() + maxWaitSeconds * 1000;
+  let attempt = 0;
+  for (;;) {
+    const build = await getBuild(appId, { version, buildNumber });
+    if (build) return build;
+    if (Date.now() >= deadline) return null;
+    attempt += 1;
+    console.log(`Build ${version} (${buildNumber}) not yet visible in App Store Connect; retry ${attempt} in 30s…`);
+    await sleep(30_000);
+  }
+}
+
+async function main() {
+  const bundleId = required('APP_BUNDLE_ID');
+  const version = required('APP_VERSION');
+  const buildNumber = required('APP_BUILD');
+  const previous = process.env.PREVIOUS_VERSION || '';
+  const maxWait = Number(process.env.MAX_WAIT_SECONDS || '1200');
+
+  const lowerRef = resolveLowerBound(previous);
+  console.log(`Changelog range: ${lowerRef ? `${lowerRef}..HEAD` : 'entire history (no previous release tag found)'}`);
+
+  const notes = generateNotes(lowerRef);
+  if (!notes) {
+    console.log('No feat/fix commits in range; leaving "What to Test" unset.');
+    return;
+  }
+  console.log(`Generated "What to Test":\n${notes}`);
+
+  const appId = await getAppId(bundleId);
+  const build = await pollForBuild(appId, version, buildNumber, maxWait);
+  if (!build) {
+    console.warn(`::warning::Build ${version} (${buildNumber}) never appeared in App Store Connect within ${maxWait}s; skipping notes.`);
+    return;
+  }
+
+  await setBetaBuildNotes(build.id, notes);
+  console.log(`Set "What to Test" on build ${version} (${buildNumber}).`);
+}
+
+main().catch((err) => {
+  // Non-fatal: never fail a deploy over cosmetic release notes.
+  console.warn(`::warning::Failed to set "What to Test" notes: ${err.message}`);
+  process.exit(0);
+});

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -111,7 +111,11 @@ jobs:
       build_number: ${{ steps.version.outputs.build_number }}
       marketing_version: ${{ steps.version.outputs.marketing_version }}
     steps:
+      # fetch-depth: 0 so the changelog step can read the full commit range
+      # between the previous release tag and HEAD.
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Select Xcode 26
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
@@ -203,6 +207,7 @@ jobs:
           echo "Previous: $LATEST → next: $MARKETING (build $BUILD)"
           echo "marketing_version=$MARKETING" >> "$GITHUB_OUTPUT"
           echo "build_number=$BUILD" >> "$GITHUB_OUTPUT"
+          echo "previous_version=$LATEST" >> "$GITHUB_OUTPUT"
           echo "APP_VERSION=$MARKETING" >> "$GITHUB_ENV"
           echo "APP_BUILD=$BUILD" >> "$GITHUB_ENV"
 
@@ -251,6 +256,30 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag "deploy/${MARKETING_VERSION}" "${{ github.sha }}"
           git push origin "deploy/${MARKETING_VERSION}"
+
+      - name: Setup Node
+        if: success()
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      # Generate a TestFlight "What to Test" from the feat/fix commits since the
+      # previous release and attach it to the build we just uploaded. Runs after
+      # the tag push (so the deploy is already recorded) but before Cleanup wipes
+      # the ASC key. Non-fatal: the script swallows its own errors.
+      - name: Set TestFlight "What to Test" notes
+        if: success()
+        working-directory: ${{ github.workspace }}
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_PATH: ~/.private_keys/AuthKey_${{ secrets.ASC_KEY_ID }}.p8
+          APP_BUNDLE_ID: com.eff3.migralog
+          APP_VERSION: ${{ steps.version.outputs.marketing_version }}
+          APP_BUILD: ${{ steps.version.outputs.build_number }}
+          PREVIOUS_VERSION: ${{ steps.version.outputs.previous_version }}
+          MAX_WAIT_SECONDS: '1200'
+        run: node .github/scripts/set-beta-notes.mjs
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
## What

Every TestFlight build currently ships with a **blank "What to Test"** field — the release pipeline uploads via `xcodebuild -exportArchive` and never sets beta build notes. This wires up automatic, deterministic notes.

## How

- New `set-beta-notes.mjs` builds a "What to Test" note from the `feat`/`fix` commit subjects since the previous release tag (`deploy/<v>` or `alpha-v<v>`), and writes it to the build's `betaBuildLocalizations` via the App Store Connect API.
- **No LLM / no extra secret** — notes are generated deterministically from conventional-commit subjects. `feat:` → "New", `fix:` → "Fixed", trailing PR refs (`(#486)`) stripped.
- **Noise filtering** so notes stay tester-facing: drops CI-scoped commits (`fix(ci)`) and test-infrastructure churn (UI/unit test repair, nightly/flaky stabilization, `waitForHittable`). Both tunable via `EXCLUDE_SCOPES` / `EXCLUDE_PATTERN`.
- **Non-fatal**: any ASC error (or a build slow to appear) logs a `::warning::` and exits 0, so this step can never block a deploy.
- Shared `asc-client.mjs` gains `setBetaBuildNotes()` (create-or-patch the `en-US` locale row).
- `release-pipeline.yml`: checkout now `fetch-depth: 0` (changelog needs full history), the version step exports `previous_version`, and a new Node + notes step runs after the deploy tag is pushed but before the ASC key is cleaned up.

## Sample (filtered, generated from a real multi-build range)

```
New:
• Clinical insight charts on the Trends screen
• Customizable triggers, symptoms and pain qualities
• Allow editing dosage amount and unit on logged doses
• iCloud Sync settings screen
...
Fixed:
• Remove PHI from log statements and Sentry error context
• Apply the selected theme from Settings
...
```
(In normal operation each build spans ~1 commit, so real per-build notes are 1–3 lines.)

## Test plan

- `node --check` passes on both scripts; workflow YAML validates.
- Filter logic verified against the `1.0.38..1.1.190` range — 6 noise commits (2 CI, 4 test-churn) correctly dropped.
- This PR touches `release-pipeline.yml` + `.github/scripts/**`, so merging triggers a real release; the notes step will run against that build and is the live end-to-end test. Being non-fatal, a failure surfaces as a warning without failing the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)