### PR TITLE
fix(ios): data-at-rest hardening + fix silent in-memory DB fallback (locked-device dose loss) (#527)

### DIFF
--- a/mobile-apps/ios/MigraLog/App/MigraLog.entitlements
+++ b/mobile-apps/ios/MigraLog/App/MigraLog.entitlements
@@ -2,17 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.usernotifications.critical-alerts</key>
-	<true/>
-	<key>com.apple.developer.usernotifications.time-sensitive</key>
-	<true/>
-	<key>com.apple.developer.icloud-services</key>
-	<array>
-		<string>CloudKit</string>
-	</array>
+	<key>com.apple.developer.default-data-protection</key>
+	<string>NSFileProtectionCompleteUntilFirstUserAuthentication</string>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.com.eff3.migralog</string>
 	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+	<key>com.apple.developer.usernotifications.critical-alerts</key>
+	<true/>
+	<key>com.apple.developer.usernotifications.time-sensitive</key>
+	<true/>
 </dict>
 </plist>

--- a/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
+++ b/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
@@ -95,7 +95,20 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         BackgroundSyncScheduler.register(syncService: syncService)
+        // If we cold-launched in the BFU window onto the in-memory fallback, the
+        // device may already be unlocked by now; reopen the real on-disk DB and
+        // make the Class C protection class explicit on the file (#527). No-op
+        // when already on disk or when protected data is still unavailable.
+        DatabaseManager.shared.reopenOnDiskDatabaseIfNeeded()
         return true
+    }
+
+    /// Protected data became available (device unlocked for the first time after
+    /// boot). Reopen the real on-disk database if we fell back to in-memory during
+    /// the BFU window, so deferred writes and sync resume against persistent
+    /// storage rather than the throwaway in-memory DB (#527).
+    func applicationProtectedDataDidBecomeAvailable(_ application: UIApplication) {
+        DatabaseManager.shared.reopenOnDiskDatabaseIfNeeded()
     }
 }
 

--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -1,5 +1,25 @@
 import Foundation
 import GRDB
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Classifies why database initialization failed so callers can react
+/// differently to a recoverable, transient locked-device condition versus
+/// genuine file corruption.
+enum DatabaseInitializationError: Error {
+    /// The database file could not be opened because the device is in the
+    /// boot→first-unlock (BFU) window and the file's data-protection class
+    /// keeps it encrypted at rest until the first unlock. This is transient:
+    /// the file is intact and becomes readable once the device is unlocked.
+    /// We must NOT treat this as corruption — doing so would let writes (e.g. a
+    /// lock-screen dose log) silently land in an empty in-memory DB and be lost.
+    case protectedDataUnavailable(underlying: Error)
+
+    /// The database file appears genuinely unreadable (e.g. on-disk
+    /// corruption). The in-memory fallback is used so recovery UI can run.
+    case corruption(underlying: Error)
+}
 
 /// Central database manager. Owns the DatabaseQueue and handles schema creation/migration.
 final class DatabaseManager: Sendable {
@@ -14,12 +34,37 @@ final class DatabaseManager: Sendable {
     /// Written once during singleton init, read-only thereafter.
     nonisolated(unsafe) static private(set) var initializationError: Error?
 
+    /// True when the live `dbQueue` is the empty in-memory fallback rather than
+    /// the on-disk database. Any path that persists data (dose logging, sync)
+    /// MUST check this and refuse to write/sync rather than silently committing
+    /// to a throwaway DB. Written once during singleton init, read-only thereafter.
+    nonisolated(unsafe) static private(set) var isUsingInMemoryFallback = false
+
+    /// True when initialization failed specifically because protected data was
+    /// unavailable (BFU window). Distinguishes the transient locked-device case
+    /// from genuine corruption so callers can defer/retry instead of dropping data.
+    nonisolated(unsafe) static private(set) var protectedDataUnavailable = false
+
     /// The file URL of the database, available even when initialization failed
     /// so the user can export the file for recovery.
     /// Written once during singleton init, read-only thereafter.
     nonisolated(unsafe) static private(set) var databaseFileURL: URL?
 
-    let dbQueue: DatabaseQueue
+    #if DEBUG
+    /// Test-only: override the in-memory-fallback flag so the sync/dose gating can be
+    /// exercised without forcing a real locked-device open failure. Always reset in the
+    /// test's teardown. Not compiled into Release.
+    static func setInMemoryFallbackForTesting(_ value: Bool) {
+        isUsingInMemoryFallback = value
+    }
+    #endif
+
+    /// The live database queue. Internally mutable only so the transient
+    /// locked-device (BFU) fallback can be swapped for the real on-disk queue
+    /// once the device unlocks (see `reopenOnDiskDatabaseIfNeeded()`); after a
+    /// genuine-corruption fallback it is never swapped. The swap happens on the
+    /// main actor at foreground, before any normal write path runs.
+    nonisolated(unsafe) private(set) var dbQueue: DatabaseQueue
 
     /// Initialize with a file-based database at the default app location.
     /// On failure, falls back to an in-memory database so the app can launch
@@ -28,7 +73,47 @@ final class DatabaseManager: Sendable {
         dbQueue = DatabaseManager.createDatabaseQueue()
     }
 
-    /// Creates the database queue, falling back to in-memory on failure.
+    /// Whether the device's protected data (Data Protection–encrypted files) is
+    /// currently available. False during the BFU window before the first unlock.
+    /// Defaults to `true` on platforms without UIKit so tests/tools aren't gated.
+    static var isProtectedDataAvailable: Bool {
+        #if canImport(UIKit)
+        return UIApplication.shared.isProtectedDataAvailable
+        #else
+        return true
+        #endif
+    }
+
+    /// Classify a database-open failure. Returns a `DatabaseInitializationError`
+    /// describing whether this is a transient locked-device (BFU) condition or
+    /// genuine corruption. Pure and side-effect free so it can be unit tested:
+    /// `protectedDataAvailable` is injected rather than read from UIKit.
+    ///
+    /// Transient when the SQLite primary result code is `SQLITE_IOERR` (10),
+    /// `SQLITE_CANTOPEN` (14), or `SQLITE_AUTH` (23) AND protected data is
+    /// unavailable — the file is encrypted at rest until first unlock.
+    static func classifyOpenFailure(
+        _ error: Error,
+        protectedDataAvailable: Bool
+    ) -> DatabaseInitializationError {
+        let transientCodes: [ResultCode] = [.SQLITE_IOERR, .SQLITE_CANTOPEN, .SQLITE_AUTH]
+        if let dbError = error as? DatabaseError,
+           transientCodes.contains(dbError.resultCode),
+           !protectedDataAvailable {
+            return .protectedDataUnavailable(underlying: error)
+        }
+        return .corruption(underlying: error)
+    }
+
+    /// Creates the database queue.
+    ///
+    /// On a genuine open failure (corruption) it falls back to an empty in-memory
+    /// database so the app can launch and present recovery UI. On a transient
+    /// locked-device (BFU) failure it records the error and still returns an
+    /// in-memory queue (the app process must come up), but flags
+    /// `protectedDataUnavailable` / `isUsingInMemoryFallback` so write paths and
+    /// sync refuse to commit to the throwaway DB — the real on-disk DB is reopened
+    /// in `reopenOnDiskDatabaseIfNeeded()` once the device is unlocked.
     /// Sets static properties for error state and file URL as side effects.
     private static func createDatabaseQueue() -> DatabaseQueue {
         let fileManager = FileManager.default
@@ -51,9 +136,20 @@ final class DatabaseManager: Sendable {
             try mgr.migrate(queue)
             return queue
         } catch {
-            initializationError = error
-            // Fall back to an in-memory database so the app can launch
-            // and present recovery UI to the user
+            let classified = classifyOpenFailure(
+                error,
+                protectedDataAvailable: isProtectedDataAvailable
+            )
+            initializationError = classified
+            isUsingInMemoryFallback = true
+            if case .protectedDataUnavailable = classified {
+                // Transient: the on-disk DB is intact but encrypted until first
+                // unlock. Do NOT treat this as corruption. The in-memory queue
+                // exists only so the process launches; writers/sync must check
+                // `isUsingInMemoryFallback` and defer. Reopened once unlocked.
+                protectedDataUnavailable = true
+            }
+            // Fall back to an in-memory database so the app can launch.
             var fallbackConfig = Configuration()
             fallbackConfig.foreignKeysEnabled = true
             // swiftlint:disable:next force_try
@@ -61,6 +157,63 @@ final class DatabaseManager: Sendable {
             let mgr = DatabaseManager.buildMigrator()
             try? mgr.migrate(queue)
             return queue
+        }
+    }
+
+    /// After the device has unlocked for the first time (protected data is now
+    /// available), attempt to reopen the real on-disk database if we are running
+    /// on the transient BFU in-memory fallback. On success the in-memory queue is
+    /// swapped out, the error/fallback flags are cleared, and the explicit Class C
+    /// file-protection attribute is (re-)applied. A no-op once already on disk, or
+    /// when the fallback was due to genuine corruption (recovery UI owns that).
+    ///
+    /// Safe to call repeatedly. Must be called once protected data is available
+    /// (e.g. from `applicationProtectedDataDidBecomeAvailable` or at foreground).
+    func reopenOnDiskDatabaseIfNeeded() {
+        guard DatabaseManager.protectedDataUnavailable,
+              DatabaseManager.isProtectedDataAvailable,
+              let dbURL = DatabaseManager.databaseFileURL else {
+            // Still on disk, genuine corruption, or protected data not yet
+            // available — apply protection where it's safe and return.
+            DatabaseManager.applyFileProtectionIfPossible()
+            return
+        }
+        do {
+            var config = Configuration()
+            config.foreignKeysEnabled = true
+            let queue = try DatabaseQueue(path: dbURL.path, configuration: config)
+            try DatabaseManager.buildMigrator().migrate(queue)
+            dbQueue = queue
+            DatabaseManager.initializationError = nil
+            DatabaseManager.isUsingInMemoryFallback = false
+            DatabaseManager.protectedDataUnavailable = false
+            DatabaseManager.applyFileProtectionIfPossible()
+        } catch {
+            // Reopen still failing after unlock: leave the fallback flags set so
+            // writers/sync keep deferring rather than committing to the throwaway
+            // in-memory DB. Will be retried on the next protected-data/foreground
+            // signal. No PHI in the error description.
+            AppLogger.shared.error("Failed to reopen on-disk database after unlock", error: error)
+        }
+    }
+
+    /// Make the Class C data-protection class explicit on the existing database
+    /// file by setting `.completeUntilFirstUserAuthentication`. This is a fast key
+    /// re-wrap, not a migration. Only runs when protected data is available (so the
+    /// file is readable) and the file exists. Safe to call repeatedly.
+    static func applyFileProtectionIfPossible() {
+        guard isProtectedDataAvailable, let dbURL = databaseFileURL else { return }
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: dbURL.path) else { return }
+        do {
+            try fileManager.setAttributes(
+                [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+                ofItemAtPath: dbURL.path
+            )
+        } catch {
+            // Non-fatal: the entitlement-driven default already covers most
+            // installs. No PHI in the error description.
+            AppLogger.shared.error("Failed to set database file protection", error: error)
         }
     }
 

--- a/mobile-apps/ios/MigraLog/Services/NotificationResponseHandler.swift
+++ b/mobile-apps/ios/MigraLog/Services/NotificationResponseHandler.swift
@@ -162,12 +162,19 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
 
         switch actionIdentifier {
         case NotificationAction.medicationTaken:
-            await logDoseFromNotification(medicationId: medicationId, status: .taken)
-            await medicationNotificationService.handleTakenResponse(medicationId: medicationId, scheduleId: scheduleId)
+            let logged = await logDoseFromNotification(medicationId: medicationId, status: .taken, scheduleId: scheduleId)
+            // Only advance reminder state if the dose actually persisted — when the
+            // DB is unavailable (locked device) we deferred, so leave the reminder
+            // intact for the re-delivered prompt (#527).
+            if logged {
+                await medicationNotificationService.handleTakenResponse(medicationId: medicationId, scheduleId: scheduleId)
+            }
 
         case NotificationAction.medicationSkipped:
-            await logDoseFromNotification(medicationId: medicationId, status: .skipped)
-            await medicationNotificationService.handleSkippedResponse(medicationId: medicationId, scheduleId: scheduleId)
+            let logged = await logDoseFromNotification(medicationId: medicationId, status: .skipped, scheduleId: scheduleId)
+            if logged {
+                await medicationNotificationService.handleSkippedResponse(medicationId: medicationId, scheduleId: scheduleId)
+            }
 
         case NotificationAction.medicationSnooze:
             if let content = content {
@@ -248,6 +255,20 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
     }
 
     func logClearDay(date: String) async {
+        // BFU guard (#527): refuse to write a clear-day status into the empty
+        // in-memory fallback when the device is locked, or it would be silently
+        // lost. The check-in reminder remains scheduled so the user is re-prompted.
+        if DatabaseManager.isUsingInMemoryFallback {
+            logger.warn("Skipping clear-day log from notification: database unavailable (locked device)")
+            ErrorLogger.shared.logError(
+                DatabaseManager.initializationError
+                    ?? DatabaseInitializationError.protectedDataUnavailable(
+                        underlying: NSError(domain: "DatabaseManager", code: -1)
+                    ),
+                context: ["action": "clearDay.deferred", "reason": "inMemoryFallback"]
+            )
+            return
+        }
         let now = TimestampHelper.now
         let status = DailyStatusLog(
             id: UUID().uuidString,
@@ -279,11 +300,39 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
 
     // MARK: - Helpers
 
-    func logDoseFromNotification(medicationId: String, status: DoseStatus) async {
+    /// Persist a dose logged from a notification action.
+    ///
+    /// Returns `true` when the dose was written, `false` when it was deferred
+    /// because the database is unavailable (locked-device in-memory fallback) or
+    /// the medication couldn't be found. Callers use the result to avoid advancing
+    /// reminder state for a dose that didn't actually land (#527).
+    @discardableResult
+    func logDoseFromNotification(medicationId: String, status: DoseStatus, scheduleId: String? = nil) async -> Bool {
+        // BFU guard: if the on-disk DB couldn't be opened because the device is
+        // still locked (boot→first-unlock), the live queue is an empty in-memory
+        // fallback. Writing here would "succeed" against a throwaway DB and the
+        // dose would be silently lost (#527). Refuse to write so the dose is NOT
+        // dropped — re-deliver the action so the user can retry after unlock.
+        if DatabaseManager.isUsingInMemoryFallback {
+            logger.warn("Skipping dose log from notification: database unavailable (locked device)")
+            ErrorLogger.shared.logError(
+                DatabaseManager.initializationError
+                    ?? DatabaseInitializationError.protectedDataUnavailable(
+                        underlying: NSError(domain: "DatabaseManager", code: -1)
+                    ),
+                context: [
+                    "handler": "NotificationResponseHandler",
+                    "action": "logDoseFromNotification.deferred",
+                    "reason": "inMemoryFallback"
+                ]
+            )
+            await redeliverMissedDoseAction(medicationId: medicationId, scheduleId: scheduleId)
+            return false
+        }
         do {
             guard let medication = try medicationRepository.getMedicationById(medicationId) else {
                 logger.warn("Medication not found for notification response: \(medicationId)")
-                return
+                return false
             }
 
             let now = TimestampHelper.now
@@ -310,6 +359,7 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
             await MainActor.run {
                 NotificationCenter.default.post(name: .medicationDataChanged, object: nil)
             }
+            return true
         } catch {
             logger.error("Failed to log dose from notification", error: error)
             ErrorLogger.shared.logError(error, context: [
@@ -317,6 +367,36 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
                 "action": "logDoseFromNotification",
                 "medicationId": medicationId,
                 "status": "\(status)"
+            ])
+            return false
+        }
+    }
+
+    /// The database was unavailable (locked device) when a dose action arrived, so the
+    /// write was deferred rather than dropped (#527). Re-deliver the medication reminder
+    /// a short interval out so the user is prompted again once the device has likely been
+    /// unlocked, at which point the on-disk DB is reopened and the dose can be logged.
+    /// Best-effort: failure to reschedule is logged, never silently swallowed.
+    private func redeliverMissedDoseAction(medicationId: String, scheduleId: String?) async {
+        let retryId = "bfu_retry_\(medicationId)_\(UUID().uuidString)"
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 600, repeats: false)
+        var userInfo: [String: Any] = ["medicationId": medicationId]
+        if let scheduleId { userInfo["scheduleId"] = scheduleId }
+        do {
+            try await notificationService.scheduleNotification(
+                id: retryId,
+                title: "Reminder",
+                body: "Tap to log your medication.",
+                trigger: trigger,
+                categoryIdentifier: NotificationCategory.medication,
+                userInfo: userInfo
+            )
+            logger.info("Re-delivered deferred medication reminder after locked-device defer")
+        } catch {
+            logger.error("Failed to re-deliver deferred medication reminder", error: error)
+            ErrorLogger.shared.logError(error, context: [
+                "handler": "NotificationResponseHandler",
+                "action": "redeliverMissedDoseAction"
             ])
         }
     }

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncService.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncService.swift
@@ -82,8 +82,13 @@ final class SyncService {
     }
 
     /// Sync only if enabled — the entry point for automatic triggers (foreground, etc.).
+    /// Never runs against the in-memory fallback DB: when database initialization fell
+    /// back to memory (corruption, or a locked-device BFU window), syncing would push the
+    /// empty fallback's state and could clobber real data on other devices, or operate on
+    /// data that isn't actually persisted (#527). Bail out until the real DB is in use.
     func syncIfEnabled() async {
         guard isEnabled else { return }
+        guard !DatabaseManager.isUsingInMemoryFallback else { return }
         try? await syncNow()
     }
 

--- a/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
@@ -316,6 +316,53 @@ final class DatabaseManagerTests: XCTestCase {
         }
     }
 
+    // MARK: - Open-failure classification (#527)
+
+    /// A locked-device (BFU) open failure surfaces as one of SQLITE_IOERR/CANTOPEN/AUTH
+    /// while protected data is unavailable. These MUST be classified as the transient
+    /// `.protectedDataUnavailable` case so writers/sync defer rather than committing to
+    /// an empty in-memory DB and silently dropping the write.
+    func testClassifyOpenFailureTreatsLockedDeviceCodesAsTransient() {
+        let transientCodes: [ResultCode] = [.SQLITE_IOERR, .SQLITE_CANTOPEN, .SQLITE_AUTH]
+        for code in transientCodes {
+            let error = DatabaseError(resultCode: code, message: "open failed")
+            let classified = DatabaseManager.classifyOpenFailure(error, protectedDataAvailable: false)
+            guard case .protectedDataUnavailable = classified else {
+                XCTFail("code \(code) while locked should be .protectedDataUnavailable, got \(classified)")
+                continue
+            }
+        }
+    }
+
+    /// The same SQLite codes, when protected data IS available, are genuine corruption —
+    /// the in-memory fallback (and recovery UI) is appropriate.
+    func testClassifyOpenFailureWithProtectedDataAvailableIsCorruption() {
+        let error = DatabaseError(resultCode: .SQLITE_CANTOPEN, message: "open failed")
+        let classified = DatabaseManager.classifyOpenFailure(error, protectedDataAvailable: true)
+        guard case .corruption = classified else {
+            return XCTFail("CANTOPEN with protected data available should be .corruption, got \(classified)")
+        }
+    }
+
+    /// A corruption-class code (e.g. SQLITE_CORRUPT) is never transient, even while locked —
+    /// it must not be mistaken for a recoverable lock-screen condition.
+    func testClassifyOpenFailureCorruptCodeIsNeverTransient() {
+        let error = DatabaseError(resultCode: .SQLITE_CORRUPT, message: "malformed")
+        let classified = DatabaseManager.classifyOpenFailure(error, protectedDataAvailable: false)
+        guard case .corruption = classified else {
+            return XCTFail("SQLITE_CORRUPT should be .corruption regardless of lock state, got \(classified)")
+        }
+    }
+
+    /// A non-DatabaseError open failure is treated as corruption (conservative default).
+    func testClassifyOpenFailureNonDatabaseErrorIsCorruption() {
+        let error = NSError(domain: "test", code: 1)
+        let classified = DatabaseManager.classifyOpenFailure(error, protectedDataAvailable: false)
+        guard case .corruption = classified else {
+            return XCTFail("non-DatabaseError should be .corruption, got \(classified)")
+        }
+    }
+
     // MARK: - Reset Database
 
     func testResetDatabaseClearsAllData() throws {

--- a/mobile-apps/ios/MigraLogTests/Services/Sync/SyncServiceTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/Sync/SyncServiceTests.swift
@@ -61,6 +61,32 @@ final class SyncServiceTests: XCTestCase {
         XCTAssertFalse(transport.zoneCreated, "no sync work when disabled")
     }
 
+    /// #527: even when sync is enabled, an automatic trigger must NOT run while the
+    /// database fell back to the empty in-memory DB (locked-device BFU or corruption).
+    /// Pushing the fallback's state could clobber real data on other devices.
+    func testSyncIfEnabledSkipsWhenUsingInMemoryFallback() async throws {
+        let db = try DatabaseManager(inMemory: true)
+        try insertMedication(db, "m1")
+        let transport = InMemoryCloudKitTransport()
+        let service = SyncService(dbManager: db, transport: transport, backupService: SpyBackupService())
+        try await service.enable()
+        // enable() runs a first sync; ignore its effects and re-arm the transport.
+        let baseline = transport.zoneCreated
+
+        DatabaseManager.setInMemoryFallbackForTesting(true)
+        defer { DatabaseManager.setInMemoryFallbackForTesting(false) }
+
+        // A row edit would normally trigger an automatic sync; the gate must block it.
+        try await db.dbQueue.write {
+            try $0.execute(sql: "UPDATE medications SET name = 'Renamed', updated_at = 2000 WHERE id = 'm1'")
+        }
+        await service.syncIfEnabled()
+
+        XCTAssertTrue(service.isEnabled, "sync stays enabled — only the run is skipped")
+        // Nothing new should have been pushed while on the fallback DB.
+        XCTAssertEqual(transport.zoneCreated, baseline, "no sync work against the in-memory fallback")
+    }
+
     func testSyncNowRecordsFailure() async throws {
         let db = try DatabaseManager(inMemory: true)
         let transport = InMemoryCloudKitTransport()

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -64,6 +64,11 @@ targets:
           - CloudKit
         com.apple.developer.icloud-container-identifiers:
           - iCloud.com.eff3.migralog
+        # Class C data protection (#527): files default to "complete until first
+        # user authentication" so the SQLite DB stays encrypted at rest until the
+        # device's first unlock after boot, while remaining readable thereafter
+        # (lock-screen dose logging keeps working after first unlock).
+        com.apple.developer.default-data-protection: NSFileProtectionCompleteUntilFirstUserAuthentication
 
   MigraLogWidgets:
     type: app-extension


### PR DESCRIPTION
Closes #527

## The live bug
Notification actions (Taken / Skipped / Snooze / Clear Day) are registered without `.authenticationRequired` so a user mid-migraine can log a dose from the lock screen. Tapping one cold-launches the app in the background and reads/writes SQLite. In the boot→first-unlock (BFU) window the DB file is encrypted at rest, so the open fails — and `DatabaseManager` previously **silently fell back to an empty in-memory DB**. The dose handler then "succeeded" against the empty DB and the dose was silently lost.

## What changed

### 1. Stop the silent fallback (`DatabaseManager`)
- `classifyOpenFailure(_:protectedDataAvailable:)` — a pure, unit-tested classifier. `SQLITE_IOERR` (10) / `SQLITE_CANTOPEN` (14) / `SQLITE_AUTH` (23) **while `isProtectedDataAvailable == false`** is a transient locked-device condition → `.protectedDataUnavailable`. Everything else (incl. those codes when unlocked, `SQLITE_CORRUPT`, non-DB errors) → `.corruption`.
- On a transient failure we record the error and set `isUsingInMemoryFallback` / `protectedDataUnavailable`, returning an in-memory queue only so the process launches. The in-memory fallback as a *recoverable* state is kept **only for genuine corruption** (so the existing recovery UI still works).
- `reopenOnDiskDatabaseIfNeeded()` reopens the real on-disk DB once protected data becomes available, swaps out the fallback queue, and clears the flags. Wired to `applicationProtectedDataDidBecomeAvailable` and `didFinishLaunchingWithOptions`.

### 2. Don't drop the write (`NotificationResponseHandler`)
- Dose logging and clear-day logging refuse to write to the in-memory fallback. The dose action is **re-delivered** (10 min out) so the user is re-prompted after unlock, and reminder state is **not** advanced for a dose that didn't persist.

### 3. Gate sync (`SyncService.syncIfEnabled`)
- Bails out when `DatabaseManager.isUsingInMemoryFallback` is true, so sync can never push the empty fallback's state and clobber real data on other devices.

### 4. Class C made explicit
- Added the `com.apple.developer.default-data-protection = NSFileProtectionCompleteUntilFirstUserAuthentication` entitlement (declared in `project.yml` so it survives `xcodegen generate`).
- Set `.fileProtectionKey = .completeUntilFirstUserAuthentication` on `migralog.db` at foreground (fast key re-wrap, no migration).

## Acceptance criteria
- ✅ A notification action in the BFU window does not silently drop the write — it defers, re-delivers, and is retried after unlock.
- ✅ Sync cannot run against the in-memory fallback DB.
- ✅ Protection class set explicitly via entitlement + file attribute.
- ✅ Lock-screen dose logging still works after first unlock (flagship feature intact — the gate is only active during the BFU fallback).

## Tests
- `DatabaseManagerTests`: classification of transient (IOERR/CANTOPEN/AUTH while locked) vs corruption (same codes when unlocked, SQLITE_CORRUPT, non-DB error).
- `SyncServiceTests`: `syncIfEnabled` skips while on the in-memory fallback.
- Ran `DatabaseManagerTests` + `SyncServiceTests` (53 tests) and `NotificationResponseHandlerTests` (38 tests) — all pass. App target builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)