### PR TITLE
fix(ios): re-add default-data-protection entitlement (#527)

### DIFF
--- a/mobile-apps/ios/MigraLog/App/MigraLog.entitlements
+++ b/mobile-apps/ios/MigraLog/App/MigraLog.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.default-data-protection</key>
+	<string>NSFileProtectionCompleteUntilFirstUserAuthentication</string>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.com.eff3.migralog</string>

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -63,14 +63,13 @@ targets:
           - CloudKit
         com.apple.developer.icloud-container-identifiers:
           - iCloud.com.eff3.migralog
-        # NOTE (#527): the `com.apple.developer.default-data-protection`
-        # entitlement (Class C "complete until first user authentication") was
-        # intentionally deferred. It requires the "Data Protection" capability to
-        # be enabled on the App ID and the "MigraLog App Store" provisioning
-        # profile regenerated — without that the distribution archive fails. The
-        # at-rest protection is still applied at runtime via the DB file's
-        # `.fileProtectionKey` (see DatabaseManager.applyFileProtectionIfPossible);
-        # re-add this entitlement once the App ID capability + profile are in place.
+        # Class C data protection (#527): files default to "complete until first
+        # user authentication" so the SQLite DB stays encrypted at rest until the
+        # device's first unlock after boot, while remaining readable thereafter
+        # (lock-screen dose logging keeps working after first unlock). Requires
+        # the App ID "Data Protection" capability (set to "Protected Until First
+        # User Authentication") and the "MigraLog App Store" profile to include it.
+        com.apple.developer.default-data-protection: NSFileProtectionCompleteUntilFirstUserAuthentication
 
   MigraLogWidgets:
     type: app-extension


### PR DESCRIPTION
Reverts the deferral in #538 now that the signing prerequisites are in place:
- ✅ **Data Protection** capability enabled on the `com.eff3.migralog` App ID (set to *Protected Until First User Authentication* = Class C).
- ✅ **MigraLog App Store** distribution profile regenerated to include it.
- ✅ `SWIFT_PROVISIONING_PROFILE` CI secret updated to the new profile.

Pins the app container's default file-protection class to `NSFileProtectionCompleteUntilFirstUserAuthentication` explicitly. Runtime enforcement on `migralog.db` is unchanged (`applyFileProtectionIfPossible`).

The archive step (which failed in #536/#538's deploys) is the real validation here — PR/simulator CI doesn't exercise distribution signing. Closes the last open item on #527.

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)