### PR TITLE
feat(ios): Med Response (time-to-relief) analytics section (#487)

### DIFF
--- a/mobile-apps/ios/MigraLog/Utils/AnalyticsInsights.swift
+++ b/mobile-apps/ios/MigraLog/Utils/AnalyticsInsights.swift
@@ -739,4 +739,166 @@ enum AnalyticsInsights {
         guard !peaks.isEmpty else { return (nil, 0) }
         return (peaks.reduce(0, +) / Double(peaks.count), peaks.count)
     }
+
+    // MARK: - Medication effectiveness
+
+    /// Default minimum number of qualifying doses before a metric is
+    /// summarized — keeps a comparison from resting on one or two data points.
+    static let minimumEffectivenessDoses = 3
+
+    /// Cap on time-to-relief, mirroring the `time_to_relief` column's 24-hour
+    /// ceiling. A relief signal that takes longer is treated as "no relief".
+    static let reliefCapMinutes = 1440
+
+    /// Median + interquartile range of a single metric, plus its sample size.
+    struct MetricSummary: Equatable {
+        let n: Int
+        let median: Double
+        let q25: Double
+        let q75: Double
+        let minimum: Double
+        let maximum: Double
+    }
+
+    /// Per-rescue-medication response, for comparing how well each rescue
+    /// medication worked over the range. `rating` and `relief` are each non-nil
+    /// only once the medication clears the minimum-sample gate for that metric,
+    /// so sparse data never produces a misleading comparison.
+    struct MedicationEffectiveness: Identifiable, Equatable {
+        let medicationId: String
+        let medicationName: String
+        let category: MedicationCategory?
+        /// Taken doses of this medication counted in the range. `rating` and
+        /// `relief` are computed from the subset of those doses carrying the
+        /// needed data.
+        let takenDoses: Int
+        /// Effectiveness-rating distribution (0–10), nil below the sample gate.
+        let rating: MetricSummary?
+        /// Time-to-relief distribution in minutes, nil below the sample gate.
+        let relief: MetricSummary?
+        var id: String { medicationId }
+    }
+
+    /// Per-rescue-medication effectiveness comparison.
+    ///
+    /// For each rescue medication, summarizes two metrics over its taken doses
+    /// in range (excluded-overlay days dropped):
+    /// - **Effectiveness rating** — the user-entered 0–10 rating on the dose.
+    /// - **Time to relief (minutes)** — the dose's explicit `timeToRelief` when
+    ///   recorded, otherwise derived as the minutes from the dose to the first
+    ///   intensity reading in the same episode that falls below the dose-time
+    ///   baseline (the last reading at or before the dose). Derived relief is
+    ///   capped at `reliefCapMinutes`; a longer gap counts as no measured
+    ///   relief. This mirrors the neurologist report's time-to-pain-drop.
+    ///
+    /// A metric is summarized only once it has at least `minimumDoses` values.
+    /// Medications with at least one taken dose are returned (sorted by name)
+    /// so the view can still prompt for more ratings; medications with no taken
+    /// doses in range are omitted.
+    static func medicationEffectiveness(
+        doses: [MedicationDose],
+        medications: [Medication],
+        readings: [IntensityReading],
+        excluded: Set<String>,
+        minimumDoses: Int = minimumEffectivenessDoses,
+        calendar: Calendar = .current
+    ) -> [MedicationEffectiveness] {
+        let rescueById = Dictionary(
+            medications.filter { $0.type == .rescue }.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        guard !rescueById.isEmpty else { return [] }
+
+        // Intensity readings per episode, ascending by time, for relief.
+        var readingsByEpisode: [String: [IntensityReading]] = [:]
+        for reading in readings {
+            readingsByEpisode[reading.episodeId, default: []].append(reading)
+        }
+        for key in readingsByEpisode.keys {
+            readingsByEpisode[key]?.sort { $0.timestamp < $1.timestamp }
+        }
+
+        var takenCount: [String: Int] = [:]
+        var ratings: [String: [Double]] = [:]
+        var reliefs: [String: [Double]] = [:]
+
+        for dose in doses where dose.status == .taken {
+            guard rescueById[dose.medicationId] != nil else { continue }
+            let day = TimestampHelper.dateString(from: TimestampHelper.toDate(dose.timestamp))
+            guard !excluded.contains(day) else { continue }
+            takenCount[dose.medicationId, default: 0] += 1
+
+            if let rating = dose.effectivenessRating {
+                ratings[dose.medicationId, default: []].append(rating)
+            }
+            if let relief = reliefMinutes(for: dose, readingsByEpisode: readingsByEpisode) {
+                reliefs[dose.medicationId, default: []].append(Double(relief))
+            }
+        }
+
+        return takenCount.keys.compactMap { medId -> MedicationEffectiveness? in
+            guard let med = rescueById[medId], let taken = takenCount[medId], taken > 0 else { return nil }
+            return MedicationEffectiveness(
+                medicationId: medId,
+                medicationName: med.name,
+                category: med.category,
+                takenDoses: taken,
+                rating: summary(of: ratings[medId] ?? [], minimum: minimumDoses),
+                relief: summary(of: reliefs[medId] ?? [], minimum: minimumDoses)
+            )
+        }
+        .sorted {
+            $0.medicationName != $1.medicationName
+                ? $0.medicationName < $1.medicationName
+                : $0.medicationId < $1.medicationId
+        }
+    }
+
+    /// Minutes from a dose to its first relief signal, or nil when none is
+    /// measurable. An explicit `timeToRelief` wins; otherwise the first
+    /// in-episode reading after the dose that falls below the dose-time
+    /// baseline, capped at `reliefCapMinutes`.
+    private static func reliefMinutes(
+        for dose: MedicationDose,
+        readingsByEpisode: [String: [IntensityReading]]
+    ) -> Int? {
+        if let explicit = dose.timeToRelief, explicit > 0 {
+            return min(explicit, reliefCapMinutes)
+        }
+        guard let episodeId = dose.episodeId,
+              let readings = readingsByEpisode[episodeId],
+              let baseline = readings.last(where: { $0.timestamp <= dose.timestamp })?.intensity else {
+            return nil
+        }
+        for reading in readings where reading.timestamp > dose.timestamp && reading.intensity < baseline {
+            let minutes = Int((reading.timestamp - dose.timestamp) / 60_000)
+            return minutes <= reliefCapMinutes ? max(minutes, 0) : nil
+        }
+        return nil
+    }
+
+    /// Median + IQR of `values`, or nil below `minimum` samples.
+    private static func summary(of values: [Double], minimum: Int) -> MetricSummary? {
+        guard values.count >= minimum else { return nil }
+        let sorted = values.sorted()
+        return MetricSummary(
+            n: sorted.count,
+            median: percentile(sorted, 0.5),
+            q25: percentile(sorted, 0.25),
+            q75: percentile(sorted, 0.75),
+            minimum: sorted.first ?? 0,
+            maximum: sorted.last ?? 0
+        )
+    }
+
+    /// Linear-interpolation percentile (numpy default), `p` in 0...1. `sorted`
+    /// must be ascending and non-empty.
+    private static func percentile(_ sorted: [Double], _ p: Double) -> Double {
+        if sorted.count == 1 { return sorted[0] }
+        let rank = p * Double(sorted.count - 1)
+        let low = Int(rank.rounded(.down))
+        let high = Int(rank.rounded(.up))
+        let weight = rank - Double(low)
+        return sorted[low] + (sorted[high] - sorted[low]) * weight
+    }
 }

--- a/mobile-apps/ios/MigraLog/Utils/AnalyticsInsights.swift
+++ b/mobile-apps/ios/MigraLog/Utils/AnalyticsInsights.swift
@@ -740,67 +740,55 @@ enum AnalyticsInsights {
         return (peaks.reduce(0, +) / Double(peaks.count), peaks.count)
     }
 
-    // MARK: - Medication effectiveness
+    // MARK: - Medication response (time to relief)
 
-    /// Default minimum number of qualifying doses before a metric is
-    /// summarized — keeps a comparison from resting on one or two data points.
-    static let minimumEffectivenessDoses = 3
+    /// Minimum number of doses with a measurable relief time before a
+    /// medication's time-to-relief is summarized — keeps a comparison from
+    /// resting on one or two data points.
+    static let minimumReliefDoses = 3
 
     /// Cap on time-to-relief, mirroring the `time_to_relief` column's 24-hour
     /// ceiling. A relief signal that takes longer is treated as "no relief".
     static let reliefCapMinutes = 1440
 
-    /// Median + interquartile range of a single metric, plus its sample size.
-    struct MetricSummary: Equatable {
-        let n: Int
-        let median: Double
-        let q25: Double
-        let q75: Double
-        let minimum: Double
-        let maximum: Double
-    }
-
-    /// Per-rescue-medication response, for comparing how well each rescue
-    /// medication worked over the range. `rating` and `relief` are each non-nil
-    /// only once the medication clears the minimum-sample gate for that metric,
-    /// so sparse data never produces a misleading comparison.
+    /// Per-rescue-medication response, for comparing how quickly each rescue
+    /// medication brought relief over the range. `reliefMedianMinutes` is
+    /// non-nil only once the medication clears the minimum-sample gate, so
+    /// sparse data never produces a misleading comparison.
     struct MedicationEffectiveness: Identifiable, Equatable {
         let medicationId: String
         let medicationName: String
         let category: MedicationCategory?
-        /// Taken doses of this medication counted in the range. `rating` and
-        /// `relief` are computed from the subset of those doses carrying the
-        /// needed data.
+        /// Taken doses of this medication counted in the range.
         let takenDoses: Int
-        /// Effectiveness-rating distribution (0–10), nil below the sample gate.
-        let rating: MetricSummary?
-        /// Time-to-relief distribution in minutes, nil below the sample gate.
-        let relief: MetricSummary?
+        /// Doses that contributed a measurable relief time.
+        let reliefDoses: Int
+        /// Median minutes to relief, nil below the sample gate.
+        let reliefMedianMinutes: Double?
         var id: String { medicationId }
     }
 
-    /// Per-rescue-medication effectiveness comparison.
+    /// Per-rescue-medication time-to-relief comparison.
     ///
-    /// For each rescue medication, summarizes two metrics over its taken doses
-    /// in range (excluded-overlay days dropped):
-    /// - **Effectiveness rating** — the user-entered 0–10 rating on the dose.
-    /// - **Time to relief (minutes)** — the dose's explicit `timeToRelief` when
-    ///   recorded, otherwise derived as the minutes from the dose to the first
-    ///   intensity reading in the same episode that falls below the dose-time
-    ///   baseline (the last reading at or before the dose). Derived relief is
-    ///   capped at `reliefCapMinutes`; a longer gap counts as no measured
-    ///   relief. This mirrors the neurologist report's time-to-pain-drop.
+    /// For each rescue medication, summarizes the time to relief over its taken
+    /// doses in range (excluded-overlay days dropped). Time to relief is the
+    /// dose's explicit `timeToRelief` when recorded, otherwise derived as the
+    /// minutes from the dose to the first intensity reading in the same episode
+    /// that falls below the dose-time baseline (the last reading at or before
+    /// the dose). Derived relief is capped at `reliefCapMinutes`; a longer gap
+    /// counts as no measured relief. This mirrors the neurologist report's
+    /// time-to-pain-drop.
     ///
-    /// A metric is summarized only once it has at least `minimumDoses` values.
-    /// Medications with at least one taken dose are returned (sorted by name)
-    /// so the view can still prompt for more ratings; medications with no taken
-    /// doses in range are omitted.
+    /// The median is reported only once a medication has at least
+    /// `minimumDoses` relief times. Medications with at least one taken dose are
+    /// returned (sorted by name) so the view can still prompt for more data;
+    /// medications with no taken doses in range are omitted.
     static func medicationEffectiveness(
         doses: [MedicationDose],
         medications: [Medication],
         readings: [IntensityReading],
         excluded: Set<String>,
-        minimumDoses: Int = minimumEffectivenessDoses,
+        minimumDoses: Int = minimumReliefDoses,
         calendar: Calendar = .current
     ) -> [MedicationEffectiveness] {
         let rescueById = Dictionary(
@@ -819,7 +807,6 @@ enum AnalyticsInsights {
         }
 
         var takenCount: [String: Int] = [:]
-        var ratings: [String: [Double]] = [:]
         var reliefs: [String: [Double]] = [:]
 
         for dose in doses where dose.status == .taken {
@@ -828,9 +815,6 @@ enum AnalyticsInsights {
             guard !excluded.contains(day) else { continue }
             takenCount[dose.medicationId, default: 0] += 1
 
-            if let rating = dose.effectivenessRating {
-                ratings[dose.medicationId, default: []].append(rating)
-            }
             if let relief = reliefMinutes(for: dose, readingsByEpisode: readingsByEpisode) {
                 reliefs[dose.medicationId, default: []].append(Double(relief))
             }
@@ -838,13 +822,15 @@ enum AnalyticsInsights {
 
         return takenCount.keys.compactMap { medId -> MedicationEffectiveness? in
             guard let med = rescueById[medId], let taken = takenCount[medId], taken > 0 else { return nil }
+            let reliefValues = reliefs[medId] ?? []
+            let medianMinutes = reliefValues.count >= minimumDoses ? median(of: reliefValues.sorted()) : nil
             return MedicationEffectiveness(
                 medicationId: medId,
                 medicationName: med.name,
                 category: med.category,
                 takenDoses: taken,
-                rating: summary(of: ratings[medId] ?? [], minimum: minimumDoses),
-                relief: summary(of: reliefs[medId] ?? [], minimum: minimumDoses)
+                reliefDoses: reliefValues.count,
+                reliefMedianMinutes: medianMinutes
             )
         }
         .sorted {
@@ -877,28 +863,10 @@ enum AnalyticsInsights {
         return nil
     }
 
-    /// Median + IQR of `values`, or nil below `minimum` samples.
-    private static func summary(of values: [Double], minimum: Int) -> MetricSummary? {
-        guard values.count >= minimum else { return nil }
-        let sorted = values.sorted()
-        return MetricSummary(
-            n: sorted.count,
-            median: percentile(sorted, 0.5),
-            q25: percentile(sorted, 0.25),
-            q75: percentile(sorted, 0.75),
-            minimum: sorted.first ?? 0,
-            maximum: sorted.last ?? 0
-        )
-    }
-
-    /// Linear-interpolation percentile (numpy default), `p` in 0...1. `sorted`
-    /// must be ascending and non-empty.
-    private static func percentile(_ sorted: [Double], _ p: Double) -> Double {
-        if sorted.count == 1 { return sorted[0] }
-        let rank = p * Double(sorted.count - 1)
-        let low = Int(rank.rounded(.down))
-        let high = Int(rank.rounded(.up))
-        let weight = rank - Double(low)
-        return sorted[low] + (sorted[high] - sorted[low]) * weight
+    /// Median of an ascending, non-empty array.
+    private static func median(of sorted: [Double]) -> Double {
+        let count = sorted.count
+        if count % 2 == 1 { return sorted[count / 2] }
+        return (sorted[count / 2 - 1] + sorted[count / 2]) / 2
     }
 }

--- a/mobile-apps/ios/MigraLog/ViewModels/AnalyticsViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/AnalyticsViewModel.swift
@@ -43,6 +43,8 @@ final class AnalyticsViewModel {
     var weeklyAdherence: [AnalyticsInsights.WeeklyAdherence] = []
     /// Medications referenced by `monthlySummaries`, for display names/order.
     var summaryMedications: [Medication] = []
+    /// Per-rescue-medication effectiveness comparison (Med Response section).
+    var medicationEffectiveness: [AnalyticsInsights.MedicationEffectiveness] = []
 
     // MARK: - Cache
 
@@ -152,6 +154,7 @@ final class AnalyticsViewModel {
             monthlySummaries = cached.monthlySummaries
             weeklyAdherence = cached.weeklyAdherence
             summaryMedications = cached.summaryMedications
+            medicationEffectiveness = cached.medicationEffectiveness
             return
         }
 
@@ -234,7 +237,8 @@ final class AnalyticsViewModel {
                 insightWarnings: insightWarnings,
                 monthlySummaries: monthlySummaries,
                 weeklyAdherence: weeklyAdherence,
-                summaryMedications: summaryMedications
+                summaryMedications: summaryMedications,
+                medicationEffectiveness: medicationEffectiveness
             )
             if hasData {
                 cache.set(cacheKey, value: cached, ttl: Self.cacheTTL)
@@ -492,6 +496,17 @@ final class AnalyticsViewModel {
             to: rangeEnd,
             calendar: calendar
         )
+
+        // Per-medication effectiveness comparison over the selected range.
+        // Readings come from the extended window, which is a superset of the
+        // range episodes, so in-range doses can resolve their episode's curve.
+        medicationEffectiveness = AnalyticsInsights.medicationEffectiveness(
+            doses: rangeDoses,
+            medications: allMedications,
+            readings: extendedReadings,
+            excluded: excluded,
+            calendar: calendar
+        )
     }
 
     /// Computes symptom and pain-location frequency over the in-range episodes.
@@ -581,4 +596,5 @@ private struct CachedAnalytics {
     let monthlySummaries: [AnalyticsInsights.MonthSummary]
     let weeklyAdherence: [AnalyticsInsights.WeeklyAdherence]
     let summaryMedications: [Medication]
+    let medicationEffectiveness: [AnalyticsInsights.MedicationEffectiveness]
 }

--- a/mobile-apps/ios/MigraLog/Views/Analytics/AnalyticsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Analytics/AnalyticsScreen.swift
@@ -6,6 +6,7 @@ import SwiftUI
 enum AnalyticsSection: String, CaseIterable, Identifiable {
     case calendar
     case insights
+    case medResponse
 
     var id: String { rawValue }
 
@@ -13,6 +14,7 @@ enum AnalyticsSection: String, CaseIterable, Identifiable {
         switch self {
         case .calendar: return "Calendar"
         case .insights: return "Insights"
+        case .medResponse: return "Med Response"
         }
     }
 }
@@ -67,6 +69,11 @@ struct AnalyticsScreen: View {
                     // Insight charts and summary table (episode totals and
                     // per-medication usage live in the Monthly Summary)
                     InsightsChartsSection(viewModel: viewModel)
+
+                case .medResponse:
+                    // Med Response follows the same range selector as Insights.
+                    TimeRangeSelectorView(viewModel: viewModel)
+                    MedicationResponseSection(viewModel: viewModel)
                 }
             }
             .padding()
@@ -666,6 +673,8 @@ struct AnalyticsVisualizationPane: View {
                         )
                     case .insights:
                         InsightsChartsSection(viewModel: viewModel)
+                    case .medResponse:
+                        MedicationResponseSection(viewModel: viewModel)
                     }
                 }
                 .padding()

--- a/mobile-apps/ios/MigraLog/Views/Analytics/MedicationResponseSection.swift
+++ b/mobile-apps/ios/MigraLog/Views/Analytics/MedicationResponseSection.swift
@@ -1,0 +1,233 @@
+import Charts
+import SwiftUI
+
+/// "Med Response" section of the Trends tab (issue #487).
+///
+/// Compares how well each rescue medication worked over the selected range:
+/// the median + IQR of its effectiveness rating and of its time to relief.
+/// A medication's metric only appears once it clears the minimum-sample gate
+/// in `AnalyticsInsights.medicationEffectiveness`, so a comparison never rests
+/// on one or two doses. Informational only — not medical advice.
+struct MedicationResponseSection: View {
+    @Bindable var viewModel: AnalyticsViewModel
+
+    private var meds: [AnalyticsInsights.MedicationEffectiveness] {
+        viewModel.medicationEffectiveness
+    }
+
+    /// Medications that cleared the gate for the effectiveness rating, used for
+    /// the at-a-glance comparison chart.
+    private var ratedMeds: [AnalyticsInsights.MedicationEffectiveness] {
+        meds.filter { $0.rating != nil }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if meds.isEmpty {
+                MedResponseEmptyState()
+            } else {
+                if !ratedMeds.isEmpty {
+                    EffectivenessComparisonCard(meds: ratedMeds)
+                }
+                ForEach(meds) { med in
+                    MedicationResponseCard(med: med)
+                }
+                Text("Informational only — not medical advice.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .accessibilityIdentifier("med-response-section")
+    }
+}
+
+// MARK: - Card chrome
+
+private struct ResponseCard<Content: View>: View {
+    let title: String
+    let subtitle: String?
+    let accessibilityId: String
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            if let subtitle {
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            content
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .accessibilityIdentifier(accessibilityId)
+    }
+}
+
+// MARK: - Empty state
+
+private struct MedResponseEmptyState: View {
+    var body: some View {
+        ResponseCard(
+            title: "Medication Response",
+            subtitle: "How well each rescue medication worked, side by side.",
+            accessibilityId: "med-response-empty"
+        ) {
+            Text("No rescue-medication doses in this range yet. Log doses against your episodes — and rate how well they worked — to compare medications here.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: 60, alignment: .leading)
+        }
+    }
+}
+
+// MARK: - Effectiveness comparison chart
+
+/// Horizontal IQR comparison of effectiveness ratings: a band from Q25 to Q75
+/// with a dot at the median, one row per medication. Higher is better.
+private struct EffectivenessComparisonCard: View {
+    let meds: [AnalyticsInsights.MedicationEffectiveness]
+
+    var body: some View {
+        ResponseCard(
+            title: "Effectiveness Compared",
+            subtitle: "Median rating with its interquartile range (25th–75th percentile). Higher is better; the dot is the median.",
+            accessibilityId: "med-response-comparison"
+        ) {
+            Chart(meds) { med in
+                if let rating = med.rating {
+                    BarMark(
+                        xStart: .value("Q25", rating.q25),
+                        xEnd: .value("Q75", rating.q75),
+                        y: .value("Medication", med.medicationName),
+                        height: 14
+                    )
+                    .foregroundStyle(Color.accentColor.opacity(0.25))
+                    .cornerRadius(4)
+
+                    PointMark(
+                        x: .value("Median", rating.median),
+                        y: .value("Medication", med.medicationName)
+                    )
+                    .foregroundStyle(Color.accentColor)
+                    .symbolSize(90)
+                    .annotation(position: .trailing, alignment: .leading) {
+                        Text(MedResponseFormat.rating(rating.median))
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .chartXScale(domain: 0...10)
+            .chartXAxis {
+                AxisMarks(values: [0, 2, 4, 6, 8, 10]) {
+                    AxisGridLine()
+                    AxisValueLabel()
+                }
+            }
+            .chartYScale(domain: meds.map(\.medicationName))
+            .frame(height: CGFloat(meds.count) * 40 + 24)
+        }
+    }
+}
+
+// MARK: - Per-medication detail card
+
+private struct MedicationResponseCard: View {
+    let med: AnalyticsInsights.MedicationEffectiveness
+
+    var body: some View {
+        ResponseCard(
+            title: med.medicationName,
+            subtitle: nil,
+            accessibilityId: "med-response-card-\(med.medicationId)"
+        ) {
+            HStack(spacing: 8) {
+                if let category = med.category {
+                    Text(category.displayName)
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Color(.tertiarySystemBackground))
+                        .clipShape(Capsule())
+                }
+                Text("\(med.takenDoses) \(med.takenDoses == 1 ? "dose" : "doses")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.bottom, 4)
+
+            MetricRow(
+                label: "Effectiveness",
+                summary: med.rating,
+                value: { MedResponseFormat.rating($0) },
+                range: { "\(MedResponseFormat.rating($0)) – \(MedResponseFormat.rating($1))" },
+                hint: "Need ≥\(AnalyticsInsights.minimumEffectivenessDoses) rated doses",
+                accessibilityId: "med-response-rating-\(med.medicationId)"
+            )
+
+            Divider()
+
+            MetricRow(
+                label: "Time to relief",
+                summary: med.relief,
+                value: { MedResponseFormat.minutes($0) },
+                range: { "\(MedResponseFormat.minutes($0)) – \(MedResponseFormat.minutes($1))" },
+                hint: "Need ≥\(AnalyticsInsights.minimumEffectivenessDoses) doses with relief data",
+                accessibilityId: "med-response-relief-\(med.medicationId)"
+            )
+        }
+    }
+}
+
+/// One labeled metric: the median big, IQR + sample size beneath, or a
+/// minimum-sample hint when the metric hasn't cleared the gate.
+private struct MetricRow: View {
+    let label: String
+    let summary: AnalyticsInsights.MetricSummary?
+    let value: (Double) -> String
+    let range: (Double, Double) -> String
+    let hint: String
+    let accessibilityId: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Spacer()
+            if let summary {
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(value(summary.median))
+                        .font(.title3.weight(.semibold).monospacedDigit())
+                    Text("IQR \(range(summary.q25, summary.q75)) · n=\(summary.n)")
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Text(hint)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .accessibilityIdentifier(accessibilityId)
+    }
+}
+
+// MARK: - Formatting
+
+private enum MedResponseFormat {
+    /// Effectiveness rating on the 0–10 scale, no decimals.
+    static func rating(_ value: Double) -> String {
+        String(Int(value.rounded()))
+    }
+
+    /// Time-to-relief minutes rendered as a duration (e.g. "45m", "2h 15m").
+    static func minutes(_ value: Double) -> String {
+        DateFormatting.formatDuration(milliseconds: Int64(value.rounded()) * 60_000)
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Analytics/MedicationResponseSection.swift
+++ b/mobile-apps/ios/MigraLog/Views/Analytics/MedicationResponseSection.swift
@@ -3,11 +3,12 @@ import SwiftUI
 
 /// "Med Response" section of the Trends tab (issue #487).
 ///
-/// Compares how well each rescue medication worked over the selected range:
-/// the median + IQR of its effectiveness rating and of its time to relief.
-/// A medication's metric only appears once it clears the minimum-sample gate
-/// in `AnalyticsInsights.medicationEffectiveness`, so a comparison never rests
-/// on one or two doses. Informational only — not medical advice.
+/// Compares how quickly each rescue medication brought relief over the
+/// selected range: the median time from a dose to the first drop in headache
+/// intensity. A medication's median only appears once it clears the
+/// minimum-sample gate in `AnalyticsInsights.medicationEffectiveness`, so a
+/// comparison never rests on one or two doses. Informational only — not
+/// medical advice.
 struct MedicationResponseSection: View {
     @Bindable var viewModel: AnalyticsViewModel
 
@@ -15,10 +16,10 @@ struct MedicationResponseSection: View {
         viewModel.medicationEffectiveness
     }
 
-    /// Medications that cleared the gate for the effectiveness rating, used for
-    /// the at-a-glance comparison chart.
-    private var ratedMeds: [AnalyticsInsights.MedicationEffectiveness] {
-        meds.filter { $0.rating != nil }
+    /// Medications that cleared the gate, fastest median first, for the chart.
+    private var reliefMeds: [AnalyticsInsights.MedicationEffectiveness] {
+        meds.filter { $0.reliefMedianMinutes != nil }
+            .sorted { ($0.reliefMedianMinutes ?? 0) < ($1.reliefMedianMinutes ?? 0) }
     }
 
     var body: some View {
@@ -26,8 +27,8 @@ struct MedicationResponseSection: View {
             if meds.isEmpty {
                 MedResponseEmptyState()
             } else {
-                if !ratedMeds.isEmpty {
-                    EffectivenessComparisonCard(meds: ratedMeds)
+                if !reliefMeds.isEmpty {
+                    ReliefComparisonCard(meds: reliefMeds)
                 }
                 ForEach(meds) { med in
                     MedicationResponseCard(med: med)
@@ -74,10 +75,10 @@ private struct MedResponseEmptyState: View {
     var body: some View {
         ResponseCard(
             title: "Medication Response",
-            subtitle: "How well each rescue medication worked, side by side.",
+            subtitle: "How quickly each rescue medication brought relief, side by side.",
             accessibilityId: "med-response-empty"
         ) {
-            Text("No rescue-medication doses in this range yet. Log doses against your episodes — and rate how well they worked — to compare medications here.")
+            Text("No rescue-medication doses in this range yet. Log doses against your episodes — and keep tracking intensity — to compare how fast each one works here.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, minHeight: 60, alignment: .leading)
@@ -85,51 +86,41 @@ private struct MedResponseEmptyState: View {
     }
 }
 
-// MARK: - Effectiveness comparison chart
+// MARK: - Time-to-relief comparison chart
 
-/// Horizontal IQR comparison of effectiveness ratings: a band from Q25 to Q75
-/// with a dot at the median, one row per medication. Higher is better.
-private struct EffectivenessComparisonCard: View {
+/// Horizontal bars of each medication's median time to relief, fastest first.
+/// Lower is faster.
+private struct ReliefComparisonCard: View {
     let meds: [AnalyticsInsights.MedicationEffectiveness]
 
     var body: some View {
         ResponseCard(
-            title: "Effectiveness Compared",
-            subtitle: "Median rating with its interquartile range (25th–75th percentile). Higher is better; the dot is the median.",
+            title: "Time to Relief Compared",
+            subtitle: "Median time from a rescue dose to the first drop in headache intensity. Lower is faster.",
             accessibilityId: "med-response-comparison"
         ) {
             Chart(meds) { med in
-                if let rating = med.rating {
+                if let minutes = med.reliefMedianMinutes {
                     BarMark(
-                        xStart: .value("Q25", rating.q25),
-                        xEnd: .value("Q75", rating.q75),
-                        y: .value("Medication", med.medicationName),
-                        height: 14
-                    )
-                    .foregroundStyle(Color.accentColor.opacity(0.25))
-                    .cornerRadius(4)
-
-                    PointMark(
-                        x: .value("Median", rating.median),
+                        x: .value("Time to relief", minutes),
                         y: .value("Medication", med.medicationName)
                     )
                     .foregroundStyle(Color.accentColor)
-                    .symbolSize(90)
                     .annotation(position: .trailing, alignment: .leading) {
-                        Text(MedResponseFormat.rating(rating.median))
+                        Text(MedResponseFormat.minutes(minutes))
                             .font(.caption2.monospacedDigit())
                             .foregroundStyle(.secondary)
                     }
                 }
             }
-            .chartXScale(domain: 0...10)
+            // Fastest median sits at the top (rows are pre-sorted ascending).
+            .chartYScale(domain: meds.map(\.medicationName))
             .chartXAxis {
-                AxisMarks(values: [0, 2, 4, 6, 8, 10]) {
+                AxisMarks(values: .automatic(desiredCount: 4)) {
                     AxisGridLine()
                     AxisValueLabel()
                 }
             }
-            .chartYScale(domain: meds.map(\.medicationName))
             .frame(height: CGFloat(meds.count) * 40 + 24)
         }
     }
@@ -161,71 +152,33 @@ private struct MedicationResponseCard: View {
             }
             .padding(.bottom, 4)
 
-            MetricRow(
-                label: "Effectiveness",
-                summary: med.rating,
-                value: { MedResponseFormat.rating($0) },
-                range: { "\(MedResponseFormat.rating($0)) – \(MedResponseFormat.rating($1))" },
-                hint: "Need ≥\(AnalyticsInsights.minimumEffectivenessDoses) rated doses",
-                accessibilityId: "med-response-rating-\(med.medicationId)"
-            )
-
-            Divider()
-
-            MetricRow(
-                label: "Time to relief",
-                summary: med.relief,
-                value: { MedResponseFormat.minutes($0) },
-                range: { "\(MedResponseFormat.minutes($0)) – \(MedResponseFormat.minutes($1))" },
-                hint: "Need ≥\(AnalyticsInsights.minimumEffectivenessDoses) doses with relief data",
-                accessibilityId: "med-response-relief-\(med.medicationId)"
-            )
-        }
-    }
-}
-
-/// One labeled metric: the median big, IQR + sample size beneath, or a
-/// minimum-sample hint when the metric hasn't cleared the gate.
-private struct MetricRow: View {
-    let label: String
-    let summary: AnalyticsInsights.MetricSummary?
-    let value: (Double) -> String
-    let range: (Double, Double) -> String
-    let hint: String
-    let accessibilityId: String
-
-    var body: some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text(label)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-            Spacer()
-            if let summary {
-                VStack(alignment: .trailing, spacing: 2) {
-                    Text(value(summary.median))
-                        .font(.title3.weight(.semibold).monospacedDigit())
-                    Text("IQR \(range(summary.q25, summary.q75)) · n=\(summary.n)")
-                        .font(.caption2.monospacedDigit())
-                        .foregroundStyle(.secondary)
+            HStack(alignment: .firstTextBaseline) {
+                Text("Time to relief")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if let minutes = med.reliefMedianMinutes {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text(MedResponseFormat.minutes(minutes))
+                            .font(.title3.weight(.semibold).monospacedDigit())
+                        Text("median · \(med.reliefDoses) \(med.reliefDoses == 1 ? "dose" : "doses")")
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Text("Need ≥\(AnalyticsInsights.minimumReliefDoses) doses with relief data")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
                 }
-            } else {
-                Text(hint)
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
             }
+            .accessibilityIdentifier("med-response-relief-\(med.medicationId)")
         }
-        .accessibilityIdentifier(accessibilityId)
     }
 }
 
 // MARK: - Formatting
 
 private enum MedResponseFormat {
-    /// Effectiveness rating on the 0–10 scale, no decimals.
-    static func rating(_ value: Double) -> String {
-        String(Int(value.rounded()))
-    }
-
     /// Time-to-relief minutes rendered as a duration (e.g. "45m", "2h 15m").
     static func minutes(_ value: Double) -> String {
         DateFormatting.formatDuration(milliseconds: Int64(value.rounded()) * 60_000)

--- a/mobile-apps/ios/MigraLogTests/MockRepositories.swift
+++ b/mobile-apps/ios/MigraLogTests/MockRepositories.swift
@@ -880,7 +880,10 @@ enum TestFixtures {
         medicationId: String,
         timestamp: Int64? = nil,
         status: DoseStatus = .taken,
-        quantity: Double = 1.0
+        quantity: Double = 1.0,
+        episodeId: String? = nil,
+        effectivenessRating: Double? = nil,
+        timeToRelief: Int? = nil
     ) -> MedicationDose {
         let ts = timestamp ?? now
         return MedicationDose(
@@ -891,9 +894,9 @@ enum TestFixtures {
             dosageAmount: 400,
             dosageUnit: "mg",
             status: status,
-            episodeId: nil,
-            effectivenessRating: nil,
-            timeToRelief: nil,
+            episodeId: episodeId,
+            effectivenessRating: effectivenessRating,
+            timeToRelief: timeToRelief,
             sideEffects: [],
             notes: nil,
             createdAt: ts,

--- a/mobile-apps/ios/MigraLogTests/Utils/AnalyticsInsightsTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Utils/AnalyticsInsightsTests.swift
@@ -702,14 +702,14 @@ final class AnalyticsInsightsTests: XCTestCase {
         XCTAssertTrue(warnings.isEmpty)
     }
 
-    // MARK: - medicationEffectiveness
+    // MARK: - medicationEffectiveness (time to relief)
 
-    func testMedicationEffectiveness_summarizesRatingMedianAndIQR() throws {
-        let triptan = TestFixtures.makeMedication(id: "med-t", name: "Sumatriptan", type: .rescue, category: .triptan)
-        // Ratings 4,6,8,10 → median 7, Q25 5.5, Q75 8.5 (linear interpolation).
-        let ratings: [Double] = [4, 6, 8, 10]
-        let doses = ratings.enumerated().map { index, rating in
-            TestFixtures.makeDose(id: "d\(index)", medicationId: "med-t", timestamp: ms(daysAgo: index + 1), effectivenessRating: rating)
+    func testMedicationEffectiveness_summarizesReliefMedian() {
+        let triptan = TestFixtures.makeMedication(id: "med-t", type: .rescue, category: .triptan)
+        // Three doses with explicit relief 20, 30, 40 → median 30, n=3.
+        let reliefs = [20, 30, 40]
+        let doses = reliefs.enumerated().map { index, relief in
+            TestFixtures.makeDose(id: "d\(index)", medicationId: "med-t", timestamp: ms(daysAgo: index + 1), timeToRelief: relief)
         }
 
         let result = AnalyticsInsights.medicationEffectiveness(
@@ -717,33 +717,30 @@ final class AnalyticsInsightsTests: XCTestCase {
         )
 
         XCTAssertEqual(result.count, 1)
-        let rating = try XCTUnwrap(result.first?.rating)
-        XCTAssertEqual(rating.n, 4)
-        XCTAssertEqual(rating.median, 7, accuracy: 0.0001)
-        XCTAssertEqual(rating.q25, 5.5, accuracy: 0.0001)
-        XCTAssertEqual(rating.q75, 8.5, accuracy: 0.0001)
-        XCTAssertEqual(result.first?.takenDoses, 4)
-        XCTAssertNil(result.first?.relief, "No relief data was provided")
+        XCTAssertEqual(result.first?.takenDoses, 3)
+        XCTAssertEqual(result.first?.reliefDoses, 3)
+        XCTAssertEqual(result.first?.reliefMedianMinutes ?? 0, 30, accuracy: 0.0001)
     }
 
-    func testMedicationEffectiveness_gatesMetricBelowMinimumDoses() {
+    func testMedicationEffectiveness_gatesReliefBelowMinimumDoses() {
         let triptan = TestFixtures.makeMedication(id: "med-t", type: .rescue, category: .triptan)
         let doses = [
-            TestFixtures.makeDose(id: "d0", medicationId: "med-t", timestamp: ms(daysAgo: 1), effectivenessRating: 8),
-            TestFixtures.makeDose(id: "d1", medicationId: "med-t", timestamp: ms(daysAgo: 2), effectivenessRating: 6),
+            TestFixtures.makeDose(id: "d0", medicationId: "med-t", timestamp: ms(daysAgo: 1), timeToRelief: 30),
+            TestFixtures.makeDose(id: "d1", medicationId: "med-t", timestamp: ms(daysAgo: 2), timeToRelief: 45),
         ]
 
         let result = AnalyticsInsights.medicationEffectiveness(
             doses: doses, medications: [triptan], readings: [], excluded: [], calendar: calendar
         )
 
-        // The medication still appears (2 taken doses) but its rating is gated.
+        // The medication still appears (2 taken doses) but its median is gated.
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first?.takenDoses, 2)
-        XCTAssertNil(result.first?.rating)
+        XCTAssertEqual(result.first?.reliefDoses, 2)
+        XCTAssertNil(result.first?.reliefMedianMinutes)
     }
 
-    func testMedicationEffectiveness_derivesReliefFromIntensityDrop() throws {
+    func testMedicationEffectiveness_derivesReliefFromIntensityDrop() {
         let triptan = TestFixtures.makeMedication(id: "med-t", type: .rescue, category: .triptan)
         var doses: [MedicationDose] = []
         var readings: [IntensityReading] = []
@@ -760,24 +757,31 @@ final class AnalyticsInsightsTests: XCTestCase {
             doses: doses, medications: [triptan], readings: readings, excluded: [], calendar: calendar
         )
 
-        let relief = try XCTUnwrap(result.first?.relief)
-        XCTAssertEqual(relief.n, 3)
-        XCTAssertEqual(relief.median, 30, accuracy: 0.0001)
+        XCTAssertEqual(result.first?.reliefDoses, 3)
+        XCTAssertEqual(result.first?.reliefMedianMinutes ?? 0, 30, accuracy: 0.0001)
     }
 
-    func testMedicationEffectiveness_explicitTimeToReliefWinsOverDerived() throws {
+    func testMedicationEffectiveness_explicitTimeToReliefWinsOverDerived() {
         let triptan = TestFixtures.makeMedication(id: "med-t", type: .rescue, category: .triptan)
-        // Explicit 45-minute relief, no episode/readings needed.
+        // Episode readings would derive a 30-minute drop, but the explicit
+        // 45-minute relief takes precedence.
+        let doseTime = ms(daysAgo: 1, hour: 12)
+        let readings = [
+            TestFixtures.makeReading(episodeId: "ep", intensity: 8, timestamp: doseTime - 5 * 60_000),
+            TestFixtures.makeReading(episodeId: "ep", intensity: 4, timestamp: doseTime + 30 * 60_000),
+        ]
         let doses = (0..<3).map { index in
-            TestFixtures.makeDose(id: "d\(index)", medicationId: "med-t", timestamp: ms(daysAgo: index + 1), timeToRelief: 45)
+            TestFixtures.makeDose(
+                id: "d\(index)", medicationId: "med-t", timestamp: ms(daysAgo: index + 1),
+                episodeId: "ep", timeToRelief: 45
+            )
         }
 
         let result = AnalyticsInsights.medicationEffectiveness(
-            doses: doses, medications: [triptan], readings: [], excluded: [], calendar: calendar
+            doses: doses, medications: [triptan], readings: readings, excluded: [], calendar: calendar
         )
 
-        let relief = try XCTUnwrap(result.first?.relief)
-        XCTAssertEqual(relief.median, 45, accuracy: 0.0001)
+        XCTAssertEqual(result.first?.reliefMedianMinutes ?? 0, 45, accuracy: 0.0001)
     }
 
     func testMedicationEffectiveness_ignoresSkippedExcludedAndPreventative() {
@@ -785,13 +789,13 @@ final class AnalyticsInsightsTests: XCTestCase {
         let preventative = TestFixtures.makeMedication(id: "med-p", type: .preventative, category: .cgrp)
         let doses = [
             // Counted.
-            TestFixtures.makeDose(id: "d0", medicationId: "med-t", timestamp: ms(daysAgo: 1), effectivenessRating: 7),
+            TestFixtures.makeDose(id: "d0", medicationId: "med-t", timestamp: ms(daysAgo: 1), timeToRelief: 30),
             // Skipped — ignored.
-            TestFixtures.makeDose(id: "d1", medicationId: "med-t", timestamp: ms(daysAgo: 2), status: .skipped, effectivenessRating: 1),
+            TestFixtures.makeDose(id: "d1", medicationId: "med-t", timestamp: ms(daysAgo: 2), status: .skipped, timeToRelief: 30),
             // Excluded day — ignored.
-            TestFixtures.makeDose(id: "d2", medicationId: "med-t", timestamp: ms(daysAgo: 3), effectivenessRating: 1),
+            TestFixtures.makeDose(id: "d2", medicationId: "med-t", timestamp: ms(daysAgo: 3), timeToRelief: 30),
             // Preventative medication — not a rescue, ignored.
-            TestFixtures.makeDose(id: "d3", medicationId: "med-p", timestamp: ms(daysAgo: 1), effectivenessRating: 9),
+            TestFixtures.makeDose(id: "d3", medicationId: "med-p", timestamp: ms(daysAgo: 1), timeToRelief: 30),
         ]
 
         let result = AnalyticsInsights.medicationEffectiveness(
@@ -805,5 +809,6 @@ final class AnalyticsInsightsTests: XCTestCase {
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first?.medicationId, "med-t")
         XCTAssertEqual(result.first?.takenDoses, 1)
+        XCTAssertEqual(result.first?.reliefDoses, 1)
     }
 }

--- a/mobile-apps/ios/MigraLogTests/Utils/AnalyticsInsightsTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Utils/AnalyticsInsightsTests.swift
@@ -701,4 +701,109 @@ final class AnalyticsInsightsTests: XCTestCase {
 
         XCTAssertTrue(warnings.isEmpty)
     }
+
+    // MARK: - medicationEffectiveness
+
+    func testMedicationEffectiveness_summarizesRatingMedianAndIQR() {
+        let triptan = TestFixtures.makeMedication(id: "med-t", name: "Sumatriptan", type: .rescue, category: .triptan)
+        // Ratings 4,6,8,10 → median 7, Q25 5.5, Q75 8.5 (linear interpolation).
+        let ratings: [Double] = [4, 6, 8, 10]
+        let doses = ratings.enumerated().map { index, rating in
+            TestFixtures.makeDose(id: "d\(index)", medicationId: "med-t", timestamp: ms(daysAgo: index + 1), effectivenessRating: rating)
+        }
+
+        let result = AnalyticsInsights.medicationEffectiveness(
+            doses: doses, medications: [triptan], readings: [], excluded: [], calendar: calendar
+        )
+
+        XCTAssertEqual(result.count, 1)
+        let rating = try! XCTUnwrap(result.first?.rating)
+        XCTAssertEqual(rating.n, 4)
+        XCTAssertEqual(rating.median, 7, accuracy: 0.0001)
+        XCTAssertEqual(rating.q25, 5.5, accuracy: 0.0001)
+        XCTAssertEqual(rating.q75, 8.5, accuracy: 0.0001)
+        XCTAssertEqual(result.first?.takenDoses, 4)
+        XCTAssertNil(result.first?.relief, "No relief data was provided")
+    }
+
+    func testMedicationEffectiveness_gatesMetricBelowMinimumDoses() {
+        let triptan = TestFixtures.makeMedication(id: "med-t", type: .rescue, category: .triptan)
+        let doses = [
+            TestFixtures.makeDose(id: "d0", medicationId: "med-t", timestamp: ms(daysAgo: 1), effectivenessRating: 8),
+            TestFixtures.makeDose(id: "d1", medicationId: "med-t", timestamp: ms(daysAgo: 2), effectivenessRating: 6),
+        ]
+
+        let result = AnalyticsInsights.medicationEffectiveness(
+            doses: doses, medications: [triptan], readings: [], excluded: [], calendar: calendar
+        )
+
+        // The medication still appears (2 taken doses) but its rating is gated.
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.takenDoses, 2)
+        XCTAssertNil(result.first?.rating)
+    }
+
+    func testMedicationEffectiveness_derivesReliefFromIntensityDrop() {
+        let triptan = TestFixtures.makeMedication(id: "med-t", type: .rescue, category: .triptan)
+        var doses: [MedicationDose] = []
+        var readings: [IntensityReading] = []
+        // Three episodes, each: baseline reading, dose, then a drop 30 min later.
+        for index in 0..<3 {
+            let episodeId = "ep\(index)"
+            let doseTime = ms(daysAgo: index + 1, hour: 12)
+            readings.append(TestFixtures.makeReading(episodeId: episodeId, intensity: 8, timestamp: doseTime - 5 * 60_000))
+            readings.append(TestFixtures.makeReading(episodeId: episodeId, intensity: 4, timestamp: doseTime + 30 * 60_000))
+            doses.append(TestFixtures.makeDose(id: "d\(index)", medicationId: "med-t", timestamp: doseTime, episodeId: episodeId))
+        }
+
+        let result = AnalyticsInsights.medicationEffectiveness(
+            doses: doses, medications: [triptan], readings: readings, excluded: [], calendar: calendar
+        )
+
+        let relief = try! XCTUnwrap(result.first?.relief)
+        XCTAssertEqual(relief.n, 3)
+        XCTAssertEqual(relief.median, 30, accuracy: 0.0001)
+    }
+
+    func testMedicationEffectiveness_explicitTimeToReliefWinsOverDerived() {
+        let triptan = TestFixtures.makeMedication(id: "med-t", type: .rescue, category: .triptan)
+        // Explicit 45-minute relief, no episode/readings needed.
+        let doses = (0..<3).map { index in
+            TestFixtures.makeDose(id: "d\(index)", medicationId: "med-t", timestamp: ms(daysAgo: index + 1), timeToRelief: 45)
+        }
+
+        let result = AnalyticsInsights.medicationEffectiveness(
+            doses: doses, medications: [triptan], readings: [], excluded: [], calendar: calendar
+        )
+
+        let relief = try! XCTUnwrap(result.first?.relief)
+        XCTAssertEqual(relief.median, 45, accuracy: 0.0001)
+    }
+
+    func testMedicationEffectiveness_ignoresSkippedExcludedAndPreventative() {
+        let triptan = TestFixtures.makeMedication(id: "med-t", type: .rescue, category: .triptan)
+        let preventative = TestFixtures.makeMedication(id: "med-p", type: .preventative, category: .cgrp)
+        let doses = [
+            // Counted.
+            TestFixtures.makeDose(id: "d0", medicationId: "med-t", timestamp: ms(daysAgo: 1), effectivenessRating: 7),
+            // Skipped — ignored.
+            TestFixtures.makeDose(id: "d1", medicationId: "med-t", timestamp: ms(daysAgo: 2), status: .skipped, effectivenessRating: 1),
+            // Excluded day — ignored.
+            TestFixtures.makeDose(id: "d2", medicationId: "med-t", timestamp: ms(daysAgo: 3), effectivenessRating: 1),
+            // Preventative medication — not a rescue, ignored.
+            TestFixtures.makeDose(id: "d3", medicationId: "med-p", timestamp: ms(daysAgo: 1), effectivenessRating: 9),
+        ]
+
+        let result = AnalyticsInsights.medicationEffectiveness(
+            doses: doses,
+            medications: [triptan, preventative],
+            readings: [],
+            excluded: [dayString(daysAgo: 3)],
+            calendar: calendar
+        )
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.medicationId, "med-t")
+        XCTAssertEqual(result.first?.takenDoses, 1)
+    }
 }

--- a/mobile-apps/ios/MigraLogTests/Utils/AnalyticsInsightsTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Utils/AnalyticsInsightsTests.swift
@@ -704,7 +704,7 @@ final class AnalyticsInsightsTests: XCTestCase {
 
     // MARK: - medicationEffectiveness
 
-    func testMedicationEffectiveness_summarizesRatingMedianAndIQR() {
+    func testMedicationEffectiveness_summarizesRatingMedianAndIQR() throws {
         let triptan = TestFixtures.makeMedication(id: "med-t", name: "Sumatriptan", type: .rescue, category: .triptan)
         // Ratings 4,6,8,10 → median 7, Q25 5.5, Q75 8.5 (linear interpolation).
         let ratings: [Double] = [4, 6, 8, 10]
@@ -717,7 +717,7 @@ final class AnalyticsInsightsTests: XCTestCase {
         )
 
         XCTAssertEqual(result.count, 1)
-        let rating = try! XCTUnwrap(result.first?.rating)
+        let rating = try XCTUnwrap(result.first?.rating)
         XCTAssertEqual(rating.n, 4)
         XCTAssertEqual(rating.median, 7, accuracy: 0.0001)
         XCTAssertEqual(rating.q25, 5.5, accuracy: 0.0001)
@@ -743,7 +743,7 @@ final class AnalyticsInsightsTests: XCTestCase {
         XCTAssertNil(result.first?.rating)
     }
 
-    func testMedicationEffectiveness_derivesReliefFromIntensityDrop() {
+    func testMedicationEffectiveness_derivesReliefFromIntensityDrop() throws {
         let triptan = TestFixtures.makeMedication(id: "med-t", type: .rescue, category: .triptan)
         var doses: [MedicationDose] = []
         var readings: [IntensityReading] = []
@@ -760,12 +760,12 @@ final class AnalyticsInsightsTests: XCTestCase {
             doses: doses, medications: [triptan], readings: readings, excluded: [], calendar: calendar
         )
 
-        let relief = try! XCTUnwrap(result.first?.relief)
+        let relief = try XCTUnwrap(result.first?.relief)
         XCTAssertEqual(relief.n, 3)
         XCTAssertEqual(relief.median, 30, accuracy: 0.0001)
     }
 
-    func testMedicationEffectiveness_explicitTimeToReliefWinsOverDerived() {
+    func testMedicationEffectiveness_explicitTimeToReliefWinsOverDerived() throws {
         let triptan = TestFixtures.makeMedication(id: "med-t", type: .rescue, category: .triptan)
         // Explicit 45-minute relief, no episode/readings needed.
         let doses = (0..<3).map { index in
@@ -776,7 +776,7 @@ final class AnalyticsInsightsTests: XCTestCase {
             doses: doses, medications: [triptan], readings: [], excluded: [], calendar: calendar
         )
 
-        let relief = try! XCTUnwrap(result.first?.relief)
+        let relief = try XCTUnwrap(result.first?.relief)
         XCTAssertEqual(relief.median, 45, accuracy: 0.0001)
     }
 

--- a/mobile-apps/ios/MigraLogUITests/TrendsAnalyticsUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/TrendsAnalyticsUITests.swift
@@ -50,6 +50,24 @@ final class TrendsAnalyticsUITests: XCTestCase {
         UITestHelpers.waitForElement(dayStatsCard)
     }
 
+    // MARK: - 7.1b Med Response section
+
+    func testMedResponseSectionAppears() throws {
+        app = UITestHelpers.launchCleanDashboard()
+        UITestHelpers.waitForDashboard(in: app)
+        UITestHelpers.navigateTo(tab: .trends, in: app)
+        let trendsScreen = app.navigationBars.staticTexts["Trends & Analytics"]
+        UITestHelpers.waitForElement(trendsScreen)
+
+        // Switch to the Med Response section; the range selector and the
+        // empty-state card should be present (no rescue doses with clean data).
+        selectSection("Med Response")
+        let rangeCustom = app.buttons["time-range-custom"]
+        UITestHelpers.waitForElement(rangeCustom)
+        let emptyTitle = app.staticTexts["Medication Response"]
+        UITestHelpers.waitForElement(emptyTitle)
+    }
+
     // MARK: - 7.2 Time range switching
 
     func testTimeRangeSwitching() throws {


### PR DESCRIPTION
## Summary

Adds a third **Med Response** segment beside Calendar and Insights on the Trends tab, comparing **how quickly each rescue medication brought relief** over the selected range. Implements (a focused slice of) the *Medication effectiveness comparison* item of #487.

Per rescue medication, over its taken doses in range (excluded-overlay days dropped):
- **Time to relief** — median minutes from the dose to relief. Uses the dose's explicit `timeToRelief` when set, otherwise derives it as the minutes to the first in-episode intensity reading below the dose-time baseline (mirrors the neurologist report's *time-to-pain-drop*), capped at 24h.

A **minimum-sample gate** (≥3 doses with a relief time) applies before a median is shown; medications with doses but too little data still appear with a "need ≥3…" hint.

### Scope note — effectiveness rating dropped (for now)
An earlier revision also compared the user-entered 0–10 **effectiveness rating** with median + IQR. That metric is effectively un-captured today (only an off-by-default toggle on the edit-dose screen writes it; no logging flow does), so the comparison was misleading. It and all the median/IQR/quartile machinery were removed; Med Response is now time-to-relief only. Capturing effectiveness (and an explicit time-to-relief) at log time is a worthwhile follow-up, tracked separately.

## Changes
- `AnalyticsInsights.medicationEffectiveness` → `MedicationEffectiveness { takenDoses, reliefDoses, reliefMedianMinutes }` plus a plain median helper (pure, unit-tested).
- `AnalyticsViewModel`: computes + caches `medicationEffectiveness` over the selected range.
- `MedicationResponseSection` view: a "Time to Relief Compared" bar chart (fastest median first, lower is faster) plus per-medication detail cards. Wired into both the iPhone stack and the iPad split pane.
- Engine unit tests (median, gating, derived vs explicit relief, skipped/excluded/preventative exclusion) and a UI test asserting the section appears.

## Verification
- `AnalyticsInsightsTests` (43) green; `AnalyticsViewModelTests` green; `TrendsAnalyticsUITests/testMedResponseSectionAppears` green.
- Demoed on iPhone 17 Pro (OS 26.5) with the screenshot dataset: the segment renders beside Calendar/Insights; the chart shows Ibuprofen (2h 12m) and Sumatriptan (3h 18m); per-med cards show median time-to-relief with dose counts.

Left as **draft** pending review. Remaining #487 items (N-of-1 triggers, CGRP cycle view, preventive responder tracking) are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)