### PR TITLE
ci(security): SHA-pin dorny/paths-filter + verify production env gate (#530)

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -17,7 +17,7 @@ jobs:
       ios: ${{ steps.filter.outputs.ios }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |


### PR DESCRIPTION
Closes #530

## 1. SHA-pin dorny/paths-filter
`.github/workflows/swift-ci.yml` used the mutable `dorny/paths-filter@v4` tag. Pinned it to the full commit SHA the v4 tag currently resolves to, matching the approach used for `sst/opencode` in #473:

```
dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
```

Resolved via `gh api repos/dorny/paths-filter/git/ref/tags/v4 --jq .object` -> a non-annotated `commit` object `fbd0ab8…`; both `v4` and `v4.0.1` tags point at it. GitHub-owned `actions/*@vN` are intentionally left untouched (out of scope).

## 2. Production environment approval gate
Verified `promote-production.yml` declares `environment: production`, but the environment's `protection_rules` are **empty (`[]`)** — **the approval gate is ABSENT**. App Store submission currently runs with no manual approval. This lives in repo Settings, not a workflow file; did not set reviewers (intended approver unspecified — not guessing). Full finding + remediation steps posted as a comment on #530.

Note: this is a `.github/workflows`-only change and does not touch `mobile-apps/ios/**`, so it does not trigger the iOS Release Pipeline (confirmed in `release-pipeline.yml` path filter).