### PR TITLE
feat(ios): privacy cover for app-switcher snapshot (#531)

### DIFF
--- a/mobile-apps/ios/MigraLog/App/ContentView.swift
+++ b/mobile-apps/ios/MigraLog/App/ContentView.swift
@@ -42,6 +42,18 @@ struct ContentView: View {
                 + "Review your schedules if you'd like to adjust them."
             )
         }
+        // Privacy shield for the app-switcher snapshot (#531). iOS snapshots the
+        // app during the `.inactive` transition (before `.background`), so cover the
+        // content whenever the scene is anything other than `.active`. The cover is
+        // opaque and carries no PHI, so the thumbnail shows the logo, not health data.
+        // No transition/animation keeps it from flickering on foreground return.
+        .overlay {
+            if scenePhase != .active {
+                PrivacyCoverView()
+                    .transition(.identity)
+            }
+        }
+        .animation(nil, value: scenePhase)
         .task { syncService.startAutoSync() }
         .onOpenURL { url in
             // Live Activity quick actions open migralog:// URLs; route them into

--- a/mobile-apps/ios/MigraLog/Views/Components/PrivacyCoverView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Components/PrivacyCoverView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Opaque, branded cover shown over the app's content whenever the scene is not
+/// `.active` (i.e. `.inactive` or `.background`). iOS snapshots the app for the
+/// app-switcher thumbnail during the `.inactive` transition — BEFORE `.background` —
+/// so covering on anything other than `.active` guarantees the snapshot captures
+/// this view instead of on-screen PHI (episode notes, triggers, medication names).
+///
+/// The view is fully opaque (it fills the screen with `Color(.systemBackground)`)
+/// so no underlying health data shows through. It carries no dynamic data and never
+/// logs, keeping it HIPAA-safe and cheap to render.
+struct PrivacyCoverView: View {
+    var body: some View {
+        ZStack {
+            // Opaque base so nothing behind it is visible in the snapshot.
+            Color(.systemBackground)
+                .ignoresSafeArea()
+
+            VStack(spacing: 16) {
+                Image(systemName: "brain.head.profile")
+                    .font(.system(size: 80))
+                    .foregroundStyle(Color.accentColor)
+
+                Text("MigraLog")
+                    .font(.largeTitle.weight(.bold))
+                    .foregroundStyle(.primary)
+            }
+        }
+        // Purely a privacy shield — hide it from assistive technologies so it
+        // doesn't announce over the real content underneath.
+        .accessibilityHidden(true)
+    }
+}
+
+#Preview {
+    PrivacyCoverView()
+}


### PR DESCRIPTION
Closes #531

## What
Adds an opaque, branded privacy cover over the app's content whenever the scene is not `.active`, so the iOS app-switcher snapshot no longer captures PHI (episode notes, trigger lists, medication names).

## How
- New `PrivacyCoverView` (logo + "MigraLog" on an opaque `systemBackground`), carries no dynamic data and never logs (HIPAA-safe).
- Overlaid on the root `ContentView` gated on `scenePhase != .active`.
- **Inactive-vs-background timing:** iOS snapshots the app during the `.inactive` transition, *before* `.background`. Covering on `!= .active` means the cover is already present when the snapshot is taken, so the thumbnail shows the logo, not health data.
- **No flicker:** the overlay uses `.transition(.identity)` and `.animation(nil, value: scenePhase)` so it appears/disappears instantly with no animation or stuck overlay on foreground return.

## Verification
- `xcodegen generate` + simulator build: **BUILD SUCCEEDED** (iPhone 17 Pro, iOS 26.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)