### PR TITLE
fix(ios): bump cooldown placeholder hint to e.g. 8

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/Settings/CategorySafetyRuleEditorSheet.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/CategorySafetyRuleEditorSheet.swift
@@ -139,7 +139,7 @@ struct CategorySafetyRuleEditorSheet: View {
         Section {
             LabeledContent("Minimum time between doses") {
                 HStack(spacing: DesignTokens.Spacing.xs) {
-                    TextField("", text: $cooldownHoursText, prompt: Text("e.g. 4"))
+                    TextField("", text: $cooldownHoursText, prompt: Text("e.g. 8"))
                         .keyboardType(.decimalPad)
                         .multilineTextAlignment(.trailing)
                         .accessibilityIdentifier("rule-editor-cooldown-hours")


### PR DESCRIPTION
Changes the cooldown "Minimum time between doses" textbox placeholder from "e.g. 4" to "e.g. 8" in the category safety rule editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)