### PR TITLE
fix(ios): defer FK-failing children across paginated sync pull (#523)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncEngine.swift
@@ -137,6 +137,14 @@ actor SyncEngine {
         var token = zoneState?.serverChangeToken
         var didResetToken = false
 
+        // A child record (e.g. intensity_readings) whose FK parent (episodes) hasn't been
+        // applied yet when we reach it. The per-batch parents-first sort below orders one
+        // batch correctly, but CloudKit paginates the zone, so on a full-history pull a
+        // child can arrive in an earlier page than its parent — its FK insert then fails
+        // (SQLite error 19) and, left to propagate, aborts the whole sync. Collect those
+        // failures and retry them once every batch has landed (#523).
+        var deferredChildren: [SyncRecord] = []
+
         // #469: if a migration added synced columns since the last pull, already-synced
         // rows are locally missing those columns (migrate-on-read dropped them) and the
         // incremental cursor will never redeliver them — the source rows haven't
@@ -164,23 +172,59 @@ actor SyncEngine {
             }
             let ordered = batch.records.sorted { Self.applyRank($0) < Self.applyRank($1) }
             for record in ordered {
-                let outcome = try applier.apply(record, now: now)
-                // A remote change that won last-write-wins supersedes any locally-queued
-                // edit for the same row — drop it so push doesn't send the now-stale local
-                // version back and clobber the winner.
-                if outcome == .appliedRemoteWin {
-                    try pendingStore.removePending(tableName: record.tableName, recordId: record.recordId)
+                do {
+                    if try applyAndReconcile(record, now: now) { applied += 1 }
+                } catch let error as DatabaseError where error.extendedResultCode == .SQLITE_CONSTRAINT_FOREIGNKEY {
+                    // Parent not here yet (later page) — retry after the pull completes.
+                    deferredChildren.append(record)
                 }
-                applied += 1
             }
             token = batch.newToken
             try zoneStore.saveChangeToken(token, zoneName: Self.zoneName, syncedAt: now)
             if !batch.moreComing { break }
         }
+        applied += try drainDeferred(deferredChildren, now: now)
         // Stamp the manifest only after the pull completed — if a re-pull fails midway
         // the stored manifest stays stale and the next sync resets the cursor again.
         if zoneState?.lastSyncedSchema != schemaManifest {
             try zoneStore.saveSyncedSchema(schemaManifest, zoneName: Self.zoneName)
+        }
+        return applied
+    }
+
+    /// Apply one remote record and reconcile the local outbound queue. Returns whether the
+    /// record counts toward the applied total (every successful apply does). A remote change
+    /// that won last-write-wins supersedes any locally-queued edit for the same row — drop it
+    /// so push doesn't send the now-stale local version back and clobber the winner.
+    @discardableResult
+    private func applyAndReconcile(_ record: SyncRecord, now: Int64) throws -> Bool {
+        let outcome = try applier.apply(record, now: now)
+        if outcome == .appliedRemoteWin {
+            try pendingStore.removePending(tableName: record.tableName, recordId: record.recordId)
+        }
+        return true
+    }
+
+    /// Retry records that failed their FK check during the batched pull, now that the rest
+    /// of the zone has landed and their parents exist. Loops until a full pass applies
+    /// nothing new: anything still failing is a genuine orphan (its parent was deleted
+    /// upstream, so a cascade would drop it anyway) and is discarded rather than aborting
+    /// the sync. Returns the number applied.
+    private func drainDeferred(_ deferred: [SyncRecord], now: Int64) throws -> Int {
+        var pending = deferred
+        var applied = 0
+        while !pending.isEmpty {
+            var stillDeferred: [SyncRecord] = []
+            for record in pending {
+                do {
+                    if try applyAndReconcile(record, now: now) { applied += 1 }
+                } catch let error as DatabaseError where error.extendedResultCode == .SQLITE_CONSTRAINT_FOREIGNKEY {
+                    stillDeferred.append(record)
+                }
+            }
+            // No progress this pass → the remainder are unresolvable orphans.
+            if stillDeferred.count == pending.count { break }
+            pending = stillDeferred
         }
         return applied
     }

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/InMemoryCloudKitTransport.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/InMemoryCloudKitTransport.swift
@@ -20,6 +20,10 @@ final class InMemoryCloudKitTransport: CloudKitTransport, @unchecked Sendable {
     var failNextFetch: Error?
     /// Controls `accountAvailable()` for precondition tests.
     var accountIsAvailable = true
+    /// When set, `fetchChanges` returns at most this many records per call and flags
+    /// `moreComing`, modelling CloudKit's zone pagination (so cross-page ordering can be
+    /// exercised). `nil` returns the whole zone in one batch.
+    var pageSize: Int?
 
     func accountAvailable() async throws -> Bool {
         lock.lock(); defer { lock.unlock() }
@@ -83,9 +87,14 @@ final class InMemoryCloudKitTransport: CloudKitTransport, @unchecked Sendable {
             .filter { $0.value > sinceSeq }
             .sorted { $0.value < $1.value }
             .map { $0.key }
-        let records = changedNames.compactMap { storage[$0] }
-        let newSeq = changeSeq.values.max() ?? sinceSeq
-        return SyncChangeBatch(records: records, newToken: Data(String(newSeq).utf8), moreComing: false)
+
+        // Paginate when pageSize is set: return one page and advance the token to the last
+        // record in it, leaving the rest for the next fetch (moreComing = true).
+        let pageNames = pageSize.map { Array(changedNames.prefix($0)) } ?? changedNames
+        let records = pageNames.compactMap { storage[$0] }
+        let moreComing = pageSize != nil && pageNames.count < changedNames.count
+        let newSeq = pageNames.last.flatMap { changeSeq[$0] } ?? (changeSeq.values.max() ?? sinceSeq)
+        return SyncChangeBatch(records: records, newToken: Data(String(newSeq).utf8), moreComing: moreComing)
     }
 
     /// Test helper: the current stored record for a recordName, if any.

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncEngineTests.swift
@@ -188,6 +188,64 @@ final class SyncEngineTests: XCTestCase {
         XCTAssertEqual(childCount, 1, "child applied after parent, no FK error")
     }
 
+    /// #523: on a full-history pull CloudKit paginates the zone, so the per-batch
+    /// parents-first sort can't help when a child (intensity_readings) lands in an earlier
+    /// page than its parent (episodes). The FK insert fails on that page; the engine must
+    /// defer it and retry once the parent arrives, instead of aborting the whole sync.
+    func testPullDefersChildUntilParentArrivesInLaterPage() async throws {
+        let reading = SyncRecord(
+            tableName: "intensity_readings", recordId: "ir1",
+            payload: payload([
+                "id": "ir1", "episode_id": "e1", "timestamp": Int64(1000), "intensity": 5.0,
+                "created_at": Int64(1000), "updated_at": Int64(1000),
+            ]),
+            schemaVersion: 31, updatedAt: 1000, deleted: false
+        )
+        let episode = SyncRecord(
+            tableName: "episodes", recordId: "e1",
+            payload: payload([
+                "id": "e1", "start_time": Int64(1000), "locations": "[]", "qualities": "[]",
+                "symptoms": "[]", "triggers": "[]", "created_at": Int64(1000), "updated_at": Int64(1000),
+            ]),
+            schemaVersion: 31, updatedAt: 1000, deleted: false
+        )
+        // Child seeded first → page 1 is the child, page 2 is the parent. The sort cannot
+        // reorder across pages, so page 1's child hits the FK constraint.
+        try await transport.push([reading])
+        try await transport.push([episode])
+        transport.pageSize = 1
+
+        let applied = try await engine.pull(now: 10)
+        XCTAssertEqual(applied, 2, "both records applied: deferred child retried after parent landed")
+        let childCount = try await dbManager.dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM intensity_readings WHERE id = 'ir1'")
+        }
+        XCTAssertEqual(childCount, 1, "child survived the cross-page FK race")
+    }
+
+    /// A child whose parent never arrives (e.g. the episode was deleted upstream) must not
+    /// crash the sync — it is dropped, and every other record still applies.
+    func testPullDropsOrphanChildWithoutAbortingSync() async throws {
+        let orphan = SyncRecord(
+            tableName: "intensity_readings", recordId: "ir-orphan",
+            payload: payload([
+                "id": "ir-orphan", "episode_id": "missing", "timestamp": Int64(1000), "intensity": 5.0,
+                "created_at": Int64(1000), "updated_at": Int64(1000),
+            ]),
+            schemaVersion: 31, updatedAt: 1000, deleted: false
+        )
+        try await transport.push([orphan])
+        try await transport.push([remoteMedication("m1", name: "Survivor", updatedAt: 1000)])
+
+        let applied = try await engine.pull(now: 10)
+        XCTAssertEqual(applied, 1, "orphan dropped, the medication still applied")
+        XCTAssertEqual(try medicationName("m1"), "Survivor", "sync did not abort on the orphan")
+        let orphanCount = try await dbManager.dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM intensity_readings WHERE id = 'ir-orphan'")
+        }
+        XCTAssertEqual(orphanCount, 0, "child with no parent was discarded, not inserted")
+    }
+
     func testPullIsIncremental() async throws {
         try await transport.push([remoteMedication("m1", name: "X", updatedAt: 1000)])
         _ = try await engine.pull(now: 10)


### PR DESCRIPTION
## Problem
Enabling iCloud sync on a fresh install that should pull down existing history fails with a modal:

> SQLite error 19: FOREIGN KEY constraint failed — while executing `INSERT INTO intensity_readings (...) ON CONFLICT(id) DO UPDATE SET ...`

Episodes partially sync but many `intensity_readings` are dropped (episodes show no intensity graph). Fixes #523.

## Root cause
`SyncEngine.pull` sorts each fetched batch parents-first (`applyPriority`), so within a batch episodes land before their intensity_readings. But CloudKit **paginates** the zone on a full-history pull, and the per-batch sort cannot order a child in an earlier page ahead of its parent in a later page. The child's FK insert throws, and `RemoteChangeApplier.apply` propagating that error **aborts the entire sync cycle** — surfacing the modal and leaving history partial.

## Fix
- Catch `SQLITE_CONSTRAINT_FOREIGNKEY` failures during the pull and **defer** those records instead of letting them abort the sync.
- After every batch has landed, **retry** the deferred records (parents now present), looping until a pass makes no progress.
- Records still failing after no progress are **genuine orphans** (parent deleted upstream — a cascade would drop the child anyway) and are discarded rather than crashing.
- The per-batch parents-first sort is retained as an optimization (fewer deferrals when a parent and child share a page).

## Tests
- `InMemoryCloudKitTransport` gains a `pageSize` knob to model CloudKit zone pagination.
- `testPullDefersChildUntilParentArrivesInLaterPage` — child in page 1, parent in page 2; both apply.
- `testPullDropsOrphanChildWithoutAbortingSync` — orphan dropped, the rest of the pull still applies.
- Full `SyncEngineTests` suite green (19 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)