### PR TITLE
ci: Pushover preview of next Beta→Pre-flight promotion

### DIFF
--- a/.github/scripts/promote-preflight.mjs
+++ b/.github/scripts/promote-preflight.mjs
@@ -25,6 +25,7 @@
 //   DRY_RUN ('true' evaluates without promoting)
 //   ASC_* (via asc-client)
 
+import { writeFileSync } from 'node:fs';
 import {
   required,
   getAppId,
@@ -129,6 +130,19 @@ function parseBlocked(csv) {
   return new Set((csv || '').split(',').map((s) => s.trim()).filter(Boolean));
 }
 
+// Additive: when SUMMARY_FILE is set, write a machine-readable JSON summary of the
+// evaluation so callers (e.g. the preview-notification workflow) can build a clean
+// message without scraping logs. No-op when unset, so the real promotion is unchanged.
+function writeSummary(obj) {
+  const path = process.env.SUMMARY_FILE;
+  if (!path) return;
+  try {
+    writeFileSync(path, JSON.stringify(obj, null, 2));
+  } catch (err) {
+    console.warn(`::warning::Failed to write SUMMARY_FILE: ${err.message}`);
+  }
+}
+
 async function main() {
   const bundleId = required('APP_BUNDLE_ID');
   const sourceName = required('SOURCE_GROUP_NAME');
@@ -187,6 +201,13 @@ async function main() {
   }
 
   console.log('## Evaluation');
+  const evaluation = results.map((r) => ({
+    build: r.build.buildNumber,
+    version: r.build.version,
+    ageHours: Number(r.ageHours.toFixed(1)),
+    eligible: r.reasons.length === 0,
+    reasons: r.reasons,
+  }));
   for (const r of results) {
     const tag = r.reasons.length === 0 ? 'ELIGIBLE' : 'skip';
     console.log(`- [${tag}] build ${r.build.buildNumber} (${r.build.version}), age ${r.ageHours.toFixed(1)}h${r.reasons.length ? ' — ' + r.reasons.join('; ') : ''}`);
@@ -195,10 +216,28 @@ async function main() {
   const eligible = results.find((r) => r.reasons.length === 0);
   if (!eligible) {
     console.log('No eligible build to promote.');
+    writeSummary({
+      eligible: false,
+      soakHours,
+      targetGroup: targetName,
+      currentTargetBuild: maxTargetBuildNumber || null,
+      evaluation,
+    });
     return;
   }
 
   const notes = rollupNotes(latestTarget?.version, eligible.build.version);
+
+  writeSummary({
+    eligible: true,
+    soakHours,
+    targetGroup: targetName,
+    currentTargetBuild: maxTargetBuildNumber || null,
+    build: eligible.build.buildNumber,
+    version: eligible.build.version,
+    notes: notes || null,
+    evaluation,
+  });
 
   if (dryRun) {
     console.log(`DRY RUN: would promote build ${eligible.build.buildNumber} to ${targetName}`);

--- a/.github/scripts/pushover-preflight-preview.mjs
+++ b/.github/scripts/pushover-preflight-preview.mjs
@@ -1,0 +1,99 @@
+// Sends a Pushover notification previewing the next Beta → Pre-flight promotion.
+//
+// Reads the JSON written by promote-preflight.mjs (via SUMMARY_FILE) and posts a
+// concise message: which build is likely to promote, the rolled-up "What to Test"
+// changes, and any build whose only blocker is soak that will clear it before the
+// real promotion (LEAD_HOURS later). Best-effort — a Pushover failure exits non-zero
+// so the workflow surfaces it, but nothing here touches the promotion itself.
+//
+// Env:
+//   SUMMARY_FILE   — path to the evaluation JSON (required)
+//   PUSHOVER_TOKEN — Pushover application/API token (required)
+//   PUSHOVER_USER  — Pushover user/group key (required)
+//   LEAD_HOURS     — hours between this preview and the actual promote (default 9)
+//   PROMOTE_WHEN   — human label for the promote time (default 'Tue 12:00 UTC')
+
+import { readFileSync } from 'node:fs';
+
+const MESSAGE_LIMIT = 1024; // Pushover message hard cap
+
+function required(name) {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing required env: ${name}`);
+  return v;
+}
+
+function clamp(s) {
+  return s.length > MESSAGE_LIMIT ? `${s.slice(0, MESSAGE_LIMIT - 1)}…` : s;
+}
+
+function buildMessage(summary, leadHours, promoteWhen) {
+  const lines = [];
+  const target = summary.targetGroup || 'Pre-flight';
+  const current = summary.currentTargetBuild ? ` (current ${target}: ${summary.currentTargetBuild})` : '';
+
+  if (summary.eligible) {
+    lines.push(`<b>Build ${summary.build} (v${summary.version})</b> likely promotes to ${target} ${promoteWhen}${current}.`);
+    lines.push('');
+    if (summary.notes) {
+      lines.push('<b>What to Test</b>');
+      lines.push(summary.notes);
+    } else {
+      lines.push('No rolled-up "What to Test"; build keeps its upload-time notes.');
+    }
+  } else {
+    lines.push(`<b>No build currently eligible</b> for ${target}${current}. Nothing would promote ${promoteWhen}.`);
+  }
+
+  // Heads-up: builds blocked ONLY by soak that will pass the soak gate by promote
+  // time. Their reason reads "soak X.Xh < Yh"; project age forward by leadHours.
+  const soak = Number(summary.soakHours) || 0;
+  const nearMiss = (summary.evaluation || [])
+    .filter((e) => !e.eligible
+      && e.reasons.length === 1
+      && /^soak /.test(e.reasons[0])
+      && e.ageHours + leadHours >= soak)
+    .map((e) => `• build ${e.build} (v${e.version}): ${e.ageHours.toFixed(1)}h now → ~${(e.ageHours + leadHours).toFixed(1)}h at promote (soak ${soak}h)`);
+
+  if (nearMiss.length) {
+    lines.push('');
+    lines.push('<b>May also qualify by promote time</b> (soak clears):');
+    lines.push(...nearMiss);
+  }
+
+  return clamp(lines.join('\n'));
+}
+
+async function main() {
+  const summary = JSON.parse(readFileSync(required('SUMMARY_FILE'), 'utf8'));
+  const token = required('PUSHOVER_TOKEN');
+  const user = required('PUSHOVER_USER');
+  const leadHours = Number(process.env.LEAD_HOURS || '9');
+  const promoteWhen = process.env.PROMOTE_WHEN || 'Tue 12:00 UTC';
+
+  const title = summary.eligible
+    ? `Pre-flight preview: build ${summary.build} → promote ${promoteWhen}`
+    : `Pre-flight preview: none eligible for ${promoteWhen}`;
+
+  const params = new URLSearchParams({
+    token,
+    user,
+    title,
+    message: buildMessage(summary, leadHours, promoteWhen),
+    html: '1',
+  });
+
+  const res = await fetch('https://api.pushover.net/1/messages.json', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params,
+  });
+  const body = await res.text();
+  if (!res.ok) throw new Error(`Pushover → ${res.status}: ${body}`);
+  console.log(`Pushover notification sent: ${title}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,6 +10,7 @@ CI/CD for the MigraLog iOS Swift app (`mobile-apps/ios`).
 | `swift-nightly.yml` — `[iOS] Nightly UI suite` | Daily 09:17 UTC + manual | Runs the **Full** test plan (entire suite minus screenshot capture). On failure opens/appends a `nightly-failure` tracking issue. Does **not** gate PRs. |
 | `release-pipeline.yml` — `[iOS] Release Pipeline` | Push → `main` (iOS paths) + manual | Unit tests, then archive + upload to the **Beta** (internal) TestFlight group. Build number patch-bumps from the latest `deploy/*` (or legacy `alpha-v*`) git tag; tags `deploy/<version>` on success. |
 | `promote-preflight.yml` — `[iOS] Promote Beta → Pre-flight` | Weekly (Tue 12:00 UTC) + manual | Promotes the latest eligible Beta build to the **Pre-flight** external group behind a Sentry crash-free soak gate (72 h, ≥ 99 % crash-free, 0 unresolved issues). Respects `block-promotion/build-*` tags. |
+| `promote-preflight-preview.yml` — `[iOS] Pre-flight promote preview (notify)` | Weekly (Tue 03:00 UTC ≈ Mon 8 PM PT) + manual | Runs the **same** eligibility gate in dry-run ~9 h before the promotion and sends a **Pushover** preview of the build likely to promote, its rolled-up "What to Test", and any build whose soak will clear by promote time — leaving a window to push a `block-promotion/build-<N>` tag. Keep its gate inputs (`SOAK_HOURS`/`MIN_*`/`MAX_*`) in sync with `promote-preflight.yml`. |
 | `promote-manual.yml` — `[iOS] Promote Build → Group (manual)` | Manual | Attach a specific build number to any TestFlight group, bypassing the soak gate. |
 | `promote-production.yml` — `[iOS] Promote Beta → Production` | Manual | Submit a build to App Store review (phased release by default). Uses the `production` environment. |
 | `swift-deps-update.yml` — `[iOS] Swift package updates` | Weekly (Mon 09:00 UTC) + manual | Checks the exact pins in `mobile-apps/ios/project.yml` against the latest GitHub releases (via `.github/scripts/swift-deps-check.mjs`) and opens/updates a bump PR on the `automated/swift-deps-update` branch. The PR is opened with the default `GITHUB_TOKEN`, which can't trigger CI — close & reopen it (or push to the branch) to run the gate. |
@@ -53,6 +54,10 @@ Signing / upload (already configured): `SWIFT_CERTIFICATE_P12`,
 `ASC_KEY_ID`, `ASC_API_KEY_P8`, `ASC_ISSUER_ID`.
 
 Pre-flight soak gate (new): `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`.
+
+Pre-flight promote preview (new): `PUSHOVER_TOKEN` (Pushover application/API token)
+and `PUSHOVER_USER` (your Pushover user/group key). Used only by
+`promote-preflight-preview.yml`.
 
 Also requires TestFlight groups named **`Beta`** (internal, auto-distribute on)
 and **`Pre-flight`** (external) in App Store Connect, and a `nightly-failure`

--- a/.github/workflows/promote-preflight-preview.yml
+++ b/.github/workflows/promote-preflight-preview.yml
@@ -1,0 +1,88 @@
+name: '[iOS] Pre-flight promote preview (notify)'
+
+# Runs the Beta → Pre-flight eligibility gate in DRY-RUN ~9h before the real
+# promotion (promote-preflight.yml, Tue 12:00 UTC) and sends a Pushover preview of
+# which build is likely to promote and what changed — so there is time to push a
+# block-promotion/build-<N> tag before it ships.
+#
+# Scheduled Tue 03:00 UTC = Mon 8:00 PM PDT (7:00 PM PST). Keep the gate inputs
+# (SOAK_HOURS / MIN_* / MAX_*) identical to promote-preflight.yml so the preview
+# reflects the real decision; if you change them there, change them here too.
+
+on:
+  schedule:
+    - cron: '0 3 * * 2'
+  workflow_dispatch:
+
+concurrency:
+  group: promote-preflight-preview
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    name: Preview the next Pre-flight promotion and notify via Pushover
+    runs-on: ubuntu-latest
+    steps:
+      # Full history + tags: the rollup "What to Test" walks git log between the
+      # deploy/<version> tags, same as the real promotion job.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Setup App Store Connect API key
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+        run: |
+          mkdir -p ~/.private_keys
+          echo -n "$ASC_API_KEY_P8" > ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8
+
+      - name: Fetch blocked build numbers from git tags
+        id: blocks
+        run: |
+          git fetch --tags --quiet
+          BLOCKED=$(git tag -l 'block-promotion/build-*' | sed 's|block-promotion/build-||' | tr '\n' ',' | sed 's/,$//')
+          echo "blocked=${BLOCKED}" >> "$GITHUB_OUTPUT"
+          echo "Blocked builds: ${BLOCKED:-(none)}"
+
+      - name: Evaluate eligibility (dry run) and write summary
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_PATH: ~/.private_keys/AuthKey_${{ secrets.ASC_KEY_ID }}.p8
+          APP_BUNDLE_ID: com.eff3.migralog
+          SOURCE_GROUP_NAME: Beta
+          TARGET_GROUP_NAME: Pre-flight
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SOAK_HOURS: '72'
+          MIN_SESSIONS: '5'
+          MIN_CRASH_FREE_RATE: '0.99'
+          MAX_UNRESOLVED_ISSUES: '0'
+          BLOCKED_BUILDS: ${{ steps.blocks.outputs.blocked }}
+          DRY_RUN: 'true'
+          SUMMARY_FILE: ${{ runner.temp }}/preflight-preview.json
+        run: node .github/scripts/promote-preflight.mjs
+
+      - name: Send Pushover preview
+        env:
+          SUMMARY_FILE: ${{ runner.temp }}/preflight-preview.json
+          PUSHOVER_TOKEN: ${{ secrets.PUSHOVER_TOKEN }}
+          PUSHOVER_USER: ${{ secrets.PUSHOVER_USER }}
+          LEAD_HOURS: '9'
+          PROMOTE_WHEN: 'Tue 12:00 UTC'
+        run: node .github/scripts/pushover-preflight-preview.mjs
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf ~/.private_keys || true


### PR DESCRIPTION
## What
A new workflow that, ~9h before the weekly Beta→Pre-flight promotion (Tue 12:00 UTC), runs the **same eligibility gate in dry-run** and sends a **Pushover** notification previewing:

- the build that's likely to promote (number + version),
- its rolled-up "What to Test" changes,
- and any build whose soak window will clear by promote time (near-miss heads-up),

so there's a window to push a `block-promotion/build-<N>` tag before it ships.

## Timing
Scheduled `0 3 * * 2` = **Tue 03:00 UTC = Mon 8:00 PM PT** (7 PM in PST). That's the latest 8am–8pm-local slot before the Tue 12:00 UTC promote — a fixed **9h lead**. (Cron is UTC, so the clock-time shifts ±1h with DST but the 9h gap and the 8am–8pm window placement hold.)

## Changes
- **`promote-preflight.mjs`** — additive `SUMMARY_FILE` JSON output (eligible build, rollup notes, full evaluation incl. soak ages). No-op when the env var is unset, so the real promotion path is byte-for-byte unchanged.
- **`pushover-preflight-preview.mjs`** — builds the message from that summary and POSTs to the Pushover API; projects near-miss soak builds forward by `LEAD_HOURS`.
- **`promote-preflight-preview.yml`** — mirrors the real gate inputs (`SOAK_HOURS`/`MIN_*`/`MAX_*`) in `DRY_RUN`; reuses the existing `ASC_*` + `SENTRY_*` secrets.
- README updated (workflow table + new secrets).

## ⚠️ Action required before this works
Add two repo secrets (all other gate secrets already exist):
- `PUSHOVER_TOKEN` — Pushover application/API token
- `PUSHOVER_USER` — your Pushover user/group key

## Testing
Message builder exercised locally against eligible + no-eligible summaries with a stubbed `fetch`; both render correctly and the near-miss heads-up fires when `age + 9h ≥ soak`. Trigger live with **Run workflow** (`workflow_dispatch`) once the secrets are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)