### PR TITLE
fix(ios): harden Sentry PHI scrubber to redact dates (#528)

### DIFF
--- a/mobile-apps/ios/MigraLog/Services/SentrySetup.swift
+++ b/mobile-apps/ios/MigraLog/Services/SentrySetup.swift
@@ -41,48 +41,104 @@ enum SentrySetup {
 
     // MARK: - Privacy Scrubbing
 
-    /// Keys that may contain PHI/sensitive health data
+    /// Keys that may contain PHI/sensitive health data.
+    ///
+    /// Compared case-insensitively (see `isSensitiveKey`), so list the
+    /// canonical form once.
     private static let sensitiveKeys: Set<String> = [
         // Medication fields
-        "medication", "medicationName", "medication_name",
-        "dose", "dosage", "units", "medicationId",
+        "medication", "medicationname", "medication_name",
+        "dose", "dosage", "units", "medicationid",
         // Episode fields
-        "intensity", "pain_location", "painLocation",
+        "intensity", "pain_location", "painlocation",
         "symptom", "symptoms", "trigger", "triggers",
         // User data
-        "notes", "note", "userNotes", "user_notes",
-        "name", "userName", "email",
+        "notes", "note", "usernotes", "user_notes",
+        "name", "username", "email",
         // Location
         "latitude", "longitude", "location",
-        "locationAccuracy", "locationTimestamp",
+        "locationaccuracy", "locationtimestamp",
+        // Dates/times. A specific episode/dose date is PHI on its own
+        // (it reveals when a person had a migraine or took medication),
+        // so any date-bearing key is redacted. Sentry's own automatic
+        // event/breadcrumb timestamps are separate fields and unaffected.
+        "date", "datestring", "timestamp", "createdat", "created_at",
+        "updatedat", "updated_at", "loggedat", "logged_at",
+        "starttime", "start_time", "endtime", "end_time",
+        "occurredat", "occurred_at", "onset", "onsetdate",
     ]
 
-    /// Scrub sensitive data from Sentry events (HIPAA compliance)
-    private static func scrubSensitiveData(from event: Event) -> Event {
+    /// Substrings that mark any containing key as sensitive (case-insensitive),
+    /// so newly-introduced variants (e.g. `medicationLogId`, `symptomNotes`,
+    /// `episodeDate`) are caught without an exact match.
+    private static let sensitiveSubstrings: [String] = [
+        "medication", "symptom", "date",
+    ]
+
+    /// Whether a dictionary key should be redacted. Case-insensitive, with a
+    /// substring fallback for un-enumerated variants.
+    private static func isSensitiveKey(_ key: String) -> Bool {
+        let lowered = key.lowercased()
+        if sensitiveKeys.contains(lowered) { return true }
+        return sensitiveSubstrings.contains { lowered.contains($0) }
+    }
+
+    private static let redacted = "[REDACTED]"
+
+    /// Scrub sensitive data from Sentry events (HIPAA compliance).
+    ///
+    /// Walks every event field where caller-supplied PHI can land:
+    /// `extra`, `breadcrumbs[].data`, `tags`, and custom `context` values.
+    /// Sentry-maintained fields (message/exception strings, stack traces,
+    /// auto-populated contexts like device/os/app) are not key:value PHI
+    /// carriers; we deliberately do not attempt free-text redaction there.
+    ///
+    /// Internal (not private) so the HIPAA regression test can exercise it
+    /// directly via `@testable import`.
+    static func scrubSensitiveData(from event: Event) -> Event {
         // Scrub extra data
-        if var extra = event.extra {
-            for key in extra.keys {
-                if sensitiveKeys.contains(key) || key.lowercased().contains("medication") || key.lowercased().contains("symptom") {
-                    extra[key] = "[REDACTED]"
-                }
-            }
-            event.extra = extra
+        if let extra = event.extra {
+            event.extra = redactSensitiveValues(in: extra)
         }
 
         // Scrub breadcrumb data
         if let breadcrumbs = event.breadcrumbs {
             for breadcrumb in breadcrumbs {
-                if var data = breadcrumb.data {
-                    for key in data.keys {
-                        if sensitiveKeys.contains(key) || key.lowercased().contains("medication") || key.lowercased().contains("symptom") {
-                            data[key] = "[REDACTED]"
-                        }
-                    }
-                    breadcrumb.data = data
+                if let data = breadcrumb.data {
+                    breadcrumb.data = redactSensitiveValues(in: data)
                 }
             }
         }
 
+        // Scrub tags (String:String) — callers can attach arbitrary tags.
+        if let tags = event.tags {
+            var scrubbed = tags
+            for key in tags.keys where isSensitiveKey(key) {
+                scrubbed[key] = redacted
+            }
+            event.tags = scrubbed
+        }
+
+        // Scrub custom contexts. `context` is a dict of named context
+        // dictionaries; redact sensitive keys inside each one.
+        if let context = event.context {
+            var scrubbedContext = context
+            for (name, values) in context {
+                scrubbedContext[name] = redactSensitiveValues(in: values)
+            }
+            event.context = scrubbedContext
+        }
+
         return event
+    }
+
+    /// Returns a copy of `dictionary` with sensitive keys' values replaced by
+    /// `[REDACTED]`.
+    private static func redactSensitiveValues(in dictionary: [String: Any]) -> [String: Any] {
+        var result = dictionary
+        for key in dictionary.keys where isSensitiveKey(key) {
+            result[key] = redacted
+        }
+        return result
     }
 }

--- a/mobile-apps/ios/MigraLogTests/Services/SentrySetupTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/SentrySetupTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+import Sentry
+@testable import MigraLog
+
+/// HIPAA regression tests for the Sentry PHI scrubber (issue #528).
+///
+/// The scrubber is the last line of defense keeping health data out of crash
+/// reports. These tests construct synthetic `Event`s with sensitive keys in
+/// every caller-writable field and assert they come out `[REDACTED]`.
+final class SentrySetupTests: XCTestCase {
+
+    private static let redacted = "[REDACTED]"
+
+    // Representative sensitive keys we expect the scrubber to catch. `date` is
+    // the key #528 was filed for; the rest cover the categories of PHI we emit.
+    private static let sensitiveKeys: [String] = [
+        // The headline regression: a bare date is PHI on its own.
+        "date", "dateString", "timestamp", "occurredAt", "onsetDate",
+        "createdAt", "loggedAt", "startTime", "endTime",
+        // Medication
+        "medication", "medicationName", "dose", "dosage", "medicationId",
+        // Episode / symptoms
+        "intensity", "painLocation", "symptom", "symptoms", "trigger",
+        // Notes / identity
+        "notes", "note", "userNotes", "name", "userName", "email",
+        // Location
+        "latitude", "longitude", "location", "locationTimestamp",
+        // Substring-fallback variants that are NOT exact matches but must
+        // still be caught (these guard the substring rule).
+        "episodeDate", "medicationLogId", "symptomSeverity",
+    ]
+
+    // A non-sensitive key that must survive scrubbing untouched, so we know the
+    // scrubber isn't just redacting everything.
+    private static let safeKey = "deviationCount"
+    private static let safeValue = 42
+
+    private func sensitivePayload() -> [String: Any] {
+        var payload: [String: Any] = [:]
+        for key in Self.sensitiveKeys {
+            payload[key] = "sensitive-value-for-\(key)"
+        }
+        payload[Self.safeKey] = Self.safeValue
+        return payload
+    }
+
+    private func assertScrubbed(_ dict: [String: Any]?, field: String) {
+        guard let dict else {
+            XCTFail("\(field) was nil after scrubbing")
+            return
+        }
+        for key in Self.sensitiveKeys {
+            XCTAssertEqual(
+                dict[key] as? String,
+                Self.redacted,
+                "Sensitive key '\(key)' in \(field) was NOT redacted — PHI would leak to Sentry"
+            )
+        }
+        XCTAssertEqual(
+            dict[Self.safeKey] as? Int,
+            Self.safeValue,
+            "Non-sensitive key '\(Self.safeKey)' in \(field) was incorrectly altered"
+        )
+    }
+
+    // MARK: - extra
+
+    func testExtraSensitiveKeysAreRedacted() {
+        let event = Event()
+        event.extra = sensitivePayload()
+
+        let scrubbed = SentrySetup.scrubSensitiveData(from: event)
+
+        assertScrubbed(scrubbed.extra, field: "extra")
+    }
+
+    // MARK: - breadcrumbs
+
+    func testBreadcrumbDataSensitiveKeysAreRedacted() {
+        let event = Event()
+        let breadcrumb = Breadcrumb()
+        breadcrumb.data = sensitivePayload()
+        event.breadcrumbs = [breadcrumb]
+
+        let scrubbed = SentrySetup.scrubSensitiveData(from: event)
+
+        assertScrubbed(scrubbed.breadcrumbs?.first?.data, field: "breadcrumb.data")
+    }
+
+    // MARK: - tags
+
+    func testTagSensitiveKeysAreRedacted() {
+        let event = Event()
+        var tags: [String: String] = [:]
+        for key in Self.sensitiveKeys {
+            tags[key] = "sensitive-tag-\(key)"
+        }
+        tags[Self.safeKey] = "safe"
+        event.tags = tags
+
+        let scrubbed = SentrySetup.scrubSensitiveData(from: event)
+
+        guard let scrubbedTags = scrubbed.tags else {
+            return XCTFail("tags were nil after scrubbing")
+        }
+        for key in Self.sensitiveKeys {
+            XCTAssertEqual(
+                scrubbedTags[key],
+                Self.redacted,
+                "Sensitive tag '\(key)' was NOT redacted — PHI would leak to Sentry"
+            )
+        }
+        XCTAssertEqual(scrubbedTags[Self.safeKey], "safe", "Safe tag was altered")
+    }
+
+    // MARK: - custom contexts
+
+    func testCustomContextSensitiveKeysAreRedacted() {
+        let event = Event()
+        event.context = ["episode": sensitivePayload()]
+
+        let scrubbed = SentrySetup.scrubSensitiveData(from: event)
+
+        assertScrubbed(scrubbed.context?["episode"], field: "context.episode")
+    }
+
+    // MARK: - the #528 headline case, explicit
+
+    func testBareDateKeyIsRedacted() {
+        let event = Event()
+        event.extra = ["date": "2026-06-18T09:30:00Z"]
+
+        let scrubbed = SentrySetup.scrubSensitiveData(from: event)
+
+        XCTAssertEqual(
+            scrubbed.extra?["date"] as? String,
+            Self.redacted,
+            "A 'date' key must be redacted (issue #528)"
+        )
+    }
+
+    func testBareDateBreadcrumbKeyIsRedacted() {
+        let event = Event()
+        let breadcrumb = Breadcrumb()
+        breadcrumb.data = ["date": "2026-06-18"]
+        event.breadcrumbs = [breadcrumb]
+
+        let scrubbed = SentrySetup.scrubSensitiveData(from: event)
+
+        XCTAssertEqual(
+            scrubbed.breadcrumbs?.first?.data?["date"] as? String,
+            Self.redacted,
+            "A 'date' breadcrumb key must be redacted (issue #528)"
+        )
+    }
+
+    // MARK: - regression guard
+
+    /// Canary: if a new sensitive key is introduced into the scrubber's key
+    /// list but the matching logic regresses, this fails. Every key declared
+    /// sensitive here must be redacted when present in `extra`.
+    func testEverySensitiveKeyIsRedactedInExtra() {
+        for key in Self.sensitiveKeys {
+            let event = Event()
+            event.extra = [key: "value", Self.safeKey: Self.safeValue]
+
+            let scrubbed = SentrySetup.scrubSensitiveData(from: event)
+
+            XCTAssertEqual(
+                scrubbed.extra?[key] as? String,
+                Self.redacted,
+                "Scrubber missed sensitive key '\(key)' — would leak PHI to Sentry"
+            )
+            XCTAssertEqual(
+                scrubbed.extra?[Self.safeKey] as? Int,
+                Self.safeValue,
+                "Scrubber over-redacted: safe key removed alongside '\(key)'"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #528

## What
Hardens the Sentry `beforeSend` PHI scrubber (`SentrySetup.swift`) and adds the missing regression test.

## Changes
- **Redact date keys.** `date`, `dateString`, `timestamp`, `createdAt`, `loggedAt`, `onset`, start/end times, etc. A specific episode/dose date is PHI on its own. Added a `date` substring fallback so variants like `episodeDate` are caught.
- **Case-insensitive key matching.**
- **Wider field coverage.** Audited the Sentry `Event` type; in addition to `extra` and `breadcrumbs[].data`, the scrubber now also walks `tags` and custom `context` dictionaries, where caller-supplied PHI can land. Sentry-maintained free-text fields (message/exception/stack traces, auto contexts) are intentionally not free-text-redacted.
- **Regression test (`SentrySetupTests`).** Synthetic `Event`s with sensitive keys (including `date`) in `extra`, `breadcrumbs`, `tags`, and `context` asserted `[REDACTED]`; a canary fails if any enumerated sensitive key stops being redacted; a safe key asserts no over-redaction.

## Tests
`SentrySetupTests` — 7 tests, all passing locally (iPhone 17 Pro, iOS 26.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)