### PR TITLE
feat(design): consolidate design tokens for app + website (#437)

### DIFF
--- a/mobile-apps/ios/MigraLog/DesignSystem/DesignTokens.swift
+++ b/mobile-apps/ios/MigraLog/DesignSystem/DesignTokens.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+/// MigraLog design tokens — the single source of truth for brand colors,
+/// domain color palettes, spacing, radius and typography.
+///
+/// Mirrors the brand guidelines in `website/branding.html` so the iOS app and
+/// the marketing site stay visually in sync. When a value changes here it must
+/// change there too (and vice-versa). Domain palettes (pain scale, medication
+/// types) intentionally live here as well so every surface reads the same hex.
+///
+/// This file is compiled into both the app and the widget extension targets, so
+/// it must not reference app-only domain types — the medication-type *mapping*
+/// stays in `MedicationTypeColors.swift`; only the raw colors live here.
+enum DesignTokens {
+
+    // MARK: - Brand
+
+    /// Core brand palette. Orange is the primary accent (see `AccentColor`),
+    /// navy anchors headings and dark surfaces.
+    enum Brand {
+        static let navy = Color(hex: "#152233")
+        static let navyLight = Color(hex: "#2A3D54")
+        static let navyLighter = Color(hex: "#3F5875")
+
+        static let orange = Color(hex: "#FF552A")        // primary accent
+        static let orangeHover = Color(hex: "#E64D26")
+        static let orangeLight = Color(hex: "#FF7055")
+    }
+
+    // MARK: - Neutrals
+
+    /// Brand-neutral greys. Prefer the system semantic colors
+    /// (`Color(.systemBackground)`, `.secondary`, …) for adaptive light/dark
+    /// surfaces; reach for these only when a fixed brand neutral is required.
+    enum Neutral {
+        static let white = Color(hex: "#FFFFFF")
+        static let gray50 = Color(hex: "#F8F9FA")
+        static let gray600 = Color(hex: "#6C757D")
+        static let gray900 = Color(hex: "#343A40")
+        /// Tinted "orange 50" surface used behind orange iconography/callouts.
+        static let orange50 = Color(hex: "#FFF8F0")
+    }
+
+    // MARK: - Semantic status
+
+    /// Success / danger pairs (text foreground, fill background, border) used by
+    /// added/removed badges and resolved/active episode chrome.
+    enum Status {
+        static let successText = Color(hex: "#2E7D32")
+        static let successFill = Color(hex: "#E8F5E9")
+        static let successBorder = Color(hex: "#66BB6A")
+
+        static let dangerText = Color(hex: "#C62828")
+        static let dangerFill = Color(hex: "#FFEBEE")
+        static let dangerBorder = Color(hex: "#FFCDD2")
+    }
+
+    // MARK: - Pain scale (0–10)
+
+    /// Pain-intensity gradient from 0 (calm green) through orange to 10 (purple).
+    /// The single owner of these hexes — `PainScale` and the intensity sparkline
+    /// both read from here. See spec/functional-specification.md §5.1.
+    enum Pain {
+        static let palette: [Color] = [
+            Color(hex: "#2E7D32"), // 0  — Dark green
+            Color(hex: "#558B2F"), // 1
+            Color(hex: "#689F38"), // 2
+            Color(hex: "#F9A825"), // 3
+            Color(hex: "#FF8F00"), // 4
+            Color(hex: "#EF6C00"), // 5
+            Color(hex: "#E65100"), // 6
+            Color(hex: "#D84315"), // 7
+            Color(hex: "#C62828"), // 8
+            Color(hex: "#EC407A"), // 9
+            Color(hex: "#AB47BC"), // 10 — Purple
+        ]
+
+        /// Color for a 0–10 pain level, clamped into range.
+        static func color(at level: Int) -> Color {
+            palette[max(0, min(palette.count - 1, level))]
+        }
+    }
+
+    // MARK: - Medication types
+
+    /// Raw medication-type badge colors. Type → color mapping stays in
+    /// `MedicationTypeColors`. See spec/functional-specification.md §5.2.
+    enum Medication {
+        static let preventative = Color(hex: "#32D65F") // green
+        static let rescue = Color(hex: "#0066CC")       // blue
+        static let other = Color(hex: "#AEAEB2")        // gray
+    }
+
+    // MARK: - Live Activity
+
+    /// Episode Live Activity accents. Kept as exact sRGB components to preserve
+    /// the existing rendered tints.
+    enum LiveActivity {
+        /// Warm red for the active-episode icon, keyline and duration emphasis.
+        static let active = Color(red: 0.84, green: 0.23, blue: 0.30)
+        /// Softer tint for the post-episode close state.
+        static let calm = Color(red: 0.30, green: 0.55, blue: 0.50)
+    }
+
+    // MARK: - Spacing
+
+    /// 4-pt spacing scale. Use for stack spacing, padding and gaps.
+    enum Spacing {
+        static let xs: CGFloat = 4
+        static let sm: CGFloat = 8
+        static let md: CGFloat = 12
+        static let lg: CGFloat = 16
+        static let xl: CGFloat = 24
+        static let xxl: CGFloat = 32
+    }
+
+    // MARK: - Radius
+
+    /// Corner-radius scale. `lg` (12) is the default card/button radius.
+    enum Radius {
+        static let sm: CGFloat = 4
+        static let md: CGFloat = 8
+        static let lg: CGFloat = 12
+        static let pill: CGFloat = 999
+    }
+
+    // MARK: - Typography
+
+    /// Display font sizes used for hero/empty-state numerals and glyphs that sit
+    /// outside Dynamic Type's text styles. Body/heading text should keep using
+    /// the semantic styles (`.largeTitle`, `.headline`, `.caption`, …) so it
+    /// scales with the user's accessibility settings.
+    enum Typography {
+        static let displayXL: CGFloat = 80
+        static let displayLarge: CGFloat = 60
+        static let displayMedium: CGFloat = 56
+    }
+}
+
+// MARK: - Color(hex:)
+
+extension Color {
+    /// Create a Color from a `#RRGGBB` or `#AARRGGBB` hex string.
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 6:
+            (a, r, g, b) = (255, (int >> 16) & 0xFF, (int >> 8) & 0xFF, int & 0xFF)
+        case 8:
+            (a, r, g, b) = ((int >> 24) & 0xFF, (int >> 16) & 0xFF, (int >> 8) & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (255, 0, 0, 0)
+        }
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}

--- a/mobile-apps/ios/MigraLog/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/mobile-apps/ios/MigraLog/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2A",
+          "green" : "0x55",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile-apps/ios/MigraLog/Utils/MedicationTypeColors.swift
+++ b/mobile-apps/ios/MigraLog/Utils/MedicationTypeColors.swift
@@ -5,9 +5,9 @@ enum MedicationTypeColors {
     /// Get the badge color for a medication type, adapting to light/dark mode
     static func color(for type: MedicationType) -> Color {
         switch type {
-        case .preventative: Color(hex: "#32D65F") // green
-        case .rescue: Color(hex: "#0066CC")       // blue
-        case .other: Color(hex: "#AEAEB2")        // gray
+        case .preventative: DesignTokens.Medication.preventative
+        case .rescue: DesignTokens.Medication.rescue
+        case .other: DesignTokens.Medication.other
         }
     }
 

--- a/mobile-apps/ios/MigraLog/Utils/PainScale.swift
+++ b/mobile-apps/ios/MigraLog/Utils/PainScale.swift
@@ -10,18 +10,20 @@ enum PainScale {
         let color: Color
     }
 
+    // Colors come from the shared palette in DesignTokens.Pain — the single
+    // owner of the pain-scale hexes.
     static let levels: [Level] = [
-        Level(value: 0, label: "No Pain", description: "Pain-free", color: Color(hex: "#2E7D32")),
-        Level(value: 1, label: "Minimal", description: "Very mild, barely noticeable", color: Color(hex: "#558B2F")),
-        Level(value: 2, label: "Mild", description: "Minor annoyance, can be ignored", color: Color(hex: "#689F38")),
-        Level(value: 3, label: "Mild", description: "Noticeable but can function normally", color: Color(hex: "#F9A825")),
-        Level(value: 4, label: "Uncomfortable", description: "Distracting but manageable", color: Color(hex: "#FF8F00")),
-        Level(value: 5, label: "Moderate", description: "Interferes with concentration", color: Color(hex: "#EF6C00")),
-        Level(value: 6, label: "Distressing", description: "Difficult to ignore, limits activities", color: Color(hex: "#E65100")),
-        Level(value: 7, label: "Severe", description: "Dominant focus, impedes daily function", color: Color(hex: "#D84315")),
-        Level(value: 8, label: "Intense", description: "Overwhelming, unable to function", color: Color(hex: "#C62828")),
-        Level(value: 9, label: "Excruciating", description: "Unbearable, incapacitating", color: Color(hex: "#EC407A")),
-        Level(value: 10, label: "Debilitating", description: "Worst imaginable, requires emergency care", color: Color(hex: "#AB47BC")),
+        Level(value: 0, label: "No Pain", description: "Pain-free", color: DesignTokens.Pain.color(at: 0)),
+        Level(value: 1, label: "Minimal", description: "Very mild, barely noticeable", color: DesignTokens.Pain.color(at: 1)),
+        Level(value: 2, label: "Mild", description: "Minor annoyance, can be ignored", color: DesignTokens.Pain.color(at: 2)),
+        Level(value: 3, label: "Mild", description: "Noticeable but can function normally", color: DesignTokens.Pain.color(at: 3)),
+        Level(value: 4, label: "Uncomfortable", description: "Distracting but manageable", color: DesignTokens.Pain.color(at: 4)),
+        Level(value: 5, label: "Moderate", description: "Interferes with concentration", color: DesignTokens.Pain.color(at: 5)),
+        Level(value: 6, label: "Distressing", description: "Difficult to ignore, limits activities", color: DesignTokens.Pain.color(at: 6)),
+        Level(value: 7, label: "Severe", description: "Dominant focus, impedes daily function", color: DesignTokens.Pain.color(at: 7)),
+        Level(value: 8, label: "Intense", description: "Overwhelming, unable to function", color: DesignTokens.Pain.color(at: 8)),
+        Level(value: 9, label: "Excruciating", description: "Unbearable, incapacitating", color: DesignTokens.Pain.color(at: 9)),
+        Level(value: 10, label: "Debilitating", description: "Worst imaginable, requires emergency care", color: DesignTokens.Pain.color(at: 10)),
     ]
 
     /// Get the pain level for an intensity value (0-10)
@@ -47,28 +49,5 @@ enum PainScale {
     }
 }
 
-// MARK: - Color extension for hex
-
-extension Color {
-    init(hex: String) {
-        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-        var int: UInt64 = 0
-        Scanner(string: hex).scanHexInt64(&int)
-        let a, r, g, b: UInt64
-        switch hex.count {
-        case 6:
-            (a, r, g, b) = (255, (int >> 16) & 0xFF, (int >> 8) & 0xFF, int & 0xFF)
-        case 8:
-            (a, r, g, b) = ((int >> 24) & 0xFF, (int >> 16) & 0xFF, (int >> 8) & 0xFF, int & 0xFF)
-        default:
-            (a, r, g, b) = (255, 0, 0, 0)
-        }
-        self.init(
-            .sRGB,
-            red: Double(r) / 255,
-            green: Double(g) / 255,
-            blue: Double(b) / 255,
-            opacity: Double(a) / 255
-        )
-    }
-}
+// Note: the `Color(hex:)` initializer now lives in DesignTokens.swift, the
+// shared design-system source.

--- a/mobile-apps/ios/MigraLog/Views/Episodes/IntensitySparklineView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/IntensitySparklineView.swift
@@ -9,20 +9,9 @@ struct IntensitySparklineView: View {
     /// Episode end time (nil for ongoing — uses current time)
     var episodeEnd: Int64?
 
-    /// Pain scale gradient colors from 0 (green) to 10 (purple)
-    private static let gradientColors: [Color] = [
-        Color(hex: "#2E7D32"), // 0 - Dark Green
-        Color(hex: "#558B2F"), // 1
-        Color(hex: "#689F38"), // 2
-        Color(hex: "#F9A825"), // 3
-        Color(hex: "#FF8F00"), // 4
-        Color(hex: "#EF6C00"), // 5
-        Color(hex: "#E65100"), // 6
-        Color(hex: "#D84315"), // 7
-        Color(hex: "#C62828"), // 8
-        Color(hex: "#EC407A"), // 9
-        Color(hex: "#AB47BC"), // 10
-    ]
+    /// Pain scale gradient colors from 0 (green) to 10 (purple).
+    /// Sourced from the shared palette in DesignTokens.Pain.
+    private static let gradientColors: [Color] = DesignTokens.Pain.palette
 
     var body: some View {
         GeometryReader { geo in

--- a/mobile-apps/ios/MigraLog/Views/Episodes/TimelineView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/TimelineView.swift
@@ -311,10 +311,10 @@ struct TimelineView: View {
                         .font(.caption.weight(.medium))
                         .padding(.horizontal, 10)
                         .padding(.vertical, 5)
-                        .foregroundStyle(Color(hex: "#2E7D32"))
-                        .background(Color(hex: "#E8F5E9"))
+                        .foregroundStyle(DesignTokens.Status.successText)
+                        .background(DesignTokens.Status.successFill)
                         .clipShape(Capsule())
-                        .overlay(Capsule().stroke(Color(hex: "#66BB6A"), lineWidth: 1))
+                        .overlay(Capsule().stroke(DesignTokens.Status.successBorder, lineWidth: 1))
                 }
                 // Removed locations — light bg, red text
                 ForEach(delta.removed) { location in
@@ -322,10 +322,10 @@ struct TimelineView: View {
                         .font(.caption.weight(.medium))
                         .padding(.horizontal, 10)
                         .padding(.vertical, 5)
-                        .foregroundStyle(Color(hex: "#C62828"))
-                        .background(Color(hex: "#FFEBEE"))
+                        .foregroundStyle(DesignTokens.Status.dangerText)
+                        .background(DesignTokens.Status.dangerFill)
                         .clipShape(Capsule())
-                        .overlay(Capsule().stroke(Color(hex: "#FFCDD2"), lineWidth: 1))
+                        .overlay(Capsule().stroke(DesignTokens.Status.dangerBorder, lineWidth: 1))
                 }
                 // Unchanged locations (neutral gray)
                 ForEach(delta.unchanged) { location in

--- a/mobile-apps/ios/MigraLogWidgets/LiveActivityStyle.swift
+++ b/mobile-apps/ios/MigraLogWidgets/LiveActivityStyle.swift
@@ -5,10 +5,10 @@ import SwiftUI
 enum LiveActivityStyle {
     /// The "active episode" accent — a warm red used for the icon, keyline and
     /// duration emphasis.
-    static let activeColor = Color(red: 0.84, green: 0.23, blue: 0.30)
+    static let activeColor = DesignTokens.LiveActivity.active
 
     /// A softer tint used for the post-episode close state.
-    static let calmColor = Color(red: 0.30, green: 0.55, blue: 0.50)
+    static let calmColor = DesignTokens.LiveActivity.calm
 
     static func intensityLabel(_ intensity: Double?) -> String? {
         guard let intensity else { return nil }

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -38,6 +38,7 @@ targets:
         DEVELOPMENT_TEAM: "43DNX2P3T6"
         CODE_SIGN_STYLE: Automatic
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         GENERATE_INFOPLIST_FILE: false
         SWIFT_STRICT_CONCURRENCY: complete
         TARGETED_DEVICE_FAMILY: "1,2"
@@ -72,6 +73,9 @@ targets:
       # Shared ActivityKit contract — also compiled into the app target via its
       # MigraLog/ source root. Both targets must see the same types.
       - path: MigraLog/LiveActivity/Shared
+      # Shared design tokens (brand colors, Live Activity accents, Color(hex:)).
+      # Also compiled into the app via its MigraLog/ source root.
+      - path: MigraLog/DesignSystem
     settings:
       base:
         INFOPLIST_FILE: MigraLogWidgets/Info.plist

--- a/website/website/contact.html
+++ b/website/website/contact.html
@@ -12,7 +12,10 @@
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    
+
+    <!-- Design tokens — single source of truth for brand colors/spacing/type -->
+    <link rel="stylesheet" href="css/tokens.css">
+
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -20,11 +23,12 @@
             theme: {
                 extend: {
                     colors: {
-                        'migralog-navy': '#152233',
-                        'migralog-navy-light': '#2A3D54',
-                        'migralog-orange': '#FF552A',
-                        'migralog-orange-hover': '#E64D26',
-                        'migralog-orange-light': '#FF7055',
+                        'migralog-navy': 'var(--migralog-navy)',
+                        'migralog-navy-light': 'var(--migralog-navy-light)',
+                        'migralog-navy-lighter': 'var(--migralog-navy-lighter)',
+                        'migralog-orange': 'var(--migralog-orange)',
+                        'migralog-orange-hover': 'var(--migralog-orange-hover)',
+                        'migralog-orange-light': 'var(--migralog-orange-light)',
                     }
                 }
             }
@@ -32,7 +36,7 @@
     </script>
     <style>
         *:focus-visible {
-            outline: 3px solid #FF552A;
+            outline: 3px solid var(--migralog-orange);
             outline-offset: 2px;
         }
         

--- a/website/website/css/tokens.css
+++ b/website/website/css/tokens.css
@@ -1,0 +1,58 @@
+/*
+ * MigraLog design tokens — the single source of truth for the marketing site.
+ *
+ * Mirrors the brand guidelines in branding.html and the iOS app's
+ * mobile-apps/ios/MigraLog/DesignSystem/DesignTokens.swift. When a brand value
+ * changes, update it here, in branding.html, and in the iOS tokens together.
+ *
+ * Every page links this file in <head>, and each page's Tailwind config maps its
+ * brand color names to these variables (e.g. 'migralog-orange':
+ * 'var(--migralog-orange)'), so all color values trace back to this file.
+ *
+ * Colors are also exposed as space-separated RGB triplets (…-rgb) for use with
+ * rgb(var(--token-rgb) / <alpha>) wherever a translucent tint is needed.
+ */
+:root {
+  /* Brand */
+  --migralog-navy: #152233;
+  --migralog-navy-light: #2A3D54;
+  --migralog-navy-lighter: #3F5875;
+  --migralog-orange: #FF552A;
+  --migralog-orange-hover: #E64D26;
+  --migralog-orange-light: #FF7055;
+
+  --migralog-navy-rgb: 21 34 51;
+  --migralog-orange-rgb: 255 85 42;
+
+  /* Neutrals */
+  --color-white: #FFFFFF;
+  --color-gray-50: #F8F9FA;
+  --color-gray-600: #6C757D;
+  --color-gray-900: #343A40;
+  --color-orange-50: #FFF8F0; /* tinted surface behind orange callouts */
+
+  /* Typography — Inter primary typeface (see branding.html §3) */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'Courier New', monospace;
+
+  --text-h1: 3.75rem;   /* 60px Bold,    -0.02em tracking */
+  --text-h2: 2.5rem;    /* 40px Semibold,-0.01em tracking */
+  --text-h3: 1.5rem;    /* 24px Medium */
+  --text-lead: 1.125rem;/* 18px Regular, 1.625 line height */
+  --text-body: 1rem;    /* 16px Regular, 1.5 line height */
+  --text-small: 0.875rem;/* 14px Regular, 1.5 line height */
+
+  /* Spacing — 4px scale */
+  --space-xs: 0.25rem;  /* 4  */
+  --space-sm: 0.5rem;   /* 8  */
+  --space-md: 0.75rem;  /* 12 */
+  --space-lg: 1rem;     /* 16 */
+  --space-xl: 1.5rem;   /* 24 */
+  --space-2xl: 2rem;    /* 32 */
+
+  /* Radius */
+  --radius-sm: 0.25rem; /* 4  */
+  --radius-md: 0.5rem;  /* 8  */
+  --radius-lg: 0.75rem; /* 12 */
+  --radius-pill: 9999px;
+}

--- a/website/website/index.html
+++ b/website/website/index.html
@@ -42,6 +42,9 @@
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
     <link rel="manifest" href="site.webmanifest">
+    <!-- Design tokens — single source of truth for brand colors/spacing/type -->
+    <link rel="stylesheet" href="css/tokens.css">
+
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -49,12 +52,12 @@
             theme: {
                 extend: {
                     colors: {
-                        'migralog-navy': '#152233',
-                        'migralog-navy-light': '#2A3D54',
-                        'migralog-navy-lighter': '#3F5875',
-                        'migralog-orange': '#FF552A',
-                        'migralog-orange-hover': '#E64D26',
-                        'migralog-orange-light': '#FF7055',
+                        'migralog-navy': 'var(--migralog-navy)',
+                        'migralog-navy-light': 'var(--migralog-navy-light)',
+                        'migralog-navy-lighter': 'var(--migralog-navy-lighter)',
+                        'migralog-orange': 'var(--migralog-orange)',
+                        'migralog-orange-hover': 'var(--migralog-orange-hover)',
+                        'migralog-orange-light': 'var(--migralog-orange-light)',
                     }
                 }
             }
@@ -83,7 +86,7 @@
         }
         
         *:focus-visible {
-            outline: 3px solid #FF552A;
+            outline: 3px solid var(--migralog-orange);
             outline-offset: 2px;
         }
         
@@ -143,11 +146,11 @@
         }
         
         .theme-toggle button:hover {
-            background: rgba(255, 85, 42, 0.2);
+            background: rgb(var(--migralog-orange-rgb) / 0.2);
         }
 
         .theme-toggle button.active {
-            background: rgba(255, 85, 42, 0.3);
+            background: rgb(var(--migralog-orange-rgb) / 0.3);
         }
     </style>
     <!-- Structured Data -->


### PR DESCRIPTION
Unifies the scattered brand/domain colors across the iOS app and the marketing site into a single design-token source per platform, mirroring the brand spec in `website/branding.html`. Part of #437 (the "Unify design tokens" checkbox).

## iOS
- **New `MigraLog/DesignSystem/DesignTokens.swift`** — single owner of brand (navy/orange), neutrals, semantic status, pain-scale, medication-type and Live Activity colors, plus spacing/radius/typography scales and `Color(hex:)`. Compiled into both the app and widget targets.
- Rewired the scattered definitions to it: `PainScale`, `IntensitySparklineView` (the pain palette was duplicated in both), `MedicationTypeColors`, `TimelineView` status badges, and the widget's `LiveActivityStyle`. Removed the second `Color(hex:)` definition.
- **Brand-orange `AccentColor` asset** + `ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME`, so the app's system tint matches the brand (was system-default blue).

## Website
- **New `website/website/css/tokens.css`** — `:root` variables for the full brand palette, neutrals, spacing, radius and type scale.
- Each page's Tailwind config + inline styles now resolve to those variables, so every color on `index.html`/`contact.html` traces back to one file.

Color **values** are unchanged, so rendered output and the Playwright visual snapshots match.

## Verification
- iOS: `BUILD SUCCEEDED` (app + widget); **980 unit tests pass**, 0 failures.
- Website: served locally; `tokens.css` loads, both pages link it, zero scattered brand hex remain (only the `<meta theme-color>` literal).
- Both reviewed visually (app with seeded sample data + live site) and approved.

## Follow-ups (out of scope here, part of the rest of #437)
- The **deployed `website/website/branding.html`** is a stale purple/amber *exploration* page, not the current navy/orange brand guidelines — should be refreshed.
- Typography/spacing tokens are now defined as a single source but only **colors** were fully migrated; the type/spacing scales are ready for incremental adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)