### PR TITLE
feat(ios): delete an episode from the detail screen

### DIFF
--- a/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
@@ -219,6 +219,29 @@ final class EpisodeDetailViewModel {
         }
     }
 
+    /// Permanently delete this episode and everything attached to it (intensity
+    /// readings, symptom/pain logs, notes — cascaded by the DB). Doses keep their
+    /// history; their `episode_id` is nulled by the foreign key. Used to discard an
+    /// episode started by accident, whether it's still active or already ended.
+    @MainActor
+    func deleteEpisode() async {
+        guard let episode = details?.episode else { return }
+        do {
+            try await episodeRepository.deleteEpisode(episode.id)
+            // Drop any Live Activity tied to the now-deleted episode.
+            liveActivityManager.dismiss(episodeId: episode.id)
+            // If it was active, daily check-ins were suppressed — reinstate them
+            // now that no episode is in progress.
+            if episode.isActive {
+                try? await dailyCheckinService.scheduleNotifications()
+            }
+            details = nil
+        } catch {
+            ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "deleteEpisode"])
+            self.error = error.localizedDescription
+        }
+    }
+
     // MARK: - Intensity Readings
 
     @MainActor

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -7,6 +7,7 @@ struct EpisodeDetailScreen: View {
     /// a same-episode detail alive in another tab can't steal the action. See #416.
     var consumesDeepLinks: Bool = false
     @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
     @State private var viewModel = EpisodeDetailViewModel()
     @State private var showEndTimePicker = false
     @State private var showEditSheet = false
@@ -54,16 +55,42 @@ struct EpisodeDetailScreen: View {
                     }
                 } footer: {
                     // Actions span the full width below the columns
-                    if details.episode.isActive {
-                        EpisodeActionButtons(
-                            episode: details.episode,
-                            episodeId: episodeId,
-                            viewModel: viewModel,
-                            showLogUpdate: $showLogUpdate,
-                            showLogMedication: $showLogMedication,
-                            customEndTime: $customEndTime,
-                            showEndTimePicker: $showEndTimePicker
-                        )
+                    VStack(spacing: 12) {
+                        if details.episode.isActive {
+                            EpisodeActionButtons(
+                                episode: details.episode,
+                                episodeId: episodeId,
+                                viewModel: viewModel,
+                                showLogUpdate: $showLogUpdate,
+                                showLogMedication: $showLogMedication,
+                                customEndTime: $customEndTime,
+                                showEndTimePicker: $showEndTimePicker
+                            )
+                        }
+
+                        // Discard an episode entirely (e.g. started by accident).
+                        // Available whether it's still active or already ended.
+                        Button {
+                            pendingDeleteLabel = "Episode"
+                            pendingDeleteAction = {
+                                await viewModel.deleteEpisode()
+                                // Clearing the selection pops the iPhone detail
+                                // (path binding) and empties the iPad detail
+                                // column; dismiss() covers plain pushes from
+                                // Dashboard / Daily Status.
+                                appState.selectedEpisodeId = nil
+                                dismiss()
+                            }
+                            showDeleteConfirmation = true
+                        } label: {
+                            Label("Delete Episode", systemImage: "trash")
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.red.opacity(0.1))
+                                .foregroundStyle(.red)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+                        .accessibilityIdentifier("delete-episode-button")
                     }
                 }
                 .accessibilityIdentifier("episode-detail-scroll")

--- a/mobile-apps/ios/MigraLogTests/ViewModels/EpisodeDetailViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/EpisodeDetailViewModelTests.swift
@@ -94,6 +94,47 @@ final class EpisodeDetailViewModelTests: XCTestCase {
         XCTAssertFalse(mockRepo.updateEpisodeCalled)
     }
 
+    // MARK: - Delete Episode
+
+    func testDeleteEpisode_deletesAndClearsDetails() async throws {
+        await sut.loadEpisode()
+        XCTAssertNotNil(sut.details)
+
+        await sut.deleteEpisode()
+
+        XCTAssertTrue(mockRepo.deleteEpisodeCalled)
+        XCTAssertNil(sut.details, "Detail should clear so the screen can dismiss")
+        XCTAssertNil(sut.error)
+    }
+
+    func testDeleteEpisode_completedEpisode_deletes() async throws {
+        mockRepo.episodes = [TestFixtures.makeEpisode(id: "ep-1", endTime: TimestampHelper.now)]
+        await sut.loadEpisode()
+        XCTAssertFalse(sut.episode!.isActive)
+
+        await sut.deleteEpisode()
+
+        XCTAssertTrue(mockRepo.deleteEpisodeCalled)
+        XCTAssertNil(sut.details)
+    }
+
+    func testDeleteEpisode_notLoaded_noOp() async throws {
+        // details is nil — nothing loaded yet
+        await sut.deleteEpisode()
+
+        XCTAssertFalse(mockRepo.deleteEpisodeCalled)
+    }
+
+    func testDeleteEpisode_error_setsError() async throws {
+        await sut.loadEpisode()
+        mockRepo.errorToThrow = TestError.mockError("delete failed")
+
+        await sut.deleteEpisode()
+
+        XCTAssertNotNil(sut.error)
+        XCTAssertNotNil(sut.details, "Details should remain when the delete fails")
+    }
+
     // MARK: - Add Intensity Reading
 
     func testAddIntensityReading_addsToDetails() async throws {

--- a/mobile-apps/ios/MigraLogUITests/EpisodeLifecycleUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/EpisodeLifecycleUITests.swift
@@ -305,6 +305,48 @@ final class EpisodeLifecycleUITests: XCTestCase {
                       "Primary action should remain Log Update while the episode stays ongoing")
     }
 
+    // MARK: - 2.4 Delete an episode started by accident
+
+    func testDeleteOngoingEpisode() throws {
+        createActiveEpisode()
+
+        // Open the ongoing episode's detail.
+        let activeCard = app.buttons["active-episode-card"]
+        UITestHelpers.waitForHittable(activeCard)
+        activeCard.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // Find and tap "Delete Episode".
+        let deleteButton = app.buttons["delete-episode-button"]
+        let scroll = app.scrollViews.firstMatch
+        if !deleteButton.isHittable {
+            UITestHelpers.scrollToElement(deleteButton, in: scroll)
+        }
+        UITestHelpers.waitForHittable(deleteButton)
+        deleteButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // Confirm the destructive alert.
+        let confirm = app.alerts.buttons["Delete"]
+        XCTAssertTrue(confirm.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+                      "A confirmation alert should appear before deleting")
+        confirm.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // Back on the dashboard there is no longer an active episode — the
+        // primary action returns to "Start Episode".
+        let startButton = app.buttons["start-episode-button"]
+        XCTAssertTrue(startButton.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+                      "Start Episode should return once the episode is deleted")
+        XCTAssertFalse(app.buttons["active-episode-card"].exists,
+                       "The deleted episode should no longer show on the dashboard")
+
+        // The Episodes list is empty too.
+        UITestHelpers.navigateTo(tab: .episodes, in: app)
+        XCTAssertFalse(app.buttons["episode-card-0"].waitForExistence(timeout: 2),
+                       "The deleted episode should not appear in history")
+    }
+
     // MARK: - Helpers
 
     private func createActiveEpisode() {


### PR DESCRIPTION
## Summary
Adds the ability to **delete an episode** (ongoing or completed) from the Episode Detail screen — for discarding an episode started by accident.

- New **"Delete Episode"** destructive button in the detail footer, gated behind the existing confirmation alert ("Delete Episode? · This cannot be undone").
- `EpisodeDetailViewModel.deleteEpisode()`: deletes via the repository (cascades intensity/symptom/pain logs + notes; doses keep their history with `episode_id` nulled), dismisses any Live Activity for the episode, and reinstates daily check-in notifications if the deleted episode was active.
- Navigation away after delete works on both form factors: clearing `selectedEpisodeId` pops the iPhone detail (path binding) and empties the iPad detail column; `dismiss()` covers plain pushes from Dashboard / Daily Status.

The repository delete and the list view-model's cleanup already existed but were never reachable from the UI; this wires deletion to a real surface.

## Testing
- `EpisodeDetailViewModelTests`: new tests for delete (active, completed, not-loaded no-op, error path). Full class green (26 tests).
- `EpisodeLifecycleUITests.testDeleteOngoingEpisode`: create → open detail → delete → confirm → verify gone from dashboard and history. Passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)