### PR TITLE
fix(ios): don't cache empty Trends results so synced data appears on all ranges

### DIFF
--- a/mobile-apps/ios/MigraLog/ViewModels/AnalyticsViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/AnalyticsViewModel.swift
@@ -209,7 +209,15 @@ final class AnalyticsViewModel {
                 rangeEnd: TimestampHelper.toDate(range.end)
             )
 
-            // Cache the results
+            // Cache the results — but never cache an empty result. A fetch
+            // that lands before sync delivers data would otherwise pin an
+            // empty snapshot under this range's key for the full TTL. Because
+            // 30 days is the default range it's the one viewed first (often
+            // before the initial sync finishes), which left it stuck showing
+            // "no data" while ranges visited later — 14d, 90d — fetched fresh
+            // and rendered correctly. Empty fetches are cheap to recompute, so
+            // skip caching them and let the next visit re-query.
+            let hasData = !episodes.isEmpty || !dailyStatuses.isEmpty || !rescueDoses.isEmpty
             let cached = CachedAnalytics(
                 episodes: episodes,
                 intensityReadings: intensityReadings,
@@ -228,7 +236,9 @@ final class AnalyticsViewModel {
                 weeklyAdherence: weeklyAdherence,
                 summaryMedications: summaryMedications
             )
-            cache.set(cacheKey, value: cached, ttl: Self.cacheTTL)
+            if hasData {
+                cache.set(cacheKey, value: cached, ttl: Self.cacheTTL)
+            }
 
             isLoading = false
         } catch {

--- a/mobile-apps/ios/MigraLogTests/ViewModels/AnalyticsViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/AnalyticsViewModelTests.swift
@@ -116,6 +116,27 @@ final class AnalyticsViewModelTests: XCTestCase {
         XCTAssertEqual(sut.episodes.count, 1)
     }
 
+    /// Regression: an empty fetch (e.g. before the initial sync delivers
+    /// data) must not be cached, otherwise the default 30-day range stays
+    /// pinned to "no data" for the full TTL while data that arrives via sync
+    /// only shows on ranges visited afterwards. The same range must re-query
+    /// and pick up the freshly synced data on the next visit.
+    func testFetchData_emptyResultNotCached() async throws {
+        // First fetch lands before any data exists (pre-sync).
+        await sut.fetchData()
+        XCTAssertTrue(sut.episodes.isEmpty)
+
+        // Sync delivers an episode in range.
+        mockEpisodeRepo.episodes = [
+            TestFixtures.makeEpisode(id: "ep-1", startTime: TimestampHelper.now - 3600000)
+        ]
+
+        // Same range, same cache key: must re-query rather than serve the
+        // stale empty snapshot.
+        await sut.fetchData()
+        XCTAssertEqual(sut.episodes.count, 1)
+    }
+
     func testRefreshData_invalidatesCache() async throws {
         let ep = TestFixtures.makeEpisode(id: "ep-1", startTime: TimestampHelper.now - 3600000)
         mockEpisodeRepo.episodes = [ep]


### PR DESCRIPTION
## Problem

After loading a fresh build and syncing, the **Trends → Insights** screen showed **no data on the 30-day range**, while the 14-day and 90-day ranges showed data clearly. Since the 30-day window is a strict superset of the 14-day window, 30-day showing *less* than 14-day is impossible from the data alone — it's a bug.

## Root cause

The analytics cache (`AnalyticsViewModel.fetchData`) caches results keyed by range (`analytics_30`, `analytics_14`, …) with a 5-minute TTL.

1. `selectedRange` defaults to `.thirtyDays`, so **30d is the first range viewed** when the Trends screen appears.
2. On a fresh launch the initial CloudKit sync hasn't delivered data yet, so that first fetch computes an **empty** result and **caches it** under `analytics_30`.
3. Sync writes to the DB **silently** — the `Sync/` layer posts no data-changed notification, and `refreshData()` (the only method that invalidates the cache) is **never called anywhere**.
4. The user later taps 14d / 90d → those keys miss the cache → fetch fresh → data shows. ✅
5. Returning to 30d → cache **hit** → stale empty snapshot. ❌ (self-heals after the TTL — hence the "strange artifact")

## Fix

Never cache an all-empty result (no episodes, daily statuses, or rescue doses). Empty fetches are cheap to recompute, and skipping the cache lets the next visit re-query and pick up data that arrived via sync.

## Testing

- Added `testFetchData_emptyResultNotCached` — reproduces the exact pre-sync-empty → data-arrives → same-range-re-query path. Fails without the fix (cached empty → 0 episodes), passes with it.
- Full `AnalyticsViewModelTests` suite green (16/16) on iPhone 17 Pro / iOS 26.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)