### PR TITLE
fix(ios): start episode Live Activity only once foreground (#416)

### DIFF
--- a/mobile-apps/ios/MigraLog/App/ContentView.swift
+++ b/mobile-apps/ios/MigraLog/App/ContentView.swift
@@ -6,6 +6,10 @@ struct ContentView: View {
     @Environment(SyncService.self) private var syncService
     @Environment(\.scenePhase) private var scenePhase
 
+    /// Ensures the launch-time Live Activity reconcile runs exactly once per app
+    /// launch, on the first foreground (see the `.active` handler below).
+    @State private var didReconcileLiveActivities = false
+
     var body: some View {
         @Bindable var appState = appState
         Group {
@@ -64,6 +68,18 @@ struct ContentView: View {
             switch phase {
             case .active:
                 Task { await syncService.syncIfEnabled() }
+                // Re-attach or clean up the active-episode Live Activity after
+                // launch (recover from a force-quit, or dismiss a stale one).
+                // This must run on the `.active` scene phase, not a launch-time
+                // `.task`: ActivityKit rejects `Activity.request()` with an
+                // `ActivityAuthorization: visibility (Code 7)` error when the app
+                // isn't yet foreground, which the launch `.task` could not
+                // guarantee. Gated to the first foreground per launch so it
+                // doesn't dismiss the warm post-episode close on every return.
+                if !didReconcileLiveActivities {
+                    didReconcileLiveActivities = true
+                    LiveActivityManager.shared.reconcileOnLaunch()
+                }
             case .background:
                 // Queue a background refresh so changes keep syncing while backgrounded (#462).
                 BackgroundSyncScheduler.schedule()

--- a/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
+++ b/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
@@ -74,9 +74,11 @@ struct MigraLogApp: App {
                     await medicationNotificationService.topUp()
                     try? await dailyCheckinService.scheduleNotifications()
                     await timezoneChangeService.checkForChange()
-                    // Re-attach or clean up the active-episode Live Activity after
-                    // launch (e.g. recover from a force-quit, or dismiss a stale one).
-                    LiveActivityManager.shared.reconcileOnLaunch()
+                    // Note: the active-episode Live Activity is reconciled from
+                    // ContentView's `.active` scene-phase handler, not here — a
+                    // launch-time `.task` runs before the scene is foreground and
+                    // ActivityKit rejects `Activity.request()` with a `visibility`
+                    // error if the app isn't yet active.
                 }
         }
     }


### PR DESCRIPTION
## Problem

Sentry issue [`ActivityAuthorization: visibility (Code: 7)`](https://eff3.sentry.io/issues/7560100209/) — 8 events on build 1.1.205, appearing right after the Live Activity work (#513–#516) shipped.

`LiveActivityManager.reconcileOnLaunch()` was invoked from the `WindowGroup` `.task` in `MigraLogApp`. The `.task` modifier fires at view appearance, which on cold launch happens **before** the scene transitions to `.active`. ActivityKit refuses to *start* a Live Activity (`Activity.request()`) while the app isn't foreground and throws `ActivityAuthorizationError.visibility` (Code 7).

The existing `isEnabled` guard (`ActivityAuthorizationInfo().areActivitiesEnabled`) does **not** prevent this — that flag reflects the user's Live Activities *permission setting*, not the app's foreground/visibility state.

## Fix

Move the launch reconcile out of the launch `.task` and into `ContentView`'s existing `.onChange(of: scenePhase)` `.active` handler (the same path that already drives `syncIfEnabled()`), so `Activity.request()` only runs while the app is genuinely foreground.

Gated with a `@State` flag to fire **once per launch**: running it on every foreground would immediately dismiss the 30-minute warm post-episode close if the user returns to the app during that window.

## Testing

- `xcodebuild build` — succeeds
- `LiveActivityContentStateTests` — 4/4 pass
- The timing change is at the view layer (scene-phase driven), consistent with the existing first-foreground sync trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)