### PR TITLE
refactor(ios): adopt spacing/radius/typography tokens (#437)

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/Analytics/AnalyticsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Analytics/AnalyticsScreen.swift
@@ -39,7 +39,7 @@ struct AnalyticsScreen: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
                 AnalyticsSectionPicker(selection: $selectedSection)
 
                 switch selectedSection {
@@ -118,7 +118,7 @@ struct MonthlyCalendarView: View {
     }
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: DesignTokens.Spacing.sm) {
             // Month navigation
             HStack {
                 Button {
@@ -181,7 +181,7 @@ struct MonthlyCalendarView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
         .sheet(isPresented: $viewModel.showDailyStatusPrompt) {
             if let date = viewModel.selectedCalendarDate {
                 NavigationStack {
@@ -290,7 +290,7 @@ struct TimeRangeSelectorView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 8) {
+            HStack(spacing: DesignTokens.Spacing.sm) {
                 ForEach(TimeRangeDays.allCases) { range in
                     let isSelected = viewModel.customRange == nil && viewModel.selectedRange == range
                     Button {
@@ -331,7 +331,7 @@ struct TimeRangeSelectorView: View {
     private func chipLabel(_ text: String, isSelected: Bool) -> some View {
         Text(text)
             .font(.caption.weight(isSelected ? .bold : .regular))
-            .padding(.horizontal, 12)
+            .padding(.horizontal, DesignTokens.Spacing.md)
             .padding(.vertical, 6)
             .background(isSelected ? Color.accentColor : Color(.secondarySystemBackground))
             .foregroundStyle(isSelected ? .white : .primary)
@@ -397,7 +397,7 @@ struct DayStatisticsCard: View {
     @Bindable var viewModel: AnalyticsViewModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
             Text("Day Statistics")
                 .font(.headline)
 
@@ -416,7 +416,7 @@ struct DayStatisticsCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
         .accessibilityIdentifier("day-statistics-card")
     }
 }
@@ -445,7 +445,7 @@ struct DurationMetricsCard: View {
 
     var body: some View {
         if !viewModel.episodes.isEmpty {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
                 Text("Duration Metrics")
                     .font(.headline)
 
@@ -466,7 +466,7 @@ struct DurationMetricsCard: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
             .background(Color(.secondarySystemBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
             .accessibilityIdentifier("duration-metrics-card")
         }
     }
@@ -480,7 +480,7 @@ struct OverlayListCard: View {
     var onEdit: ((CalendarOverlay) -> Void)?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
             HStack {
                 Text("Overlays")
                     .font(.headline)
@@ -528,7 +528,7 @@ struct OverlayListCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
     }
 
     private func formatDateRange(_ overlay: CalendarOverlay) -> String {
@@ -653,7 +653,7 @@ struct AnalyticsVisualizationPane: View {
     var body: some View {
         GeometryReader { geo in
             ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
                     AnalyticsSectionPicker(selection: $selectedSection)
 
                     switch selectedSection {

--- a/mobile-apps/ios/MigraLog/Views/Analytics/InsightsChartsSection.swift
+++ b/mobile-apps/ios/MigraLog/Views/Analytics/InsightsChartsSection.swift
@@ -11,7 +11,7 @@ struct InsightsChartsSection: View {
     @Bindable var viewModel: AnalyticsViewModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
             WarningCalloutsCard(warnings: viewModel.insightWarnings)
             MonthlySummaryCard(summaries: viewModel.monthlySummaries, medications: viewModel.summaryMedications)
             HeadacheBurdenChartCard(points: viewModel.headacheDayTrend)
@@ -34,7 +34,7 @@ private struct InsightCard<Content: View>: View {
     @ViewBuilder var content: Content
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
             Text(title)
                 .font(.headline)
             Text(subtitle)
@@ -45,7 +45,7 @@ private struct InsightCard<Content: View>: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
         .accessibilityIdentifier(accessibilityId)
     }
 }
@@ -65,12 +65,12 @@ struct WarningCalloutsCard: View {
     let warnings: [AnalyticsInsights.Warning]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
             Text("Warning Signs")
                 .font(.headline)
 
             if warnings.isEmpty {
-                HStack(spacing: 8) {
+                HStack(spacing: DesignTokens.Spacing.sm) {
                     Image(systemName: "checkmark.seal.fill")
                         .foregroundStyle(.green)
                     Text("Nothing flagged in the current data.")
@@ -101,7 +101,7 @@ struct WarningCalloutsCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
         .accessibilityIdentifier("insights-warnings-card")
     }
 
@@ -216,7 +216,7 @@ private struct ClassIntakeChart: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
             HStack(spacing: 6) {
                 Circle()
                     .fill(color)
@@ -254,7 +254,7 @@ private struct ClassIntakeChart: View {
                     .foregroundStyle(.tertiary)
             }
         }
-        .padding(.top, 4)
+        .padding(.top, DesignTokens.Spacing.xs)
     }
 }
 
@@ -404,7 +404,7 @@ struct MonthlySummaryCard: View {
             if summaries.isEmpty {
                 EmptyChartPlaceholder()
             } else {
-                HStack(alignment: .top, spacing: 8) {
+                HStack(alignment: .top, spacing: DesignTokens.Spacing.sm) {
                     labelColumn
                     scrollableValueColumns
                 }

--- a/mobile-apps/ios/MigraLog/Views/Components/MedicationSafetyBanners.swift
+++ b/mobile-apps/ios/MigraLog/Views/Components/MedicationSafetyBanners.swift
@@ -20,7 +20,7 @@ struct MedicationSafetyBanners: View {
     var medicationId: String?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
             if let cooldown, let text = cooldownText(cooldown) {
                 Label(text, systemImage: "clock.fill")
                     .font(.caption)

--- a/mobile-apps/ios/MigraLog/Views/Components/PainIntensitySlider.swift
+++ b/mobile-apps/ios/MigraLog/Views/Components/PainIntensitySlider.swift
@@ -11,7 +11,7 @@ struct PainIntensitySlider: View {
     var body: some View {
         let level = PainScale.level(for: intensity)
 
-        VStack(spacing: 8) {
+        VStack(spacing: DesignTokens.Spacing.sm) {
             // Number + Label
             HStack {
                 Text(String(format: "%.0f", intensity))

--- a/mobile-apps/ios/MigraLog/Views/Components/PainLocationGrid.swift
+++ b/mobile-apps/ios/MigraLog/Views/Components/PainLocationGrid.swift
@@ -51,9 +51,9 @@ struct PainLocationGrid: View {
                 .frame(minHeight: 44)
                 .background(isSelected ? Color.accentColor : Color(.tertiarySystemBackground))
                 .foregroundStyle(isSelected ? .white : .primary)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.md))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 8)
+                    RoundedRectangle(cornerRadius: DesignTokens.Radius.md)
                         .stroke(isSelected ? Color.accentColor : Color(.separator), lineWidth: 1)
                 )
         }

--- a/mobile-apps/ios/MigraLog/Views/Components/SelectableChip.swift
+++ b/mobile-apps/ios/MigraLog/Views/Components/SelectableChip.swift
@@ -12,7 +12,7 @@ struct SelectableChip: View {
         Button(action: action) {
             Text(title)
                 .font(.subheadline)
-                .padding(.horizontal, 16)
+                .padding(.horizontal, DesignTokens.Spacing.lg)
                 .padding(.vertical, 10)
                 .foregroundStyle(isSelected ? .white : .primary)
                 .background(isSelected ? Color.accentColor : Color(.tertiarySystemBackground))

--- a/mobile-apps/ios/MigraLog/Views/DailyStatus/DailyStatusPromptScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/DailyStatus/DailyStatusPromptScreen.swift
@@ -23,7 +23,7 @@ struct DailyStatusPromptScreen: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
                 // Date header
                 Text(DateFormatting.displayDate(date))
                     .font(.title3.weight(.bold))
@@ -99,7 +99,7 @@ struct DailyStatusPromptScreen: View {
         }
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
 
         // Show notes if logged
         if let existingNotes = existingStatus?.notes, !existingNotes.isEmpty, !isEditing {
@@ -114,7 +114,7 @@ struct DailyStatusPromptScreen: View {
 
     @ViewBuilder
     private var episodesSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
             Text("Episodes")
                 .font(.headline)
 
@@ -139,7 +139,7 @@ struct DailyStatusPromptScreen: View {
                     }
                     .padding()
                     .background(Color(.secondarySystemBackground))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
                 }
                 .buttonStyle(.plain)
             }
@@ -150,7 +150,7 @@ struct DailyStatusPromptScreen: View {
 
     @ViewBuilder
     private var overlaysSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
             Text("Overlays")
                 .font(.headline)
 
@@ -171,7 +171,7 @@ struct DailyStatusPromptScreen: View {
                 }
                 .padding()
                 .background(Color(.secondarySystemBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
             }
         }
     }
@@ -180,7 +180,7 @@ struct DailyStatusPromptScreen: View {
 
     @ViewBuilder
     private var editStatusSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
             if existingStatus == nil && !isImplicitRed {
                 Text("Log this day")
                     .font(.headline)
@@ -189,7 +189,7 @@ struct DailyStatusPromptScreen: View {
                     .font(.headline)
             }
 
-            HStack(spacing: 16) {
+            HStack(spacing: DesignTokens.Spacing.lg) {
                 StatusButton(title: "Clear", color: .green, isSelected: selectedStatus == .green) {
                     selectedStatus = .green
                     selectedType = nil
@@ -203,12 +203,12 @@ struct DailyStatusPromptScreen: View {
             }
 
             if selectedStatus == .yellow {
-                VStack(alignment: .leading, spacing: 8) {
+                VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
                     Text("Type (optional)")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
 
-                    FlowLayout(spacing: 8) {
+                    FlowLayout(spacing: DesignTokens.Spacing.sm) {
                         ForEach(YellowDayType.allCases) { type in
                             SelectableChip(
                                 title: type.displayName,
@@ -361,7 +361,7 @@ struct StatusButton: View {
                 .padding()
                 .background(isSelected ? color : color.opacity(0.2))
                 .foregroundStyle(isSelected ? .white : color)
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
         }
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -93,10 +93,10 @@ struct DashboardScreen: View {
     // MARK: - iPhone Layout (existing single-column)
 
     private var iPhoneDashboardLayout: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: DesignTokens.Spacing.lg) {
             TodaysMedicationsCard(viewModel: viewModel)
             DailyStatusWidgetView(viewModel: viewModel)
-            HStack(spacing: 12) {
+            HStack(spacing: DesignTokens.Spacing.md) {
                 startEpisodeButton
                 logMedicationButton
             }
@@ -124,17 +124,17 @@ struct DashboardScreen: View {
                 // Landscape / wide: three balanced columns — actions, activity,
                 // and the month calendar — so the wide canvas carries real
                 // content instead of trailing whitespace.
-                HStack(alignment: .top, spacing: 16) {
-                    VStack(spacing: 16) {
+                HStack(alignment: .top, spacing: DesignTokens.Spacing.lg) {
+                    VStack(spacing: DesignTokens.Spacing.lg) {
                         TodaysMedicationsCard(viewModel: viewModel)
-                        HStack(spacing: 12) {
+                        HStack(spacing: DesignTokens.Spacing.md) {
                             startEpisodeButton
                             logMedicationButton
                         }
                     }
                     .frame(maxWidth: .infinity, alignment: .top)
 
-                    VStack(spacing: 16) {
+                    VStack(spacing: DesignTokens.Spacing.lg) {
                         DailyStatusWidgetView(viewModel: viewModel)
                         RecentEpisodesCard(viewModel: viewModel)
                     }
@@ -150,18 +150,18 @@ struct DashboardScreen: View {
                 // Portrait iPad: medications + status side by side, then
                 // full-width actions, then recent episodes beside the
                 // month calendar.
-                VStack(spacing: 16) {
-                    HStack(alignment: .top, spacing: 16) {
+                VStack(spacing: DesignTokens.Spacing.lg) {
+                    HStack(alignment: .top, spacing: DesignTokens.Spacing.lg) {
                         TodaysMedicationsCard(viewModel: viewModel)
                             .frame(maxWidth: .infinity)
                         DailyStatusWidgetView(viewModel: viewModel)
                             .frame(maxWidth: .infinity)
                     }
-                    HStack(spacing: 12) {
+                    HStack(spacing: DesignTokens.Spacing.md) {
                         startEpisodeButton
                         logMedicationButton
                     }
-                    HStack(alignment: .top, spacing: 16) {
+                    HStack(alignment: .top, spacing: DesignTokens.Spacing.lg) {
                         RecentEpisodesCard(viewModel: viewModel)
                             .frame(maxWidth: .infinity)
                         MonthlyCalendarView(viewModel: calendarViewModel)
@@ -198,7 +198,7 @@ struct DashboardScreen: View {
                 .padding(.vertical, 14)
                 .background(Color.accentColor)
                 .foregroundStyle(.white)
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
         }
         .accessibilityIdentifier(hasOngoingEpisode ? "log-update-button" : "start-episode-button")
         .accessibilityHint(hasOngoingEpisode
@@ -217,7 +217,7 @@ struct DashboardScreen: View {
                 .padding(.vertical, 14)
                 .background(Color.blue.opacity(0.1))
                 .foregroundStyle(.blue)
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
         }
         .accessibilityIdentifier("log-medication-button")
     }
@@ -230,7 +230,7 @@ struct DailyStatusWidgetView: View {
 
     var body: some View {
         if viewModel.yesterdayStatus != nil || viewModel.shouldShowYesterdayPrompt {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
                 if let yesterdayStatus = viewModel.yesterdayStatus {
                     HStack {
                         Text("Yesterday logged as \(yesterdayStatus.status.displayName) day")
@@ -243,11 +243,11 @@ struct DailyStatusWidgetView: View {
                     }
                     .accessibilityIdentifier("daily-status-widget-logged")
                 } else {
-                    VStack(alignment: .leading, spacing: 8) {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
                         Text("How was yesterday?")
                             .font(.headline)
 
-                        HStack(spacing: 12) {
+                        HStack(spacing: DesignTokens.Spacing.md) {
                             Button {
                                 Task { await viewModel.logYesterdayStatus(.green) }
                             } label: {
@@ -256,7 +256,7 @@ struct DailyStatusWidgetView: View {
                                     .padding(.vertical, 10)
                                     .background(Color.green.opacity(0.2))
                                     .foregroundStyle(.green)
-                                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                                    .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
                             }
                             .accessibilityLabel("Clear day")
                             .accessibilityIdentifier("green-day-button")
@@ -269,7 +269,7 @@ struct DailyStatusWidgetView: View {
                                     .padding(.vertical, 10)
                                     .background(Color.yellow.opacity(0.2))
                                     .foregroundStyle(.orange)
-                                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                                    .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
                             }
                             .accessibilityLabel("Not clear day")
                             .accessibilityIdentifier("yellow-day-button")
@@ -281,7 +281,7 @@ struct DailyStatusWidgetView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()
             .background(Color(.secondarySystemBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
         }
     }
 }
@@ -307,7 +307,7 @@ struct TodaysMedicationsCard: View {
         SwiftUI.TimelineView(.periodic(from: .now, by: 60)) { context in
             let items = visibleItems(now: context.date)
             if !items.isEmpty {
-                VStack(alignment: .leading, spacing: 8) {
+                VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
                     Text("Today's Medications")
                         .font(.headline)
 
@@ -321,7 +321,7 @@ struct TodaysMedicationsCard: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding()
                 .background(Color(.secondarySystemBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
                 // Contain children so this identifier stays on the card and
                 // doesn't override the per-row identifiers (e.g.
                 // medication-name-link-*).
@@ -369,7 +369,7 @@ struct MedicationScheduleRow: View {
         let catStatus = categoryStatus
         let showBanners = item.dose == nil
 
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
             if showBanners {
                 MedicationSafetyBanners(
                     cooldown: status,
@@ -424,7 +424,7 @@ struct MedicationScheduleRow: View {
                     Button {
                         Task { await viewModel.logDose(scheduleItem: item) }
                     } label: {
-                        HStack(spacing: 4) {
+                        HStack(spacing: DesignTokens.Spacing.xs) {
                             if status.isOnCooldown {
                                 Image(systemName: "clock.fill")
                                     .foregroundStyle(.orange)
@@ -438,11 +438,11 @@ struct MedicationScheduleRow: View {
                             Text("Log \(doseLabel)")
                         }
                         .font(.caption.weight(.medium))
-                        .padding(.horizontal, 12)
+                        .padding(.horizontal, DesignTokens.Spacing.md)
                         .padding(.vertical, 6)
                         .background(Color.accentColor)
                         .foregroundStyle(.white)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.md))
                     }
 
                     Button {
@@ -450,16 +450,16 @@ struct MedicationScheduleRow: View {
                     } label: {
                         Text("Skip")
                             .font(.caption.weight(.medium))
-                            .padding(.horizontal, 12)
+                            .padding(.horizontal, DesignTokens.Spacing.md)
                             .padding(.vertical, 6)
                             .background(Color.red.opacity(0.15))
                             .foregroundStyle(.red)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                            .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.md))
                     }
                 }
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, DesignTokens.Spacing.xs)
     }
 }
 
@@ -476,7 +476,7 @@ struct RecentEpisodesCard: View {
 
     var body: some View {
         if hasContent {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
                 Text("Recent Episodes")
                     .font(.headline)
 

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EditEpisodeScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EditEpisodeScreen.swift
@@ -51,7 +51,7 @@ struct EditEpisodeScreen: View {
             }
 
             Section("Symptoms") {
-                FlowLayout(spacing: 8) {
+                FlowLayout(spacing: DesignTokens.Spacing.sm) {
                     ForEach(symptomChoices) { symptom in
                         Toggle(isOn: Binding(
                             get: { selectedSymptoms.contains(symptom) },
@@ -67,7 +67,7 @@ struct EditEpisodeScreen: View {
             }
 
             Section("Triggers") {
-                FlowLayout(spacing: 8) {
+                FlowLayout(spacing: DesignTokens.Spacing.sm) {
                     ForEach(triggerChoices) { trigger in
                         Toggle(isOn: Binding(
                             get: { selectedTriggers.contains(trigger) },

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeActionButtons.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeActionButtons.swift
@@ -12,7 +12,7 @@ struct EpisodeActionButtons: View {
     @Binding var showEndTimePicker: Bool
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: DesignTokens.Spacing.sm) {
             Button {
                 showLogUpdate = true
             } label: {
@@ -21,7 +21,7 @@ struct EpisodeActionButtons: View {
                     .padding()
                     .background(Color.blue.opacity(0.1))
                     .foregroundStyle(.blue)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
             }
             .accessibilityIdentifier("log-update-button")
 
@@ -33,11 +33,11 @@ struct EpisodeActionButtons: View {
                     .padding()
                     .background(Color.green.opacity(0.1))
                     .foregroundStyle(.green)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
             }
             .accessibilityIdentifier("log-medication-button")
 
-            HStack(spacing: 8) {
+            HStack(spacing: DesignTokens.Spacing.sm) {
                 Button {
                     Task {
                         await viewModel.endEpisode(episodeId, at: TimestampHelper.now)
@@ -48,7 +48,7 @@ struct EpisodeActionButtons: View {
                         .padding()
                         .background(Color.red.opacity(0.1))
                         .foregroundStyle(.red)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
                 }
                 .accessibilityIdentifier("end-now-button")
 
@@ -61,7 +61,7 @@ struct EpisodeActionButtons: View {
                         .padding()
                         .background(Color.orange.opacity(0.1))
                         .foregroundStyle(.orange)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
                 }
                 .accessibilityIdentifier("end-custom-button")
             }

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -212,7 +212,7 @@ struct EpisodeDetailScreen: View {
 
     @ViewBuilder
     private func episodeSummarySection(_ episode: Episode) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
             // Dates row
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 2) {
@@ -228,7 +228,7 @@ struct EpisodeDetailScreen: View {
                 if episode.isActive {
                     Text("Ongoing")
                         .font(.caption.weight(.bold))
-                        .padding(.horizontal, 12)
+                        .padding(.horizontal, DesignTokens.Spacing.md)
                         .padding(.vertical, 6)
                         .background(Color.red.opacity(0.2))
                         .foregroundStyle(.red)
@@ -267,12 +267,12 @@ struct EpisodeDetailScreen: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                     Spacer()
-                    FlowLayout(spacing: 4) {
+                    FlowLayout(spacing: DesignTokens.Spacing.xs) {
                         ForEach(episode.symptoms) { symptom in
                             Text(symptom.displayName)
                                 .font(.caption)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
+                                .padding(.horizontal, DesignTokens.Spacing.sm)
+                                .padding(.vertical, DesignTokens.Spacing.xs)
                                 .background(Color.purple.opacity(0.1))
                                 .clipShape(Capsule())
                         }
@@ -288,12 +288,12 @@ struct EpisodeDetailScreen: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                     Spacer()
-                    FlowLayout(spacing: 4) {
+                    FlowLayout(spacing: DesignTokens.Spacing.xs) {
                         ForEach(episode.triggers) { trigger in
                             Text(trigger.displayName)
                                 .font(.caption)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
+                                .padding(.horizontal, DesignTokens.Spacing.sm)
+                                .padding(.vertical, DesignTokens.Spacing.xs)
                                 .background(Color.orange.opacity(0.1))
                                 .clipShape(Capsule())
                         }
@@ -316,7 +316,7 @@ struct EpisodeDetailScreen: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
     }
 }
 

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodesScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodesScreen.swift
@@ -13,7 +13,7 @@ struct EpisodesScreen: View {
                 )
             } else {
                 ScrollView {
-                    LazyVStack(spacing: 12) {
+                    LazyVStack(spacing: DesignTokens.Spacing.md) {
                         ForEach(viewModel.episodes) { episode in
                             // Value-based link so taps drive the same path binding
                             // (selectedEpisodeId) that deep links use — one nav system.
@@ -41,17 +41,17 @@ struct EpisodeCardView: View {
     let readings: [IntensityReading]
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
+        HStack(alignment: .center, spacing: DesignTokens.Spacing.md) {
             // Left side: text info
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
                 HStack {
                     Text(DateFormatting.relativeDate(episode.startDate))
                         .font(.headline)
                     if episode.isActive {
                         Text("Ongoing")
                             .font(.caption)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
+                            .padding(.horizontal, DesignTokens.Spacing.sm)
+                            .padding(.vertical, DesignTokens.Spacing.xs)
                             .background(Color.red.opacity(0.2))
                             .foregroundStyle(.red)
                             .clipShape(Capsule())
@@ -99,12 +99,12 @@ struct EpisodeCardView: View {
                     episodeEnd: episode.endTime
                 )
                 .frame(width: 160, height: 50)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.sm))
             }
         }
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
     }
 }
 
@@ -117,8 +117,8 @@ struct EpisodeListRowView: View {
     let readings: [IntensityReading]
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
+        HStack(alignment: .center, spacing: DesignTokens.Spacing.md) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
                 HStack {
                     Text(DateFormatting.relativeDate(episode.startDate))
                         .font(.headline)
@@ -127,8 +127,8 @@ struct EpisodeListRowView: View {
                         // color identity on the selection highlight.
                         Text("Ongoing")
                             .font(.caption)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
+                            .padding(.horizontal, DesignTokens.Spacing.sm)
+                            .padding(.vertical, DesignTokens.Spacing.xs)
                             .background(Color.red.opacity(0.2))
                             .background(Color(.systemBackground))
                             .foregroundStyle(.red)
@@ -175,10 +175,10 @@ struct EpisodeListRowView: View {
                     episodeEnd: episode.endTime
                 )
                 .frame(width: 140, height: 44)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.sm))
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, DesignTokens.Spacing.xs)
     }
 }
 

--- a/mobile-apps/ios/MigraLog/Views/Episodes/IntensitySparklineView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/IntensitySparklineView.swift
@@ -33,7 +33,7 @@ struct IntensitySparklineView: View {
                 )
 
                 // Background gradient (green at bottom, purple at top)
-                RoundedRectangle(cornerRadius: 4)
+                RoundedRectangle(cornerRadius: DesignTokens.Radius.sm)
                     .fill(
                         LinearGradient(
                             colors: Self.gradientColors.map { $0.opacity(0.15) },

--- a/mobile-apps/ios/MigraLog/Views/Episodes/LogUpdateScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/LogUpdateScreen.swift
@@ -26,7 +26,7 @@ struct LogUpdateScreen: View {
             }
 
             Section("Additional Symptoms") {
-                FlowLayout(spacing: 8) {
+                FlowLayout(spacing: DesignTokens.Spacing.sm) {
                     ForEach(symptomChoices) { symptom in
                         SelectableChip(
                             title: symptom.displayName,

--- a/mobile-apps/ios/MigraLog/Views/Episodes/NewEpisodeScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/NewEpisodeScreen.swift
@@ -22,7 +22,7 @@ struct NewEpisodeScreen: View {
             }
 
             Section("Pain Qualities") {
-                FlowLayout(spacing: 8) {
+                FlowLayout(spacing: DesignTokens.Spacing.sm) {
                     ForEach(trackingOptions.activeQualities) { quality in
                         SelectableChip(
                             title: quality.displayName,
@@ -39,7 +39,7 @@ struct NewEpisodeScreen: View {
             }
 
             Section("Symptoms") {
-                FlowLayout(spacing: 8) {
+                FlowLayout(spacing: DesignTokens.Spacing.sm) {
                     ForEach(trackingOptions.activeSymptoms) { symptom in
                         SelectableChip(
                             title: symptom.displayName,
@@ -56,7 +56,7 @@ struct NewEpisodeScreen: View {
             }
 
             Section("Possible Triggers") {
-                FlowLayout(spacing: 8) {
+                FlowLayout(spacing: DesignTokens.Spacing.sm) {
                     ForEach(trackingOptions.activeTriggers) { trigger in
                         SelectableChip(
                             title: trigger.displayName,

--- a/mobile-apps/ios/MigraLog/Views/Episodes/TimelineView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/TimelineView.swift
@@ -56,7 +56,7 @@ struct TimelineView: View {
     @Binding var showEditEpisodeSheet: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
             Text("Timeline")
                 .font(.headline)
 
@@ -68,8 +68,8 @@ struct TimelineView: View {
                     episodeEnd: details.episode.endTime
                 )
                 .frame(height: 80)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-                .padding(.bottom, 4)
+                .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.sm))
+                .padding(.bottom, DesignTokens.Spacing.xs)
             }
 
             // Merge all events into a chronological timeline
@@ -129,7 +129,7 @@ struct TimelineView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
     }
 
     private func buildTimelineEvents(from details: EpisodeWithDetails) -> [TimelineEvent] {
@@ -230,7 +230,7 @@ struct TimelineView: View {
     /// Day separator row marking the start of a calendar day within the timeline.
     @ViewBuilder
     private func dayHeader(for date: Date, isFirst: Bool) -> some View {
-        HStack(spacing: 8) {
+        HStack(spacing: DesignTokens.Spacing.sm) {
             Text(DateFormatting.timelineDayHeader(date))
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.secondary)
@@ -239,7 +239,7 @@ struct TimelineView: View {
                 .frame(height: 1)
         }
         .padding(.top, isFirst ? 0 : 12)
-        .padding(.bottom, 4)
+        .padding(.bottom, DesignTokens.Spacing.xs)
     }
 
     @ViewBuilder
@@ -280,7 +280,7 @@ struct TimelineView: View {
         switch event.kind {
         case .intensity(let reading):
             let intensityColor = PainScale.color(for: reading.intensity)
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
                 // Intensity bar
                 GeometryReader { geo in
                     ZStack(alignment: .leading) {
@@ -298,7 +298,7 @@ struct TimelineView: View {
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(intensityColor)
             }
-            .padding(.top, 4)
+            .padding(.top, DesignTokens.Spacing.xs)
 
         case .symptomOnset, .symptomResolved:
             EmptyView()
@@ -337,7 +337,7 @@ struct TimelineView: View {
                         .clipShape(Capsule())
                 }
             }
-            .padding(.top, 4)
+            .padding(.top, DesignTokens.Spacing.xs)
 
         case .note(let note):
             Text(note.note)

--- a/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
@@ -11,7 +11,7 @@ struct LogMedicationScreen: View {
 
     var body: some View {
         ScrollView {
-            LazyVStack(spacing: 12) {
+            LazyVStack(spacing: DesignTokens.Spacing.md) {
                 let allMeds = rescueOnly
                     ? viewModel.medications.filter { $0.type == .rescue }
                     : viewModel.medications
@@ -92,7 +92,7 @@ struct LogMedicationCard: View {
     var body: some View {
         let status = cooldownStatus
         let catStatus = categoryStatus
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(medication.name)
                     .font(.headline)
@@ -109,7 +109,7 @@ struct LogMedicationCard: View {
                 medicationId: medication.id
             )
 
-            HStack(spacing: 8) {
+            HStack(spacing: DesignTokens.Spacing.sm) {
                 Button(action: onQuickLog) {
                     HStack(spacing: 6) {
                         if status.isOnCooldown {
@@ -125,7 +125,7 @@ struct LogMedicationCard: View {
                         Text("Log \(MedicationFormatting.formatDose(quantity: medication.defaultQuantity ?? 1, amount: medication.dosageAmount, unit: medication.dosageUnit))")
                     }
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 12)
+                    .padding(.vertical, DesignTokens.Spacing.md)
                     .background(Color.accentColor)
                     .foregroundStyle(.white)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
@@ -134,7 +134,7 @@ struct LogMedicationCard: View {
                 Button(action: onDetails) {
                     Text("Details")
                         .padding(.horizontal, 20)
-                        .padding(.vertical, 12)
+                        .padding(.vertical, DesignTokens.Spacing.md)
                         .background(Color(.systemGray4))
                         .foregroundStyle(.primary)
                         .clipShape(RoundedRectangle(cornerRadius: 10))
@@ -143,7 +143,7 @@ struct LogMedicationCard: View {
         }
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
     }
 }
 

--- a/mobile-apps/ios/MigraLog/Views/Medications/MedicationDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/MedicationDetailScreen.swift
@@ -41,7 +41,7 @@ struct MedicationDetailScreen: View {
                             .padding()
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .background(Color.orange.opacity(0.1))
-                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                            .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
                             .accessibilityIdentifier("cooldown-banner")
                     }
 
@@ -57,7 +57,7 @@ struct MedicationDetailScreen: View {
                             .padding()
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .background(tint.opacity(0.12))
-                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                            .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
                             .accessibilityIdentifier("category-warning-banner")
                     }
 
@@ -82,7 +82,7 @@ struct MedicationDetailScreen: View {
                         .padding()
                         .background(Color.accentColor)
                         .foregroundStyle(.white)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
                     }
                     .accessibilityIdentifier("log-dose-button")
                 } secondary: {
@@ -101,7 +101,7 @@ struct MedicationDetailScreen: View {
                             .padding()
                             .background(Color.orange.opacity(0.1))
                             .foregroundStyle(.orange)
-                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                            .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
                     }
                     .accessibilityIdentifier("archive-medication-button")
                 }
@@ -192,7 +192,7 @@ struct MedicationDetailScreen: View {
 
     @ViewBuilder
     private func medicationInfoSection(_ medication: Medication) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
             LabeledContent("Type") { Text(medication.type.displayName) }
             LabeledContent("Dosage") {
                 Text(MedicationFormatting.formatDosage(amount: medication.dosageAmount, unit: medication.dosageUnit))
@@ -209,12 +209,12 @@ struct MedicationDetailScreen: View {
         }
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
     }
 
     @ViewBuilder
     private func schedulesSection(_ medication: Medication) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
             HStack {
                 Text("Reminders")
                     .font(.headline)
@@ -279,7 +279,7 @@ struct MedicationDetailScreen: View {
         }
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
     }
 
     @ViewBuilder
@@ -291,7 +291,7 @@ struct MedicationDetailScreen: View {
         }
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
     }
 
     @ViewBuilder
@@ -313,7 +313,7 @@ struct MedicationDetailScreen: View {
             } label: {
                 Image(systemName: "ellipsis.circle")
                     .foregroundStyle(.secondary)
-                    .padding(.leading, 4)
+                    .padding(.leading, DesignTokens.Spacing.xs)
             }
             .accessibilityIdentifier("dose-menu-\(dose.id)")
         }
@@ -333,7 +333,7 @@ struct MedicationDetailScreen: View {
 
     @ViewBuilder
     private func recentActivitySection() -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.sm) {
             Text("Recent Activity")
                 .font(.headline)
 
@@ -350,7 +350,7 @@ struct MedicationDetailScreen: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
     }
 }
 
@@ -380,6 +380,6 @@ struct DoseRowView: View {
                     .foregroundStyle(.red)
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, DesignTokens.Spacing.xs)
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Medications/MedicationsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/MedicationsScreen.swift
@@ -94,7 +94,7 @@ struct MedicationRowView: View {
     let medication: Medication
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
             Text(medication.name)
                 .font(.headline)
             Text(MedicationFormatting.formatDosage(amount: medication.dosageAmount, unit: medication.dosageUnit))
@@ -106,7 +106,7 @@ struct MedicationRowView: View {
                     Text(category.displayName)
                         .font(.caption2.weight(.semibold))
                         .padding(.horizontal, 10)
-                        .padding(.vertical, 4)
+                        .padding(.vertical, DesignTokens.Spacing.xs)
                         .foregroundStyle(.secondary)
                         .background(Color(.systemGray5))
                         .clipShape(Capsule())
@@ -125,7 +125,7 @@ struct MedicationListRowView: View {
     let medication: Medication
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
             Text(medication.name)
                 .font(.headline)
                 .foregroundStyle(.primary)
@@ -138,7 +138,7 @@ struct MedicationListRowView: View {
                     Text(category.displayName)
                         .font(.caption2.weight(.semibold))
                         .padding(.horizontal, 10)
-                        .padding(.vertical, 4)
+                        .padding(.vertical, DesignTokens.Spacing.xs)
                         .foregroundStyle(Color(.secondaryLabel))
                         .background(Color(.systemGray5))
                         .background(Color(.systemBackground))
@@ -237,7 +237,7 @@ struct MedicationTypeBadge: View {
         Text(MedicationTypeColors.label(for: type))
             .font(.caption2.weight(.semibold))
             .padding(.horizontal, 10)
-            .padding(.vertical, 4)
+            .padding(.vertical, DesignTokens.Spacing.xs)
             .foregroundStyle(badgeColor)
             .background(badgeColor.opacity(0.2))
             .background(Color(.systemBackground))

--- a/mobile-apps/ios/MigraLog/Views/Onboarding/WelcomeScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Onboarding/WelcomeScreen.swift
@@ -11,7 +11,7 @@ struct WelcomeScreen: View {
     var body: some View {
         VStack {
             // Progress
-            HStack(spacing: 8) {
+            HStack(spacing: DesignTokens.Spacing.sm) {
                 ForEach(0..<totalSteps, id: \.self) { step in
                     RoundedRectangle(cornerRadius: 2)
                         .fill(step <= currentStep ? Color.accentColor : Color(.systemGray4))
@@ -55,7 +55,7 @@ struct WelcomeScreen: View {
                         .padding()
                         .background(Color.accentColor)
                         .foregroundStyle(.white)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
                 }
                 .padding(.horizontal)
                 .padding(.bottom)
@@ -68,16 +68,16 @@ struct WelcomeScreen: View {
 
 struct WelcomeStepView: View {
     var body: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: DesignTokens.Spacing.xl) {
             Spacer()
             Image(systemName: "brain.head.profile")
-                .font(.system(size: 80))
+                .font(.system(size: DesignTokens.Typography.displayXL))
                 .foregroundStyle(Color.accentColor)
 
             Text("Welcome to MigraLog")
                 .font(.largeTitle.weight(.bold))
 
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
                 FeatureRow(icon: "bolt.heart", title: "Track Episodes", description: "Log migraine episodes with intensity, symptoms, and triggers")
                 FeatureRow(icon: "pills", title: "Medication Tracking", description: "Track preventative and rescue medications")
                 FeatureRow(icon: "chart.bar", title: "Insights", description: "Discover patterns and trends over time")
@@ -90,10 +90,10 @@ struct WelcomeStepView: View {
 
 struct DisclaimerStepView: View {
     var body: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: DesignTokens.Spacing.xl) {
             Spacer()
             Image(systemName: "heart.text.square")
-                .font(.system(size: 60))
+                .font(.system(size: DesignTokens.Typography.displayLarge))
                 .foregroundStyle(.red)
 
             Text("Medical Disclaimer")
@@ -113,10 +113,10 @@ struct NotificationPermissionStepView: View {
     let onContinue: () -> Void
 
     var body: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: DesignTokens.Spacing.xl) {
             Spacer()
             Image(systemName: "bell.badge")
-                .font(.system(size: 60))
+                .font(.system(size: DesignTokens.Typography.displayLarge))
                 .foregroundStyle(.blue)
 
             Text("Notification Permissions")
@@ -139,7 +139,7 @@ struct NotificationPermissionStepView: View {
                     .padding()
                     .background(Color.accentColor)
                     .foregroundStyle(.white)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
             }
             .padding(.horizontal)
             Spacer()
@@ -152,10 +152,10 @@ struct LocationPermissionStepView: View {
     let onComplete: () -> Void
 
     var body: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: DesignTokens.Spacing.xl) {
             Spacer()
             Image(systemName: "location")
-                .font(.system(size: 60))
+                .font(.system(size: DesignTokens.Typography.displayLarge))
                 .foregroundStyle(.green)
 
             Text("Location Services")
@@ -179,7 +179,7 @@ struct LocationPermissionStepView: View {
                     .padding()
                     .background(Color.accentColor)
                     .foregroundStyle(.white)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
             }
             .padding(.horizontal)
             Spacer()
@@ -195,7 +195,7 @@ struct FeatureRow: View {
     let description: String
 
     var body: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: DesignTokens.Spacing.lg) {
             Image(systemName: icon)
                 .font(.title2)
                 .foregroundStyle(Color.accentColor)

--- a/mobile-apps/ios/MigraLog/Views/Settings/AddTrackingOptionSheet.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/AddTrackingOptionSheet.swift
@@ -33,7 +33,7 @@ struct AddTrackingOptionSheet: View {
                 let matches = viewModel.suggestions(for: category, query: name)
                 if !matches.isEmpty {
                     Section("Suggestions") {
-                        FlowLayout(spacing: 8) {
+                        FlowLayout(spacing: DesignTokens.Spacing.sm) {
                             ForEach(matches) { suggestion in
                                 SelectableChip(
                                     title: suggestion.displayName,

--- a/mobile-apps/ios/MigraLog/Views/Settings/CategorySafetyRuleEditorSheet.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/CategorySafetyRuleEditorSheet.swift
@@ -111,7 +111,7 @@ struct CategorySafetyRuleEditorSheet: View {
                     .accessibilityIdentifier("rule-editor-max-days")
             }
             LabeledContent("In any rolling window of") {
-                HStack(spacing: 4) {
+                HStack(spacing: DesignTokens.Spacing.xs) {
                     TextField("", text: $windowDaysText, prompt: Text("e.g. 30"))
                         .keyboardType(.numberPad)
                         .multilineTextAlignment(.trailing)
@@ -138,7 +138,7 @@ struct CategorySafetyRuleEditorSheet: View {
     private var cooldownSection: some View {
         Section {
             LabeledContent("Minimum time between doses") {
-                HStack(spacing: 4) {
+                HStack(spacing: DesignTokens.Spacing.xs) {
                     TextField("", text: $cooldownHoursText, prompt: Text("e.g. 4"))
                         .keyboardType(.decimalPad)
                         .multilineTextAlignment(.trailing)

--- a/mobile-apps/ios/MigraLog/Views/Settings/DatabaseErrorView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DatabaseErrorView.swift
@@ -15,11 +15,11 @@ struct DatabaseErrorView: View {
     }
 
     var body: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: DesignTokens.Spacing.xl) {
             Spacer()
 
             Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 56))
+                .font(.system(size: DesignTokens.Typography.displayMedium))
                 .foregroundStyle(.orange)
 
             Text("Database Error")
@@ -30,23 +30,23 @@ struct DatabaseErrorView: View {
                 .font(.body)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
-                .padding(.horizontal, 32)
+                .padding(.horizontal, DesignTokens.Spacing.xxl)
 
             if let error {
                 Text(error.localizedDescription)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 32)
+                    .padding(.horizontal, DesignTokens.Spacing.xxl)
             }
 
             if databaseFileExists {
-                VStack(spacing: 12) {
+                VStack(spacing: DesignTokens.Spacing.md) {
                     Text("You can export the database file so it can be recovered or sent to support.")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
-                        .padding(.horizontal, 32)
+                        .padding(.horizontal, DesignTokens.Spacing.xxl)
 
                     Button {
                         showShareSheet = true
@@ -55,14 +55,14 @@ struct DatabaseErrorView: View {
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.borderedProminent)
-                    .padding(.horizontal, 32)
+                    .padding(.horizontal, DesignTokens.Spacing.xxl)
                 }
             } else {
                 Text("No database file was found on this device.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 32)
+                    .padding(.horizontal, DesignTokens.Spacing.xxl)
             }
 
             Spacer()

--- a/mobile-apps/ios/MigraLog/Views/Settings/DeveloperToolsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DeveloperToolsScreen.swift
@@ -44,7 +44,7 @@ struct DeveloperToolsScreen: View {
                     showResyncConfirm = true
                 } label: {
                     if syncService.isSyncing {
-                        HStack(spacing: 8) {
+                        HStack(spacing: DesignTokens.Spacing.sm) {
                             ProgressView()
                             Text("Re-syncing…")
                         }

--- a/mobile-apps/ios/MigraLog/Views/Settings/LogViewerScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/LogViewerScreen.swift
@@ -22,8 +22,8 @@ struct LogViewerScreen: View {
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(filtered) { entry in
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack(spacing: 8) {
+                        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
+                            HStack(spacing: DesignTokens.Spacing.sm) {
                                 Text(entry.level.label)
                                     .font(.caption.weight(.semibold))
                                     .foregroundStyle(color(for: entry.level))

--- a/mobile-apps/ios/MigraLog/Views/Settings/ScheduledNotificationsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/ScheduledNotificationsScreen.swift
@@ -97,8 +97,8 @@ struct ScheduledNotificationsScreen: View {
 
     @ViewBuilder
     private func row(_ entry: ScheduledNotificationEntry) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
+            HStack(spacing: DesignTokens.Spacing.sm) {
                 Text(entry.status.label)
                     .font(.caption.weight(.semibold))
                     .padding(.horizontal, 6)
@@ -271,7 +271,7 @@ private struct ScheduledNotificationDetailView: View {
                     LabeledContent("Sound", value: os.content.sound.map { "\($0)" } ?? "—")
                     LabeledContent("Interruption", value: "\(os.content.interruptionLevel.rawValue)")
                     if !os.content.userInfo.isEmpty {
-                        VStack(alignment: .leading, spacing: 4) {
+                        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
                             Text("userInfo").font(.caption).foregroundStyle(.secondary)
                             Text(formatUserInfo(os.content.userInfo))
                                 .font(.caption.monospaced())

--- a/mobile-apps/ios/MigraLog/Views/Settings/SyncSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/SyncSettingsScreen.swift
@@ -32,7 +32,7 @@ struct SyncSettingsScreen: View {
                         Task { await syncNow() }
                     } label: {
                         if syncService.isSyncing {
-                            HStack(spacing: 8) {
+                            HStack(spacing: DesignTokens.Spacing.sm) {
                                 ProgressView()
                                 Text("Syncing…")
                             }

--- a/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivity.swift
+++ b/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivity.swift
@@ -87,7 +87,7 @@ struct EpisodeLockScreenView: View {
             }
             // Read "In migraine, <elapsed>" as one element.
             .accessibilityElement(children: .combine)
-            HStack(spacing: 12) {
+            HStack(spacing: DesignTokens.Spacing.md) {
                 if let intensity = LiveActivityStyle.intensityLabel(context.state.currentIntensity) {
                     StatChip(systemImage: "gauge.with.dots.needle.50percent", text: intensity)
                         .accessibilityLabel("Pain intensity \(intensity)")

--- a/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivityComponents.swift
+++ b/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivityComponents.swift
@@ -63,7 +63,7 @@ struct ActionRow: View {
     let episodeId: String
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: DesignTokens.Spacing.sm) {
             ActionLink(
                 title: "Log",
                 systemImage: "pills.fill",


### PR DESCRIPTION
Follow-up to #520. That PR created the `DesignTokens` spacing/radius/typography scales but only fully migrated **colors**. This adopts the remaining scales so the tokens are actually used:

- Custom display font sizes (`.system(size: 56/60/80)`) → `DesignTokens.Typography.display*`
- Stack/grid `spacing:` and `.padding(edge?, N)` on the 4/8/12/16/24/32 scale → `DesignTokens.Spacing`
- `cornerRadius:` / `.cornerRadius()` of 4/8/12 → `DesignTokens.Radius`

Off-scale values (2/5/6/10/20/40, `frame` sizes, line widths) are intentionally left as literals — only exact scale matches were migrated. Every value is **identical**, so this is a pure refactor.

## Verification
- App + widget: `BUILD SUCCEEDED`
- **980 unit tests pass**, 0 failures
- Diff reviewed: 167 replacements across 29 files, none in comments/strings, off-scale literals preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)