### PR TITLE
feat(ios): guide users to add meds from the Log Medication empty state

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
@@ -4,41 +4,35 @@ struct LogMedicationScreen: View {
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel = LogMedicationViewModel()
     @State private var detailMedication: Medication?
+    @State private var showAddMedication = false
+    @State private var showOtherMedications = false
 
     /// Filter to only rescue medications (used from Dashboard).
     /// When false, shows all active medications.
     var rescueOnly: Bool = true
 
+    /// Medications shown prominently as log cards. In rescue-only mode these are
+    /// the rescue meds; otherwise it's every active medication.
+    private var prominentMedications: [Medication] {
+        rescueOnly
+            ? viewModel.medications.filter { $0.type == .rescue }
+            : viewModel.medications
+    }
+
+    /// Non-rescue meds, tucked into a collapsed disclosure below the rescue
+    /// cards so they can still be logged from this flow. Empty when not in
+    /// rescue-only mode (everything is already shown prominently).
+    private var otherMedications: [Medication] {
+        rescueOnly ? viewModel.medications.filter { $0.type != .rescue } : []
+    }
+
     var body: some View {
-        ScrollView {
-            LazyVStack(spacing: DesignTokens.Spacing.md) {
-                let allMeds = rescueOnly
-                    ? viewModel.medications.filter { $0.type == .rescue }
-                    : viewModel.medications
-                if allMeds.isEmpty {
-                    Text(rescueOnly ? "No rescue medications configured" : "No medications configured")
-                        .foregroundStyle(.secondary)
-                        .padding(.top, 40)
-                } else {
-                    ForEach(allMeds) { med in
-                        LogMedicationCard(
-                            medication: med,
-                            lastDose: viewModel.lastDoseByMedication[med.id],
-                            categoryStatus: med.category.flatMap { viewModel.categoryUsage[$0] } ?? .noLimit,
-                            categoryCooldown: viewModel.categoryCooldowns[med.id],
-                            onQuickLog: {
-                                Task {
-                                    await quickLog(med)
-                                }
-                            },
-                            onDetails: {
-                                detailMedication = med
-                            }
-                        )
-                    }
-                }
+        Group {
+            if viewModel.medications.isEmpty {
+                emptyState
+            } else {
+                medicationList
             }
-            .padding()
         }
         .navigationTitle("Log Medication")
         .accessibilityIdentifier("log-medication-title")
@@ -46,6 +40,15 @@ struct LogMedicationScreen: View {
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button("Cancel") { dismiss() }
+            }
+        }
+        .sheet(isPresented: $showAddMedication, onDismiss: {
+            // Reload so a newly added medication appears here, ready to log
+            // without leaving the flow.
+            Task { await viewModel.loadMedications() }
+        }) {
+            NavigationStack {
+                AddMedicationScreen()
             }
         }
         .sheet(item: $detailMedication) { med in
@@ -65,6 +68,83 @@ struct LogMedicationScreen: View {
         }
         .task {
             await viewModel.loadMedications()
+        }
+    }
+
+    // MARK: - Medication list
+
+    private var medicationList: some View {
+        ScrollView {
+            LazyVStack(spacing: DesignTokens.Spacing.md) {
+                if prominentMedications.isEmpty {
+                    // Rescue-only flow where the user has meds, just no rescue
+                    // ones — explain the empty top instead of leaving it blank.
+                    Text("No rescue medications configured")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, DesignTokens.Spacing.sm)
+                } else {
+                    ForEach(prominentMedications) { med in
+                        medicationCard(med)
+                    }
+                }
+
+                if !otherMedications.isEmpty {
+                    DisclosureGroup(isExpanded: $showOtherMedications) {
+                        LazyVStack(spacing: DesignTokens.Spacing.md) {
+                            ForEach(otherMedications) { med in
+                                medicationCard(med)
+                            }
+                        }
+                        .padding(.top, DesignTokens.Spacing.sm)
+                    } label: {
+                        Text("Other Medications")
+                            .font(.headline)
+                    }
+                    .accessibilityIdentifier("log-medication-other-disclosure")
+                }
+            }
+            .padding()
+        }
+    }
+
+    private func medicationCard(_ med: Medication) -> some View {
+        LogMedicationCard(
+            medication: med,
+            lastDose: viewModel.lastDoseByMedication[med.id],
+            categoryStatus: med.category.flatMap { viewModel.categoryUsage[$0] } ?? .noLimit,
+            categoryCooldown: viewModel.categoryCooldowns[med.id],
+            onQuickLog: {
+                Task {
+                    await quickLog(med)
+                }
+            },
+            onDetails: {
+                detailMedication = med
+            }
+        )
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label(rescueOnly ? "No Rescue Medications" : "No Medications", systemImage: "pills")
+        } description: {
+            Text(rescueOnly
+                ? "Add a rescue medication to log a dose. You can manage all your medications in the Medications tab."
+                : "Add a medication to log a dose. You can manage all your medications in the Medications tab.")
+        } actions: {
+            Button {
+                showAddMedication = true
+            } label: {
+                Text("Add Medication")
+                    .fontWeight(.semibold)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .accessibilityIdentifier("log-medication-empty-add")
         }
     }
 


### PR DESCRIPTION
## What

Improves the **Log Medication** flow when the user has no rescue medications set up.

**Before:** the screen dead-ended on gray text — "No rescue medications configured" — with no way forward.

**Now:**
- An empty state (`ContentUnavailableView`) with a prominent **Add Medication** button that presents the add-medication form **inline** as a sheet. On dismiss the medication list reloads, so a newly added med is immediately loggable without leaving the flow or hunting through Settings.
- Non-rescue meds are no longer hidden here: rescue meds stay prominent (ordered most-frequently-used, unchanged), and preventative/other active meds live under a **collapsed "Other Medications"** disclosure (collapsed by default).
- If the user has meds but none are rescue, the prominent area shows a short "No rescue medications configured" note instead of a full empty state, with the others still expandable below.

## Why

User feedback: logging a medication before any are configured left people stuck with no guidance on where to add one. This keeps them in context and makes the rescue-first design legible while still allowing other meds to be logged.

## Screenshots

| Empty state (no meds) | Populated (rescue + Other Medications) |
| --- | --- |
| "No Rescue Medications" + large Add Medication CTA | Ibuprofen prominent; Amitriptyline under collapsible "Other Medications" |

## Testing

- `xcodebuild test -scheme MigraLog` on iPhone 17 Pro (iOS 26.5) — **TEST SUCCEEDED** (one prior run hit the known "test runner hung before establishing connection" simulator flake; passed clean on retry).
- Manually exercised on the simulator: empty-state CTA opens the add form and the new med appears ready to log; rescue meds prominent; "Other Medications" expands to log preventatives.

## Follow-up

Filed #552 for an in-app Help/Documentation section (Settings → Help) that will, among other things, explain this rescue-first logging design. The "Other Medications" collapsible and empty-state CTA added here are referenced there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
