### PR TITLE
fix(ios): harden backup/restore against tampered input (#529)

### DIFF
--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -252,12 +252,18 @@ final class DatabaseManager: Sendable {
     /// sit inert until SyncService owns keeping them current. Existing rows are
     /// backfilled so historical data carries a usable LWW timestamp.
     static func addSyncTimestampColumns(in db: Database) throws {
+        // SECURITY: the `table` values below are interpolated into SQL strings
+        // (SQLite cannot bind table/column identifiers as parameters). Every value
+        // here is a hardcoded constant from the literal list below — constants only,
+        // never user/sync input. Do not feed dynamic/untrusted names into `hasColumn`
+        // or the ALTER TABLE statements without an allowlist check first.
         func hasColumn(_ table: String, _ column: String) throws -> Bool {
             let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(\(table))")
             return columns.contains { (row: Row) in (row["name"] as String?) == column }
         }
 
         // Append-only / created_at-bearing tables: updated_at backfills from created_at.
+        // Hardcoded constants only — see SECURITY note above.
         for table in ["symptom_logs", "episode_notes", "category_safety_rules"] {
             if try !hasColumn(table, "updated_at") {
                 try db.execute(sql: "ALTER TABLE \(table) ADD COLUMN updated_at INTEGER CHECK(updated_at IS NULL OR updated_at > 0)")

--- a/mobile-apps/ios/MigraLog/Services/BackupService.swift
+++ b/mobile-apps/ios/MigraLog/Services/BackupService.swift
@@ -36,11 +36,12 @@ final class BackupService: BackupServiceProtocol {
     private let logger = AppLogger.shared
 
     // MARK: - Validation Bounds
+    //
+    // Backup ids are always `UUID().uuidString` (see `createBackup`). They are read
+    // back out of an on-disk metadata sidecar, so a tampered/foreign metadata file
+    // could otherwise smuggle `../` (or other path separators) into the file name we
+    // build. Reject anything that is not a canonical UUID before any file op.
 
-    /// Backup ids are always `UUID().uuidString` (see `createBackup`). They are read
-    /// back out of an on-disk metadata sidecar, so a tampered/foreign metadata file
-    /// could otherwise smuggle `../` (or other path separators) into the file name we
-    /// build. Reject anything that is not a canonical UUID before any file op.
     /// Upper bound for a restorable / loadable backup file. The on-device health DB is
     /// kilobytes-to-low-megabytes; anything past this is almost certainly corrupt or
     /// hostile, and we refuse to copy/open it. 1 GiB is far above any legitimate size.

--- a/mobile-apps/ios/MigraLog/Services/BackupService.swift
+++ b/mobile-apps/ios/MigraLog/Services/BackupService.swift
@@ -41,10 +41,6 @@ final class BackupService: BackupServiceProtocol {
     /// back out of an on-disk metadata sidecar, so a tampered/foreign metadata file
     /// could otherwise smuggle `../` (or other path separators) into the file name we
     /// build. Reject anything that is not a canonical UUID before any file op.
-    private static let uuidRegex = try! NSRegularExpression(
-        pattern: "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
-    )
-
     /// Upper bound for a restorable / loadable backup file. The on-device health DB is
     /// kilobytes-to-low-megabytes; anything past this is almost certainly corrupt or
     /// hostile, and we refuse to copy/open it. 1 GiB is far above any legitimate size.
@@ -59,10 +55,12 @@ final class BackupService: BackupServiceProtocol {
     static let minRestorableSchemaVersion = 1
 
     /// Returns `true` iff `id` is a canonical UUID string and therefore safe to
-    /// interpolate into a backup file name.
+    /// interpolate into a backup file name. Uses `Foundation.UUID`'s own parser rather
+    /// than a regex so there is no force-try / construction failure path.
     static func isValidBackupID(_ id: String) -> Bool {
-        let range = NSRange(id.startIndex..<id.endIndex, in: id)
-        return uuidRegex.firstMatch(in: id, options: [], range: range) != nil
+        // UUID(uuidString:) accepts only the canonical 8-4-4-4-12 hex form and
+        // rejects anything containing path separators (e.g. "../").
+        UUID(uuidString: id) != nil
     }
 
     /// Validates a backup id and throws `invalidBackupID` if it is not a UUID.

--- a/mobile-apps/ios/MigraLog/Services/BackupService.swift
+++ b/mobile-apps/ios/MigraLog/Services/BackupService.swift
@@ -11,6 +11,8 @@ enum BackupError: Error, Equatable {
     case invalidBackup(String)
     case restoreFailed(String)
     case deleteFailed(String)
+    /// A backup id failed UUID-format validation before being used in a file path.
+    case invalidBackupID(String)
 }
 
 // MARK: - Protocol
@@ -32,6 +34,63 @@ protocol BackupServiceProtocol {
 final class BackupService: BackupServiceProtocol {
     private let fileManager: FileManager
     private let logger = AppLogger.shared
+
+    // MARK: - Validation Bounds
+
+    /// Backup ids are always `UUID().uuidString` (see `createBackup`). They are read
+    /// back out of an on-disk metadata sidecar, so a tampered/foreign metadata file
+    /// could otherwise smuggle `../` (or other path separators) into the file name we
+    /// build. Reject anything that is not a canonical UUID before any file op.
+    private static let uuidRegex = try! NSRegularExpression(
+        pattern: "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+    )
+
+    /// Upper bound for a restorable / loadable backup file. The on-device health DB is
+    /// kilobytes-to-low-megabytes; anything past this is almost certainly corrupt or
+    /// hostile, and we refuse to copy/open it. 1 GiB is far above any legitimate size.
+    static let maxBackupFileSize: Int64 = 1_024 * 1_024 * 1_024
+
+    /// Defensive bound on the metadata `fileName` field so a bad sidecar cannot carry a
+    /// pathologically long string into UI/logging paths.
+    static let maxFileNameLength = 256
+
+    /// Lowest schema version this build knows how to restore. Backups stamped with an
+    /// older schema predate the Swift app's table shapes and are rejected up front.
+    static let minRestorableSchemaVersion = 1
+
+    /// Returns `true` iff `id` is a canonical UUID string and therefore safe to
+    /// interpolate into a backup file name.
+    static func isValidBackupID(_ id: String) -> Bool {
+        let range = NSRange(id.startIndex..<id.endIndex, in: id)
+        return uuidRegex.firstMatch(in: id, options: [], range: range) != nil
+    }
+
+    /// Validates a backup id and throws `invalidBackupID` if it is not a UUID.
+    private func validateBackupID(_ id: String) throws {
+        guard BackupService.isValidBackupID(id) else {
+            // Do NOT log the raw id: it originates from on-disk data and is not trusted.
+            logger.warn("Rejected backup id with invalid (non-UUID) format")
+            throw BackupError.invalidBackupID("Backup id must be a UUID")
+        }
+    }
+
+    /// Bounds-checks a decoded `BackupMetadata`. The sidecar JSON is on-disk data that
+    /// could be tampered with or corrupt, so we reject obviously bad/oversized values
+    /// (non-UUID id, negative or absurd counts/sizes, over-long file name) rather than
+    /// surface them to the UI or feed them back into file ops.
+    func isMetadataWellFormed(_ metadata: BackupMetadata) -> Bool {
+        guard BackupService.isValidBackupID(metadata.id) else { return false }
+        guard metadata.timestamp > 0 else { return false }
+        guard metadata.schemaVersion >= BackupService.minRestorableSchemaVersion else { return false }
+        guard metadata.episodeCount >= 0, metadata.medicationCount >= 0 else { return false }
+        if let size = metadata.fileSize {
+            guard size >= 0, size <= BackupService.maxBackupFileSize else { return false }
+        }
+        if let name = metadata.fileName {
+            guard name.count <= BackupService.maxFileNameLength else { return false }
+        }
+        return true
+    }
 
     /// App version for backup metadata
     private var appVersion: String {
@@ -158,10 +217,12 @@ final class BackupService: BackupServiceProtocol {
 
         for metaFile in metaFiles {
             if let data = try? Data(contentsOf: metaFile),
-               let metadata = try? decoder.decode(BackupMetadata.self, from: data) {
+               let metadata = try? decoder.decode(BackupMetadata.self, from: data),
+               isMetadataWellFormed(metadata) {
                 backups.append(metadata)
             } else {
-                logger.warn("Failed to read backup metadata: \(metaFile.lastPathComponent)")
+                // File name only — never the metadata contents (may be PHI/untrusted).
+                logger.warn("Failed to read or validate backup metadata: \(metaFile.lastPathComponent)")
             }
         }
 
@@ -174,6 +235,7 @@ final class BackupService: BackupServiceProtocol {
     /// Returns the on-disk URL for a backup's `.db` file. The file may not exist;
     /// callers should validate before sharing if that matters.
     func backupFileURL(for id: String) throws -> URL {
+        try validateBackupID(id)
         let backupDir = try backupDirectoryURL()
         return backupDir.appendingPathComponent("migralog_backup_\(id).db")
     }
@@ -181,6 +243,7 @@ final class BackupService: BackupServiceProtocol {
     // MARK: - Delete Backup
 
     func deleteBackup(id: String) throws {
+        try validateBackupID(id)
         let backupDir = try backupDirectoryURL()
         let dbFile = backupDir.appendingPathComponent("migralog_backup_\(id).db")
         let metaFile = backupDir.appendingPathComponent("migralog_backup_\(id).meta.json")
@@ -217,14 +280,37 @@ final class BackupService: BackupServiceProtocol {
             throw BackupError.backupNotFound
         }
 
+        // Bound the file size before doing anything expensive: refuse to open/copy a
+        // file that is empty or absurdly large (corrupt or hostile input).
+        guard let attrs = try? fileManager.attributesOfItem(atPath: path),
+              let size = attrs[.size] as? Int64 else {
+            throw BackupError.invalidBackup("Cannot read backup file attributes")
+        }
+        guard size > 0 else {
+            throw BackupError.invalidBackup("Backup file is empty")
+        }
+        guard size <= BackupService.maxBackupFileSize else {
+            throw BackupError.invalidBackup("Backup file exceeds maximum allowed size")
+        }
+
         guard validateBackup(path: path) else {
             throw BackupError.invalidBackup("Backup validation failed")
         }
 
-        // Verify the backup database can be opened and has the expected tables
+        // Verify the backup database can be opened, carries a restorable schema version,
+        // and has the expected tables.
         do {
             let backupDb = try DatabaseManager(path: path)
             try backupDb.dbQueue.read { db in
+                // Reject backups whose schema predates anything this build can restore.
+                let userVersion = try Int.fetchOne(db, sql: "PRAGMA user_version") ?? 0
+                guard userVersion >= BackupService.minRestorableSchemaVersion,
+                      userVersion <= DatabaseManager.schemaVersion else {
+                    throw BackupError.invalidBackup(
+                        "Unsupported backup schema version \(userVersion)"
+                    )
+                }
+
                 // Log tables found for debugging
                 let tables = try String.fetchAll(db, sql: """
                     SELECT name FROM sqlite_master WHERE type='table' ORDER BY name
@@ -234,6 +320,8 @@ final class BackupService: BackupServiceProtocol {
                 _ = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM episodes")
                 _ = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM medications")
             }
+        } catch let error as BackupError {
+            throw error
         } catch {
             throw BackupError.invalidBackup("Cannot read backup database: \(error.localizedDescription)")
         }
@@ -427,14 +515,54 @@ final class BackupService: BackupServiceProtocol {
         }
     }
 
+    /// Allowlist of every table/column identifier that `restoreTable` may interpolate
+    /// into SQL. SQLite cannot bind identifiers as parameters, so table and column names
+    /// are spliced into the SQL string directly. Today every caller passes hardcoded
+    /// constants (see `restoreData`), so this is a defense-in-depth guard: if a future
+    /// refactor ever routes user/sync-controlled names here, the allowlist check below
+    /// rejects them instead of allowing SQL injection. KEEP IN SYNC with `restoreData`.
+    private static let allowedRestoreTables: Set<String> = [
+        "episodes", "medications", "intensity_readings", "symptom_logs",
+        "pain_location_logs", "episode_notes", "medication_schedules",
+        "medication_doses", "daily_status_logs", "calendar_overlays",
+        "medication_reminders"
+    ]
+    private static let allowedRestoreColumns: Set<String> = [
+        "id", "start_time", "end_time", "locations", "qualities", "symptoms",
+        "triggers", "notes", "latitude", "longitude", "location_accuracy",
+        "location_timestamp", "created_at", "updated_at", "name", "type",
+        "dosage_amount", "dosage_unit", "default_quantity", "schedule_frequency",
+        "photo_uri", "active", "category", "episode_id", "timestamp", "intensity",
+        "symptom", "onset_time", "resolution_time", "severity", "pain_locations",
+        "note", "medication_id", "time", "timezone", "dosage", "enabled",
+        "notification_id", "reminder_enabled", "quantity", "status",
+        "effectiveness_rating", "time_to_relief", "side_effects", "date",
+        "status_type", "prompted", "start_date", "end_date", "label",
+        "exclude_from_stats", "scheduled_time", "completed", "snoozed_until",
+        "completed_at"
+    ]
+
     /// Restore a table by copying only the columns that exist in both source and destination.
     /// Fixes timestamp columns with invalid zero values by falling back to created_at.
+    ///
+    /// SECURITY: `table` and `destColumns` are interpolated into SQL (identifiers can't
+    /// be bound). Callers pass hardcoded constants only — never user/sync input. The
+    /// allowlist guards below enforce that invariant so a future refactor can't smuggle
+    /// an injection in.
     private func restoreTable(
         _ table: String,
         from sourceDb: Database,
         to destDb: Database,
         columns destColumns: [String]
     ) throws {
+        // Allowlist check: every interpolated identifier must be a known constant.
+        guard BackupService.allowedRestoreTables.contains(table) else {
+            throw BackupError.restoreFailed("Refusing to restore non-allowlisted table")
+        }
+        for column in destColumns where !BackupService.allowedRestoreColumns.contains(column) {
+            throw BackupError.restoreFailed("Refusing to restore non-allowlisted column")
+        }
+
         guard try tableExists(table, in: sourceDb) else {
             logger.info("Skipping restore of \(table): table not found in backup")
             return

--- a/mobile-apps/ios/MigraLogTests/Services/BackupServiceTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/BackupServiceTests.swift
@@ -119,9 +119,10 @@ final class BackupServiceTests: XCTestCase {
     }
 
     func testDeleteNonexistentBackupDoesNotThrow() throws {
-        // Deleting a backup that doesn't exist should not throw
-        // (files simply don't exist, no error)
-        XCTAssertNoThrow(try backupService.deleteBackup(id: "nonexistent-id"))
+        // Deleting a (well-formed) backup id whose files don't exist should not throw
+        // (files simply don't exist, no error). Uses a valid UUID so it passes the
+        // #529 id-format guard; non-UUID ids are covered by testDeleteBackupRejectsNonUUIDID.
+        XCTAssertNoThrow(try backupService.deleteBackup(id: UUID().uuidString))
     }
 
     // MARK: - Validate Backup
@@ -299,5 +300,115 @@ final class BackupServiceTests: XCTestCase {
 
         // Clean up
         try? backupService.deleteBackup(id: metadata.id)
+    }
+
+    // MARK: - Backup ID Validation (#529)
+
+    func testIsValidBackupIDAcceptsCanonicalUUID() {
+        XCTAssertTrue(BackupService.isValidBackupID(UUID().uuidString))
+        // Canonical uppercase form
+        XCTAssertTrue(BackupService.isValidBackupID("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+    }
+
+    func testIsValidBackupIDRejectsNonUUID() {
+        let bad = [
+            "",
+            "not-a-uuid",
+            "../../etc/passwd",
+            "../malicious",
+            "12345678-1234-1234-1234-1234567890",          // too short
+            "12345678-1234-1234-1234-1234567890123",       // too long
+            "gggggggg-gggg-gggg-gggg-gggggggggggg",         // non-hex
+            "\(UUID().uuidString)/../escape",
+            "\(UUID().uuidString).db",
+            " \(UUID().uuidString)"                          // leading space
+        ]
+        for id in bad {
+            XCTAssertFalse(BackupService.isValidBackupID(id), "Should reject id: \(id)")
+        }
+    }
+
+    func testDeleteBackupRejectsNonUUIDID() {
+        for id in ["../../etc/passwd", "not-a-uuid", "migralog_backup_x"] {
+            XCTAssertThrowsError(try backupService.deleteBackup(id: id)) { error in
+                XCTAssertEqual(error as? BackupError, .invalidBackupID("Backup id must be a UUID"))
+            }
+        }
+    }
+
+    func testBackupFileURLRejectsNonUUIDID() {
+        for id in ["../escape", "abc"] {
+            XCTAssertThrowsError(try backupService.backupFileURL(for: id)) { error in
+                XCTAssertEqual(error as? BackupError, .invalidBackupID("Backup id must be a UUID"))
+            }
+        }
+    }
+
+    func testBackupFileURLAcceptsValidUUID() throws {
+        let id = UUID().uuidString
+        let url = try backupService.backupFileURL(for: id)
+        XCTAssertEqual(url.lastPathComponent, "migralog_backup_\(id).db")
+        // Path must stay inside the backups directory (no traversal).
+        XCTAssertTrue(url.deletingLastPathComponent().lastPathComponent == "backups")
+    }
+
+    // MARK: - Metadata Bounds Validation (#529)
+
+    private func makeMetadata(
+        id: String = UUID().uuidString,
+        timestamp: Int64 = 1_700_000_000_000,
+        schemaVersion: Int = DatabaseManager.schemaVersion,
+        episodeCount: Int = 1,
+        medicationCount: Int = 1,
+        fileSize: Int64? = 1024,
+        fileName: String? = "migralog_backup.db"
+    ) -> BackupMetadata {
+        BackupMetadata(
+            id: id,
+            timestamp: timestamp,
+            version: "1.0.0",
+            schemaVersion: schemaVersion,
+            episodeCount: episodeCount,
+            medicationCount: medicationCount,
+            fileSize: fileSize,
+            fileName: fileName,
+            backupType: "manual"
+        )
+    }
+
+    func testMetadataWellFormedAcceptsValid() {
+        XCTAssertTrue(backupService.isMetadataWellFormed(makeMetadata()))
+        // Optional fields absent is fine.
+        XCTAssertTrue(backupService.isMetadataWellFormed(makeMetadata(fileSize: nil, fileName: nil)))
+    }
+
+    func testMetadataWellFormedRejectsBadID() {
+        XCTAssertFalse(backupService.isMetadataWellFormed(makeMetadata(id: "../traversal")))
+    }
+
+    func testMetadataWellFormedRejectsBadTimestamp() {
+        XCTAssertFalse(backupService.isMetadataWellFormed(makeMetadata(timestamp: 0)))
+        XCTAssertFalse(backupService.isMetadataWellFormed(makeMetadata(timestamp: -1)))
+    }
+
+    func testMetadataWellFormedRejectsBadSchemaVersion() {
+        XCTAssertFalse(backupService.isMetadataWellFormed(makeMetadata(schemaVersion: 0)))
+        XCTAssertFalse(backupService.isMetadataWellFormed(makeMetadata(schemaVersion: -5)))
+    }
+
+    func testMetadataWellFormedRejectsNegativeCounts() {
+        XCTAssertFalse(backupService.isMetadataWellFormed(makeMetadata(episodeCount: -1)))
+        XCTAssertFalse(backupService.isMetadataWellFormed(makeMetadata(medicationCount: -1)))
+    }
+
+    func testMetadataWellFormedRejectsOversizedFile() {
+        let huge = BackupService.maxBackupFileSize + 1
+        XCTAssertFalse(backupService.isMetadataWellFormed(makeMetadata(fileSize: huge)))
+        XCTAssertFalse(backupService.isMetadataWellFormed(makeMetadata(fileSize: -1)))
+    }
+
+    func testMetadataWellFormedRejectsOverlongFileName() {
+        let longName = String(repeating: "a", count: BackupService.maxFileNameLength + 1)
+        XCTAssertFalse(backupService.isMetadataWellFormed(makeMetadata(fileName: longName)))
     }
 }


### PR DESCRIPTION
Closes #529

## Summary
Defense-in-depth hardening for backup & restore. Nothing here is exploitable today (backup ids are app-generated UUIDs; table/column lists are hardcoded constants), but these are thin guards so a future change that routes user/sync-controlled input into these paths can't become a real vuln.

## Changes
- **Validate backup ids** against a UUID regex in `backupFileURL(for:)` and `deleteBackup(id:)` before interpolating into `migralog_backup_<id>.db`. Blocks `../` path traversal from a tampered metadata sidecar. New `BackupError.invalidBackupID`.
- **Bounds-check decoded `BackupMetadata`** on `listBackups` decode (UUID id, positive timestamp, restorable schema version, non-negative counts, fileSize ≤ 1 GiB, fileName length ≤ 256). Malformed sidecars are skipped.
- **Restore input validation**: bound the backup file size (non-empty, ≤ 1 GiB) and validate `PRAGMA user_version` is within the restorable schema range before importing.
- **Dynamic SQL identifiers**: explicit allowlist guard for the table/column names interpolated in `BackupService.restoreTable`, plus a SECURITY "constants only — never user input" comment at the `DatabaseManager.addSyncTimestampColumns` dynamic-SQL site.

## DatabaseManager.swift change (kept minimal for #527 parallel work)
Comment-only, no logic change: added a SECURITY note block inside `addSyncTimestampColumns` (around the `hasColumn` helper and the hardcoded `for table in [...]` loop). No edits to `createDatabaseQueue()` or init code.

## Tests
Added 11 tests to `BackupServiceTests` covering UUID validation (accept/reject, traversal strings, `deleteBackup`/`backupFileURL` rejection) and metadata bounds (bad id, timestamp, schema version, negative counts, oversized file, overlong file name). Updated `testDeleteNonexistentBackupDoesNotThrow` to use a valid UUID.

`BackupServiceTests`: 24 passed, 1 pre-existing skip (needs a local prod backup file). HIPAA: no PHI logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)