### PR TITLE
feat(ci): roll up "What to Test" across builds at Pre-flight promotion

### DIFF
--- a/.github/scripts/changelog.mjs
+++ b/.github/scripts/changelog.mjs
@@ -1,0 +1,97 @@
+// Shared changelog generation for TestFlight "What to Test" notes.
+//
+// Builds notes deterministically from conventional-commit subjects — no LLM, no
+// extra secret. `feat:` commits become a "New" list, `fix:` commits a "Fixed"
+// list; trailing PR refs like "(#486)" are stripped for tester-facing prose.
+//
+// Two classes of commit are dropped as non-tester-facing: those whose scope is
+// in EXCLUDE_SCOPES (default "ci"), and those whose subject matches
+// EXCLUDE_PATTERN (default: test-infrastructure churn).
+//
+// Used by:
+//   set-beta-notes.mjs      — upload-time notes for a single build (range: prev release..HEAD)
+//   promote-preflight.mjs   — rollup notes at promotion (range: last Pre-flight..promoted build)
+//
+// Env (read once at import):
+//   EXCLUDE_SCOPES    — optional; comma-separated scopes to drop (default "ci")
+//   EXCLUDE_PATTERN   — optional; JS regex (case-insensitive) dropping matching subjects
+
+import { execSync } from 'node:child_process';
+
+export const CHAR_LIMIT = 4000; // App Store Connect whatsNew max length
+
+// Subjects that are real commits but not tester-facing: test scaffolding,
+// flaky-test stabilization, snapshot/UI/unit test repair, CI plumbing wording.
+const DEFAULT_EXCLUDE_PATTERN =
+  '\\b(ui|unit|snapshot)\\s+tests?\\b|\\bnightly\\b|\\bflaky\\b|waitfor\\w+|\\btest\\s+(suite|harness|plan)\\b';
+
+const excludeScopes = new Set(
+  (process.env.EXCLUDE_SCOPES ?? 'ci')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean),
+);
+const excludePattern = new RegExp(process.env.EXCLUDE_PATTERN || DEFAULT_EXCLUDE_PATTERN, 'i');
+
+function capitalize(s) {
+  // Leave camelCase / brand tokens like iCloud, iPad, iOS untouched.
+  if (/^[a-z][A-Z]/.test(s)) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// Resolve a marketing version to an existing tag ref. The pipeline tags new
+// releases deploy/<version>; the pre-existing scheme used alpha-v<version>. Try
+// both. Returns the ref string, or null if neither tag exists.
+export function resolveVersionRef(version) {
+  if (!version) return null;
+  for (const ref of [`deploy/${version}`, `alpha-v${version}`]) {
+    try {
+      execSync(`git rev-parse --verify --quiet "${ref}^{commit}"`, { stdio: 'pipe' });
+      return ref;
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}
+
+// Generate "What to Test" notes from feat/fix commits in (lowerRef, upperRef].
+// lowerRef null → from the start of history. Returns the notes string, or null
+// when the range contains no tester-facing feat/fix commits.
+export function generateNotes(lowerRef, upperRef = 'HEAD') {
+  const range = lowerRef ? `${lowerRef}..${upperRef}` : upperRef;
+  const raw = execSync(`git log --no-merges --format=%s ${range}`, { encoding: 'utf8' });
+  const subjects = raw.split('\n').map((s) => s.trim()).filter(Boolean);
+
+  const features = [];
+  const fixes = [];
+  for (const s of subjects) {
+    const m = s.match(/^(feat|fix)(?:\(([^)]*)\))?!?:\s*(.+)$/i);
+    if (!m) continue;
+    const type = m[1].toLowerCase();
+    const scope = (m[2] || '').toLowerCase();
+    // Strip trailing PR refs like " (#486)" or " (#486) (#500)".
+    const text = m[3].replace(/\s*\(#\d+\)/g, '').trim();
+    if (!text) continue;
+    // Drop non-tester-facing noise: excluded scopes (e.g. ci) and test churn.
+    if (excludeScopes.has(scope)) continue;
+    if (excludePattern.test(text)) continue;
+    (type === 'feat' ? features : fixes).push(capitalize(text));
+  }
+
+  if (features.length === 0 && fixes.length === 0) return null;
+
+  const lines = [];
+  if (features.length) {
+    lines.push('New:');
+    for (const f of features) lines.push(`• ${f}`);
+  }
+  if (fixes.length) {
+    if (lines.length) lines.push('');
+    lines.push('Fixed:');
+    for (const f of fixes) lines.push(`• ${f}`);
+  }
+  let notes = lines.join('\n');
+  if (notes.length > CHAR_LIMIT) notes = `${notes.slice(0, CHAR_LIMIT - 1)}…`;
+  return notes;
+}

--- a/.github/scripts/promote-preflight.mjs
+++ b/.github/scripts/promote-preflight.mjs
@@ -32,7 +32,34 @@ import {
   listBuildsInGroup,
   attachBuildToGroup,
   submitForBetaReview,
+  setBetaBuildNotes,
 } from './asc-client.mjs';
+import { resolveVersionRef, generateNotes } from './changelog.mjs';
+
+// Roll up "What to Test" across every build accumulated since the last build in
+// Pre-flight. The promoted build's upload-time notes only cover its own one-build
+// delta; testers promoting weekly want the whole span. Range is bounded by deploy
+// tags (deploy/<version>) so it works from the promotion job's checkout, which is
+// not necessarily at the promoted build's commit. Returns notes, or null when the
+// span can't be resolved or has no tester-facing commits (caller keeps existing).
+function rollupNotes(prevPreflightVersion, promotedVersion) {
+  if (!prevPreflightVersion) {
+    console.log('No prior Pre-flight build; keeping the build\'s upload-time notes.');
+    return null;
+  }
+  const lowerRef = resolveVersionRef(prevPreflightVersion);
+  const upperRef = resolveVersionRef(promotedVersion);
+  if (!lowerRef) {
+    console.log(`No deploy tag for previous Pre-flight version ${prevPreflightVersion}; keeping upload-time notes.`);
+    return null;
+  }
+  if (!upperRef) {
+    console.log(`No deploy tag for promoted version ${promotedVersion}; keeping upload-time notes.`);
+    return null;
+  }
+  console.log(`Rollup "What to Test" range: ${lowerRef}..${upperRef}`);
+  return generateNotes(lowerRef, upperRef);
+}
 
 let _sentryProjectId;
 async function sentryProjectId(org, projectSlug, token) {
@@ -121,10 +148,11 @@ async function main() {
   const sourceBuilds = await listBuildsInGroup(appId, sourceName);
   const targetBuilds = await listBuildsInGroup(appId, targetName);
   const targetBuildIds = new Set(targetBuilds.map((b) => b.id));
-  const maxTargetBuildNumber = targetBuilds.reduce(
-    (max, b) => Math.max(max, Number(b.buildNumber) || 0),
-    0,
+  const latestTarget = targetBuilds.reduce(
+    (best, b) => (!best || (Number(b.buildNumber) || 0) > (Number(best.buildNumber) || 0) ? b : best),
+    null,
   );
+  const maxTargetBuildNumber = latestTarget ? Number(latestTarget.buildNumber) || 0 : 0;
 
   sourceBuilds.sort((a, b) => new Date(b.uploadedAt) - new Date(a.uploadedAt));
 
@@ -170,12 +198,28 @@ async function main() {
     return;
   }
 
+  const notes = rollupNotes(latestTarget?.version, eligible.build.version);
+
   if (dryRun) {
     console.log(`DRY RUN: would promote build ${eligible.build.buildNumber} to ${targetName}`);
+    if (notes) console.log(`DRY RUN: would set rollup "What to Test":\n${notes}`);
+    else console.log('DRY RUN: no rollup notes; build would keep its upload-time "What to Test".');
     return;
   }
 
   await attachBuildToGroup(eligible.build.id, targetGroupId);
+  // Cosmetic and best-effort: a notes failure must not strand a promoted build
+  // un-submitted, so swallow it and proceed to Beta App Review.
+  if (notes) {
+    try {
+      await setBetaBuildNotes(eligible.build.id, notes);
+      console.log(`Set rollup "What to Test" on build ${eligible.build.buildNumber}.`);
+    } catch (err) {
+      console.warn(`::warning::Failed to set rollup "What to Test": ${err.message}`);
+    }
+  } else {
+    console.log('No rollup notes; keeping the build\'s upload-time "What to Test".');
+  }
   await submitForBetaReview(eligible.build.id);
   console.log(`Promoted build ${eligible.build.buildNumber} to ${targetName} and submitted for Beta App Review`);
 }

--- a/.github/scripts/set-beta-notes.mjs
+++ b/.github/scripts/set-beta-notes.mjs
@@ -1,14 +1,9 @@
 // Generates TestFlight "What to Test" notes from the commits since the previous
 // release and writes them to the just-uploaded build's betaBuildLocalizations.
 //
-// Notes are built deterministically from conventional-commit subjects — no LLM,
-// no extra secret. `feat:` commits become a "New" list, `fix:` commits a "Fixed"
-// list; trailing PR refs like "(#486)" are stripped for tester-facing prose.
-//
-// To keep the notes focused on changes a tester would care about, two classes of
-// commit are dropped: those whose scope is in EXCLUDE_SCOPES (default "ci"), and
-// those whose subject matches EXCLUDE_PATTERN (default: test-infrastructure
-// churn — UI/unit test fixes, nightly/flaky stabilization, etc.).
+// Note formatting (conventional-commit parsing, scope/pattern filtering, char
+// limit) lives in changelog.mjs and is shared with the Pre-flight promotion
+// rollup so both surfaces read identically.
 //
 // Non-fatal by design: "What to Test" is cosmetic, so any failure (ASC hiccup,
 // build slow to process) logs a warning and exits 0 — it never blocks a deploy.
@@ -20,91 +15,15 @@
 //   PREVIOUS_VERSION  — marketing version of the previous release; lower bound for
 //                       the changelog range. Empty on the very first release.
 //   MAX_WAIT_SECONDS  — optional; how long to poll for the build to appear (default 1200)
-//   EXCLUDE_SCOPES    — optional; comma-separated scopes to drop (default "ci")
-//   EXCLUDE_PATTERN   — optional; JS regex (case-insensitive); subjects matching it
-//                       are dropped. Defaults to a test-infrastructure filter.
+//   EXCLUDE_SCOPES    — optional; see changelog.mjs
+//   EXCLUDE_PATTERN   — optional; see changelog.mjs
 //   ASC_*             — via asc-client
 
-import { execSync } from 'node:child_process';
 import { required, getAppId, getBuild, setBetaBuildNotes } from './asc-client.mjs';
-
-const CHAR_LIMIT = 4000; // App Store Connect whatsNew max length
-
-// Subjects that are real commits but not tester-facing: test scaffolding,
-// flaky-test stabilization, snapshot/UI/unit test repair, CI plumbing wording.
-const DEFAULT_EXCLUDE_PATTERN =
-  '\\b(ui|unit|snapshot)\\s+tests?\\b|\\bnightly\\b|\\bflaky\\b|waitfor\\w+|\\btest\\s+(suite|harness|plan)\\b';
-
-const excludeScopes = new Set(
-  (process.env.EXCLUDE_SCOPES ?? 'ci')
-    .split(',')
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean),
-);
-const excludePattern = new RegExp(process.env.EXCLUDE_PATTERN || DEFAULT_EXCLUDE_PATTERN, 'i');
-
-function capitalize(s) {
-  // Leave camelCase / brand tokens like iCloud, iPad, iOS untouched.
-  if (/^[a-z][A-Z]/.test(s)) return s;
-  return s.charAt(0).toUpperCase() + s.slice(1);
-}
+import { resolveVersionRef, generateNotes } from './changelog.mjs';
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
-}
-
-// Resolve the previous release's marketing version to an existing tag ref. The
-// pipeline tags new releases deploy/<version>; the pre-existing scheme used
-// alpha-v<version>. Try both.
-function resolveLowerBound(prev) {
-  if (!prev) return null;
-  for (const ref of [`deploy/${prev}`, `alpha-v${prev}`]) {
-    try {
-      execSync(`git rev-parse --verify --quiet "${ref}^{commit}"`, { stdio: 'pipe' });
-      return ref;
-    } catch {
-      // try next candidate
-    }
-  }
-  return null;
-}
-
-function generateNotes(lowerRef) {
-  const range = lowerRef ? `${lowerRef}..HEAD` : 'HEAD';
-  const raw = execSync(`git log --no-merges --format=%s ${range}`, { encoding: 'utf8' });
-  const subjects = raw.split('\n').map((s) => s.trim()).filter(Boolean);
-
-  const features = [];
-  const fixes = [];
-  for (const s of subjects) {
-    const m = s.match(/^(feat|fix)(?:\(([^)]*)\))?!?:\s*(.+)$/i);
-    if (!m) continue;
-    const type = m[1].toLowerCase();
-    const scope = (m[2] || '').toLowerCase();
-    // Strip trailing PR refs like " (#486)" or " (#486) (#500)".
-    const text = m[3].replace(/\s*\(#\d+\)/g, '').trim();
-    if (!text) continue;
-    // Drop non-tester-facing noise: excluded scopes (e.g. ci) and test churn.
-    if (excludeScopes.has(scope)) continue;
-    if (excludePattern.test(text)) continue;
-    (type === 'feat' ? features : fixes).push(capitalize(text));
-  }
-
-  if (features.length === 0 && fixes.length === 0) return null;
-
-  const lines = [];
-  if (features.length) {
-    lines.push('New:');
-    for (const f of features) lines.push(`• ${f}`);
-  }
-  if (fixes.length) {
-    if (lines.length) lines.push('');
-    lines.push('Fixed:');
-    for (const f of fixes) lines.push(`• ${f}`);
-  }
-  let notes = lines.join('\n');
-  if (notes.length > CHAR_LIMIT) notes = `${notes.slice(0, CHAR_LIMIT - 1)}…`;
-  return notes;
 }
 
 async function pollForBuild(appId, version, buildNumber, maxWaitSeconds) {
@@ -127,7 +46,7 @@ async function main() {
   const previous = process.env.PREVIOUS_VERSION || '';
   const maxWait = Number(process.env.MAX_WAIT_SECONDS || '1200');
 
-  const lowerRef = resolveLowerBound(previous);
+  const lowerRef = resolveVersionRef(previous);
   console.log(`Changelog range: ${lowerRef ? `${lowerRef}..HEAD` : 'entire history (no previous release tag found)'}`);
 
   const notes = generateNotes(lowerRef);

--- a/.github/workflows/promote-preflight.yml
+++ b/.github/workflows/promote-preflight.yml
@@ -24,7 +24,12 @@ jobs:
     name: Evaluate Beta builds and promote latest eligible to Pre-flight
     runs-on: ubuntu-latest
     steps:
+      # Full history + tags: the rollup "What to Test" walks git log between the
+      # deploy/<version> tags of the last Pre-flight build and the promoted build.
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Problem

The weekly Beta→Pre-flight promotion (`promote-preflight.yml`) attaches only the **newest eligible** Beta build to the Pre-flight group. Each Beta build's "What to Test" is generated at upload time (`set-beta-notes.mjs`) covering only that build's **one-build delta** (commits since the previous release tag).

Since several Beta builds accumulate between weekly promotions and only the latest is promoted, Pre-flight testers never saw the changes from the builds that were skipped in between — the notes covered a single patch, not the whole span since the last Pre-flight version.

## Change

At promotion time, regenerate the promoted build's "What to Test" as a **rollup** spanning `deploy/<last-preflight-version>..deploy/<promoted-version>`.

- Extracted the note-formatting logic (conventional-commit parsing, `feat`→New / `fix`→Fixed, scope + pattern filtering, PR-ref stripping, 4000-char cap) into a shared `changelog.mjs`, used by both `set-beta-notes.mjs` (upload-time, single build) and `promote-preflight.mjs` (promotion-time, rollup). Upload-time and promotion-time notes now read identically.
- `generateNotes(lowerRef, upperRef = 'HEAD')` is bounded by **deploy tags** rather than `HEAD`, because the promotion job's checkout isn't at the promoted build's commit.
- **Best-effort:** a notes failure is caught and logged so it can never strand a promoted build un-submitted for Beta App Review.
- Edge cases (no prior Pre-flight build, missing deploy tag) keep the build's existing upload-time notes.
- `dry_run` now prints the rollup it would set.
- Promote checkout uses `fetch-depth: 0` + `fetch-tags` so `git log` between deploy tags resolves.

## Verification

- `node --check` on all three scripts.
- Functional test of the shared generator over a real range (`deploy/1.1.208..deploy/1.1.213`) produces a clean 5-build New/Fixed rollup with PR refs stripped.
- Confirmed the HEAD-default path (single-build `set-beta-notes`) is unchanged, and missing/empty versions resolve to `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)