### PR TITLE
fix(ios): show average dose, not 30-day total, in doctor summary

### DIFF
--- a/mobile-apps/ios/MigraLog/Utils/AnalyticsInsights+DoctorSummary.swift
+++ b/mobile-apps/ios/MigraLog/Utils/AnalyticsInsights+DoctorSummary.swift
@@ -68,9 +68,15 @@ extension AnalyticsInsights {
         let dayCount: Int
         /// Sum over taken doses of `quantity × per-dose dosage amount`.
         let totalAmount: Double
-        /// Unit label for `totalAmount` (the medication's configured unit).
+        /// Unit label for `totalAmount`/`averageAmount` (the medication's unit).
         let dosageUnit: String
         var id: String { medicationId }
+
+        /// Mean amount per taken dose — the typical strength taken each time,
+        /// which reads more usefully on the report than a 30-day total.
+        var averageAmount: Double {
+            doseCount > 0 ? totalAmount / Double(doseCount) : 0
+        }
     }
 
     /// Per-rescue-medication usage over `from...to` (excluded-overlay days

--- a/mobile-apps/ios/MigraLog/Views/Settings/DoctorSummaryReportView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DoctorSummaryReportView.swift
@@ -175,7 +175,7 @@ struct DoctorSummaryReportView: View {
             Text("Type").frame(width: 70, alignment: .leading)
             Text("Doses").frame(width: 50, alignment: .trailing)
             Text("Days").frame(width: 50, alignment: .trailing)
-            Text("Total").frame(width: 80, alignment: .trailing)
+            Text("Avg dose").frame(width: 80, alignment: .trailing)
         }
         .font(.system(size: 10, weight: .semibold))
         .foregroundStyle(subtle)
@@ -196,7 +196,7 @@ struct DoctorSummaryReportView: View {
                 .frame(width: 70, alignment: .leading)
             Text("\(med.doseCount)").frame(width: 50, alignment: .trailing)
             Text("\(med.dayCount)").frame(width: 50, alignment: .trailing)
-            Text(MedicationFormatting.formatDosage(amount: med.totalAmount, unit: med.dosageUnit))
+            Text(MedicationFormatting.formatDosage(amount: med.averageAmount, unit: med.dosageUnit))
                 .frame(width: 80, alignment: .trailing)
         }
         .font(.system(size: 11))

--- a/mobile-apps/ios/MigraLogTests/Utils/AnalyticsInsightsTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Utils/AnalyticsInsightsTests.swift
@@ -857,6 +857,8 @@ final class AnalyticsInsightsTests: XCTestCase {
         XCTAssertEqual(result.first?.dayCount, 2)
         // makeDose stamps dosageAmount 400; total = (1 + 2 + 1) × 400.
         XCTAssertEqual(result.first?.totalAmount, 1600)
+        // Average is per-dose: 1600 / 3 doses.
+        XCTAssertEqual(try XCTUnwrap(result.first).averageAmount, 1600.0 / 3.0, accuracy: 0.001)
         XCTAssertEqual(result.first?.dosageUnit, "mg")
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #557. In the **Acute / rescue medication** table, the "Total" column showed the 30-day total milligrams, which isn't clinically useful. Switch it to **Avg dose** — the average amount per taken dose (total ÷ doses), i.e. the typical strength taken each time.

E.g. Sumatriptan 6 doses / 600 mg total now shows **100 mg** average; Ibuprofen 4 doses / 1600 mg shows **400 mg**.

## Implementation
- Add `averageAmount` computed property to `AnalyticsInsights.MedicationUsage` (`totalAmount / doseCount`). `totalAmount` is retained.
- Update the report view column header and value.

## Testing
- Extended the existing `medicationUsage` test to assert `averageAmount`; full `AnalyticsInsightsTests` (51) + PDF smoke tests (2) green.
- Re-rendered the sample PDF and verified the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)