### PR TITLE
docs(website): fix stale references after monorepo move (#437)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ This is a monorepo containing the app, its specifications, and the marketing web
 | [`spec/`](spec/) | Shared specifications, wireframes, data models, and test specs |
 | [`website/`](website/) | Marketing website (static site + AWS CDK infrastructure). See [`website/README.md`](website/README.md) |
 
-The marketing website is a static site deployed to AWS (S3 + CloudFront via CDK). It was previously maintained in a standalone repository and has been moved here so the brand, app, and site live together. See [`website/README.md`](website/README.md) and [`website/DEPLOYMENT.md`](website/DEPLOYMENT.md) for build and deploy instructions.
+The marketing website is a static site deployed to AWS (S3 + CloudFront via CDK). It was previously maintained in a standalone repository, now retired, and has been moved here so the brand, app, and site live together. Deployment is automated from `main` via the **[Web] Deploy** pipeline (GitHub Actions + OIDC). See [`website/README.md`](website/README.md) and [`website/docs/PIPELINE.md`](website/docs/PIPELINE.md) for build and deploy instructions.
 
 ## About
 

--- a/website/README.md
+++ b/website/README.md
@@ -2,7 +2,7 @@
 
 Marketing website for MigraLog - a migraine and chronic pain tracking app.
 
-> **Note:** This site was moved into the main [MigraLog monorepo](../README.md) (under `website/`) from its former standalone repository. Deployment is currently performed locally via [`deploy-website.sh`](./deploy-website.sh) (AWS CDK + S3/CloudFront, `migralog-website-deployer` profile). Automated CI deployment from the monorepo — described in [`docs/GITHUB-SETUP.md`](docs/GITHUB-SETUP.md) and [`docs/SECRETS-MANAGEMENT.md`](docs/SECRETS-MANAGEMENT.md) — still needs its AWS secrets configured on this repository; until then the `.github/workflows/deploy.yml` referenced below is not yet present here.
+> **Note:** This site lives in the main [MigraLog monorepo](../README.md) under `website/` (the former standalone website repository has been retired). Deployment is automated: a push to `main` touching `website/**` runs the **[Web] Deploy** pipeline (`.github/workflows/website-deploy.yml`), which deploys `staging.migralog.app`, runs the Playwright suite against it, waits for the `production` environment approval, then deploys and tests `migralog.app`. Auth is via GitHub OIDC into the Migralog AWS account — no stored AWS keys. See [`docs/PIPELINE.md`](docs/PIPELINE.md) for the full flow. The local [`deploy-website.sh`](./deploy-website.sh) is still available for manual/break-glass deploys.
 
 ## Project Structure
 
@@ -21,12 +21,13 @@ Marketing website for MigraLog - a migraine and chronic pain tracking app.
 │   ├── COPY.md           # Marketing copy
 │   ├── BUILD-PLAN.md     # Implementation plan
 │   ├── INFRASTRUCTURE.md # Infrastructure overview
-│   ├── SECRETS-MANAGEMENT.md # Secrets & security
-│   └── GITHUB-SETUP.md   # GitHub Actions setup
-├── .github/
-│   └── workflows/
-│       └── deploy.yml    # CI/CD pipeline
+│   ├── PIPELINE.md       # CI/CD pipeline (current)
+│   ├── SECRETS-MANAGEMENT.md # Secrets & security (legacy)
+│   └── GITHUB-SETUP.md   # IAM access-key CI setup (superseded by PIPELINE.md)
+├── deploy-website.sh     # Manual/break-glass deploy script
 └── README.md             # This file
+
+The CI/CD workflow lives at the repo root: .github/workflows/website-deploy.yml
 ```
 
 ## Quick Start
@@ -41,25 +42,28 @@ cd website && python -m http.server 8000
 
 ### Deploy to AWS
 
-**Simple S3 Deployment (Recommended):**
-See [DEPLOYMENT.md](DEPLOYMENT.md) for step-by-step S3 static hosting instructions.
+**Automated (default):** Merge a change touching `website/**` to `main`. The
+**[Web] Deploy** pipeline deploys staging → tests it → (production approval) →
+deploys and tests production. See [docs/PIPELINE.md](docs/PIPELINE.md).
 
-**Advanced CDK Deployment:**
-See [infrastructure/README.md](infrastructure/README.md) for CDK infrastructure deployment.
+**Manual / break-glass:** Run `./deploy-website.sh <staging|production>` locally
+(requires the `migralog-website-deployer` AWS profile). See
+[infrastructure/README.md](infrastructure/README.md) for the underlying CDK stack.
 
 ## Documentation
 
 | Document | Description |
 |----------|-------------|
-| [DEPLOYMENT.md](DEPLOYMENT.md) | **Step-by-step AWS S3 deployment guide** |
+| [docs/PIPELINE.md](docs/PIPELINE.md) | **CI/CD deploy pipeline (current — OIDC, staging→prod)** |
 | [docs/PRODUCT.md](docs/PRODUCT.md) | Product definition and philosophy |
 | [docs/WEBSITE-SPEC.md](docs/WEBSITE-SPEC.md) | Website technical specification |
 | [docs/COPY.md](docs/COPY.md) | All marketing copy for the website |
 | [docs/BUILD-PLAN.md](docs/BUILD-PLAN.md) | Implementation phases and recommendations |
 | [docs/INFRASTRUCTURE.md](docs/INFRASTRUCTURE.md) | AWS architecture overview |
-| [docs/SECRETS-MANAGEMENT.md](docs/SECRETS-MANAGEMENT.md) | How to manage secrets and credentials |
-| [docs/GITHUB-SETUP.md](docs/GITHUB-SETUP.md) | GitHub Actions setup guide |
 | [infrastructure/README.md](infrastructure/README.md) | CDK deployment instructions |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | Legacy: manual AWS S3 deployment guide |
+| [docs/SECRETS-MANAGEMENT.md](docs/SECRETS-MANAGEMENT.md) | Legacy: managing access-key secrets |
+| [docs/GITHUB-SETUP.md](docs/GITHUB-SETUP.md) | Legacy: IAM access-key CI setup (superseded by PIPELINE.md) |
 
 ## Website Features
 
@@ -138,15 +142,17 @@ npm run deploy:production
 
 ### Automatic Deployment (GitHub Actions)
 
-1. Set up GitHub Secrets (see [docs/GITHUB-SETUP.md](docs/GITHUB-SETUP.md))
-2. Push to `main` branch
-3. GitHub Actions automatically deploys
+Merge a change touching `website/**` to `main` — the **[Web] Deploy** pipeline
+(`.github/workflows/website-deploy.yml`) deploys staging, tests it, waits for the
+`production` environment approval, then deploys and tests production. It uses
+GitHub OIDC to assume short-lived roles in AWS (no stored keys). Full details and
+one-time setup are in [docs/PIPELINE.md](docs/PIPELINE.md).
 
 ## Next Steps
 
-1. ✅ Set up GitHub repository
-2. ✅ Configure GitHub Secrets
-3. ✅ Deploy infrastructure (see infrastructure/README.md)
+1. ✅ Move site into the monorepo and retire the standalone repo
+2. ✅ Deploy infrastructure (see infrastructure/README.md)
+3. ✅ Automated OIDC CI/CD pipeline (see docs/PIPELINE.md)
 4. ⏳ Replace placeholder screenshots with real app screenshots
 5. ⏳ Set up email signup integration
 6. ⏳ Update app store links when available

--- a/website/docs/GITHUB-SETUP.md
+++ b/website/docs/GITHUB-SETUP.md
@@ -1,5 +1,11 @@
 # GitHub Setup Guide
 
+> **⚠️ Superseded.** This guide describes the original standalone repo and the
+> long-lived IAM access-key CI approach with a `.github/workflows/deploy.yml`. The
+> site now lives in the monorepo and deploys via the OIDC pipeline
+> (`.github/workflows/website-deploy.yml`) — see [PIPELINE.md](PIPELINE.md). Kept
+> for historical reference only.
+
 ## Initial Repository Setup
 
 ### 1. Create GitHub Repository

--- a/website/docs/INFRASTRUCTURE.md
+++ b/website/docs/INFRASTRUCTURE.md
@@ -1,5 +1,10 @@
 # Infrastructure Setup - AWS CDK
 
+> **Note:** The "GitHub Actions (Optional)" example below shows an illustrative
+> `.github/workflows/deploy.yml`. The actual deploy workflow is
+> `.github/workflows/website-deploy.yml` (OIDC, staging→prod) — see
+> [PIPELINE.md](PIPELINE.md).
+
 ## Overview
 Static website hosted on AWS S3 with CloudFront CDN, managed via AWS CDK.
 

--- a/website/docs/SECRETS-MANAGEMENT.md
+++ b/website/docs/SECRETS-MANAGEMENT.md
@@ -1,5 +1,11 @@
 # Secrets Management
 
+> **⚠️ Partly superseded.** The live pipeline uses GitHub OIDC to assume
+> short-lived AWS roles — there are no stored AWS access keys, and the
+> `.github/workflows/deploy.yml` referenced below no longer exists (the workflow
+> is `.github/workflows/website-deploy.yml`). See [PIPELINE.md](PIPELINE.md). The
+> general "what not to commit" guidance here still applies.
+
 ## Overview
 
 This project uses AWS CDK which does not require secrets to be stored in the repository. AWS credentials are managed through the AWS CLI and IAM, not committed to git.


### PR DESCRIPTION
The standalone website repo has been **retired** and the site now deploys from the monorepo via the **[Web] Deploy** OIDC pipeline — but several docs still described local-only deploys, a non-existent `.github/workflows/deploy.yml`, and the old standalone repository. This fixes those stale references.

## Changes
- **`website/README.md`** — rewrote the header note, project-structure diagram, "Deploy to AWS" quick start, documentation table, and "Automatic Deployment" / "Next Steps" sections to point at the live OIDC pipeline ([`docs/PIPELINE.md`](website/docs/PIPELINE.md)). Demoted the local S3 guide and IAM-key docs to "legacy".
- **`README.md`** (root) — note the standalone repo is retired and deploy is automated; point at `PIPELINE.md`.
- **`docs/GITHUB-SETUP.md`** — superseded banner (IAM access-key approach → PIPELINE.md).
- **`docs/SECRETS-MANAGEMENT.md`** — banner: OIDC, no stored keys; workflow is `website-deploy.yml`.
- **`docs/INFRASTRUCTURE.md`** — banner clarifying the inline `deploy.yml` snippet is illustrative; real workflow is `website-deploy.yml`.

Live AWS resource names that share the `migralog-website-*` prefix (S3 buckets, OIDC roles, the `migralog-website-deployer` profile, CDK stack files) were left untouched — those are real infrastructure, not stale repo references.

Docs-only; no code or site content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)