### PR TITLE
feat(ios): add Doctor Visit Summary export to the Trends screen

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/Analytics/AnalyticsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Analytics/AnalyticsScreen.swift
@@ -75,6 +75,8 @@ struct AnalyticsScreen: View {
                     TimeRangeSelectorView(viewModel: viewModel)
                     MedicationResponseSection(viewModel: viewModel)
                 }
+
+                DoctorSummaryExportSection()
             }
             .padding()
         }
@@ -99,6 +101,39 @@ struct AnalyticsScreen: View {
                 })
             }
         }
+    }
+}
+
+// MARK: - Doctor Summary Export
+
+/// Prominent entry point to the one-page Doctor Visit Summary PDF, shown at the
+/// bottom of the Trends screen. The caption makes clear the report uses fixed
+/// windows (last 30 days + 6-month trend), not the range selected above — so it
+/// reads differently from "share what's on screen".
+struct DoctorSummaryExportSection: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xs) {
+            DoctorSummaryExportButton { isGenerating in
+                HStack(spacing: DesignTokens.Spacing.sm) {
+                    if isGenerating {
+                        ProgressView().tint(.white)
+                    } else {
+                        Image(systemName: "doc.richtext")
+                    }
+                    Text("Export Doctor Visit Summary")
+                        .fontWeight(.semibold)
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .accessibilityIdentifier("export-doctor-summary")
+
+            Text("A one-page PDF for a doctor's visit: the last 30 days and the 6-month trend, regardless of the range selected above.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.top, DesignTokens.Spacing.sm)
     }
 }
 
@@ -574,6 +609,19 @@ struct AnalyticsControlsColumn: View {
                     onAdd: onAddOverlay,
                     onEdit: onEditOverlay
                 )
+            }
+
+            Section {
+                DoctorSummaryExportButton { isGenerating in
+                    HStack {
+                        Label("Doctor Visit Summary (PDF)", systemImage: "doc.richtext")
+                        Spacer()
+                        if isGenerating { ProgressView() }
+                    }
+                }
+                .accessibilityIdentifier("export-doctor-summary")
+            } footer: {
+                Text("A one-page PDF: the last 30 days and the 6-month trend, regardless of the range selected.")
             }
         }
         .listStyle(.insetGrouped)

--- a/mobile-apps/ios/MigraLog/Views/Settings/DataSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DataSettingsScreen.swift
@@ -3,9 +3,6 @@ import UniformTypeIdentifiers
 
 struct DataSettingsScreen: View {
     @State private var isExporting = false
-    @State private var isGeneratingPDF = false
-    @State private var showPDFShareSheet = false
-    @State private var pdfURL: URL?
     @State private var isBackingUp = false
     @State private var isRestoring = false
     @State private var showShareSheet = false
@@ -34,16 +31,13 @@ struct DataSettingsScreen: View {
                     }
                 }
                 .disabled(isExporting)
-                Button {
-                    Task { await generateDoctorSummary() }
-                } label: {
+                DoctorSummaryExportButton { isGenerating in
                     HStack {
                         Label("Doctor Visit Summary (PDF)", systemImage: "doc.richtext")
                         Spacer()
-                        if isGeneratingPDF { ProgressView() }
+                        if isGenerating { ProgressView() }
                     }
                 }
-                .disabled(isGeneratingPDF)
             } header: {
                 Text("Export")
             } footer: {
@@ -98,18 +92,6 @@ struct DataSettingsScreen: View {
             }
         }) {
             if let url = exportURL {
-                ShareSheet(items: [url])
-            }
-        }
-        .sheet(isPresented: $showPDFShareSheet, onDismiss: {
-            // The summary is plaintext health data in tmp — remove it as soon
-            // as the share sheet is done with it.
-            if let url = pdfURL {
-                try? FileManager.default.removeItem(at: url)
-                pdfURL = nil
-            }
-        }) {
-            if let url = pdfURL {
                 ShareSheet(items: [url])
             }
         }
@@ -219,26 +201,6 @@ struct DataSettingsScreen: View {
         } catch {
             ErrorLogger.shared.logError(error, context: ["screen": "DataSettingsScreen", "action": "exportJSON"])
             errorMessage = "Export failed: \(error.localizedDescription)"
-            showError = true
-        }
-    }
-
-    private func generateDoctorSummary() async {
-        isGeneratingPDF = true
-        defer { isGeneratingPDF = false }
-        do {
-            // Build the report off the main actor (database reads), then render
-            // on the main actor (ImageRenderer requirement).
-            let report = try await Task.detached(priority: .userInitiated) {
-                try DoctorSummaryReportBuilder().buildReport()
-            }.value
-            pdfURL = try await MainActor.run {
-                try DoctorSummaryPDFRenderer.renderPDF(report: report)
-            }
-            showPDFShareSheet = true
-        } catch {
-            ErrorLogger.shared.logError(error, context: ["screen": "DataSettingsScreen", "action": "generateDoctorSummary"])
-            errorMessage = "Could not generate summary: \(error.localizedDescription)"
             showError = true
         }
     }

--- a/mobile-apps/ios/MigraLog/Views/Settings/DoctorSummaryExportButton.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DoctorSummaryExportButton.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// Reusable button that builds the one-page Doctor Visit Summary PDF and opens
+/// the share sheet. Used from both Settings → Backup & Export (as a list row)
+/// and the Trends screen (as a prominent button).
+///
+/// The caller supplies the label via the trailing closure — it receives the
+/// in-progress flag so it can swap in a spinner — and may set a `.buttonStyle`
+/// on this view; the wrapped `Button` inherits it. The generated PDF is
+/// plaintext health data in tmp and is removed as soon as the share sheet
+/// closes, matching the JSON export's handling.
+struct DoctorSummaryExportButton<Label: View>: View {
+    @ViewBuilder var label: (_ isGenerating: Bool) -> Label
+
+    @State private var isGenerating = false
+    @State private var pdfURL: URL?
+    @State private var showShareSheet = false
+    @State private var showError = false
+    @State private var errorMessage = ""
+
+    var body: some View {
+        Button {
+            Task { await generate() }
+        } label: {
+            label(isGenerating)
+        }
+        .disabled(isGenerating)
+        .sheet(isPresented: $showShareSheet, onDismiss: {
+            if let url = pdfURL {
+                try? FileManager.default.removeItem(at: url)
+                pdfURL = nil
+            }
+        }) {
+            if let url = pdfURL {
+                ShareSheet(items: [url])
+            }
+        }
+        .alert("Error", isPresented: $showError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage)
+        }
+    }
+
+    private func generate() async {
+        isGenerating = true
+        defer { isGenerating = false }
+        do {
+            // Build off the main actor (database reads), render on it (ImageRenderer).
+            let report = try await Task.detached(priority: .userInitiated) {
+                try DoctorSummaryReportBuilder().buildReport()
+            }.value
+            pdfURL = try await MainActor.run {
+                try DoctorSummaryPDFRenderer.renderPDF(report: report)
+            }
+            showShareSheet = true
+        } catch {
+            ErrorLogger.shared.logError(error, context: ["component": "DoctorSummaryExportButton", "action": "generate"])
+            errorMessage = "Could not generate summary: \(error.localizedDescription)"
+            showError = true
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #557 / #558. Adds a second entry point to the one-page Doctor Visit Summary PDF from the **Trends** tab, so it's discoverable where the stats live (not only in Settings → Backup & Export).

- **iPhone:** a prominent "Export Doctor Visit Summary" button at the bottom of the Trends screen, below the section content.
- **iPad:** a list row in the Trends controls column.
- Both include a caption clarifying the report uses **fixed windows** (last 30 days + 6-month trend) **regardless of the range selected** — chosen over a toolbar share icon, which would wrongly imply "share what's on screen."

## Implementation
- Extracted the generate-and-share flow (build report off-main → render PDF on-main → share sheet → tmp cleanup) out of `DataSettingsScreen` into a reusable `DoctorSummaryExportButton`. The caller supplies the label and may set a `.buttonStyle`, so the same component serves the Settings list row and the prominent Trends button.
- `DataSettingsScreen` now uses the shared component (removes its duplicated state, share sheet, and generate func).
- No change to report contents.

## Testing
- Build green; `DoctorSummaryPDFRendererTests` green; existing `TrendsAnalyticsUITests` navigation test still green (content added to that screen).
- Verified the button placement on the simulator via a screenshot (bottom of Trends, caption shown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)