### PR TITLE
fix(ios): defer default-data-protection entitlement to unblock release (#527)

### DIFF
--- a/mobile-apps/ios/MigraLog/App/MigraLog.entitlements
+++ b/mobile-apps/ios/MigraLog/App/MigraLog.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.default-data-protection</key>
-	<string>NSFileProtectionCompleteUntilFirstUserAuthentication</string>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.com.eff3.migralog</string>

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -63,11 +63,14 @@ targets:
           - CloudKit
         com.apple.developer.icloud-container-identifiers:
           - iCloud.com.eff3.migralog
-        # Class C data protection (#527): files default to "complete until first
-        # user authentication" so the SQLite DB stays encrypted at rest until the
-        # device's first unlock after boot, while remaining readable thereafter
-        # (lock-screen dose logging keeps working after first unlock).
-        com.apple.developer.default-data-protection: NSFileProtectionCompleteUntilFirstUserAuthentication
+        # NOTE (#527): the `com.apple.developer.default-data-protection`
+        # entitlement (Class C "complete until first user authentication") was
+        # intentionally deferred. It requires the "Data Protection" capability to
+        # be enabled on the App ID and the "MigraLog App Store" provisioning
+        # profile regenerated — without that the distribution archive fails. The
+        # at-rest protection is still applied at runtime via the DB file's
+        # `.fileProtectionKey` (see DatabaseManager.applyFileProtectionIfPossible);
+        # re-add this entitlement once the App ID capability + profile are in place.
 
   MigraLogWidgets:
     type: app-extension


### PR DESCRIPTION
## Problem
#527 added the `com.apple.developer.default-data-protection` entitlement. The "MigraLog App Store" distribution provisioning profile does **not** include the Data Protection capability, so the TestFlight **archive** fails:

```
error: Provisioning profile "MigraLog App Store" doesn't include the com.apple.developer.default-data-protection entitlement.
```

Simulator `build-and-test` CI doesn't exercise distribution signing, so this only surfaced in the post-merge release archive — **breaking every deploy on main** (runs 27797776463, 27798631338).

## Fix
Remove the entitlement from `project.yml` + `MigraLog.entitlements` for now. The at-rest protection #527 actually relies on is still applied **at runtime** via the DB file's `.fileProtectionKey` (`DatabaseManager.applyFileProtectionIfPossible`, `.completeUntilFirstUserAuthentication`) — unchanged, needs no entitlement. The critical data-loss fix (no silent in-memory fallback in the boot→first-unlock window) is unaffected.

## Follow-up required (needs Apple Developer portal access)
To re-add the entitlement: enable the **Data Protection** capability on the `com.eff3.migralog` App ID, regenerate the **MigraLog App Store** provisioning profile, then revert this commit. Tracked on #527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)