### PR TITLE
feat(ios): reorganize Settings — Beta Features, App Information, theme cards

### DIFF
--- a/mobile-apps/ios/MigraLog/Utils/FeatureFlags.swift
+++ b/mobile-apps/ios/MigraLog/Utils/FeatureFlags.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Lightweight, `UserDefaults`-backed feature flag for pre-release builds.
+///
+/// Flags let us land in-progress features behind a toggle so they ship to
+/// TestFlight (where evaluators can opt in via **Settings → Beta Features**)
+/// while staying off by default and invisible in App Store builds.
+///
+/// To add a flag, declare a `static let` below and append it to `all`; the Beta
+/// Features screen renders a toggle for every entry automatically. Read a flag
+/// anywhere with `FeatureFlags.isEnabled(.someFlag)`, or observe it reactively
+/// in a view with `@AppStorage(FeatureFlag.someFlag.storageKey)`.
+struct FeatureFlag: Identifiable {
+    /// Stable identifier; also forms the persistence key. Never reuse a key for
+    /// a different feature.
+    let key: String
+    /// Short label shown next to the toggle.
+    let title: String
+    /// One-line explanation shown beneath the toggle.
+    let details: String
+    /// State when the user has never touched the toggle.
+    var defaultValue: Bool = false
+
+    var id: String { key }
+
+    /// `@AppStorage` / `UserDefaults` key. Namespaced so flags can never collide
+    /// with other persisted settings.
+    var storageKey: String { "featureFlag.\(key)" }
+
+    // MARK: - Registry
+
+    // Declare experimental flags here, e.g.:
+    // static let newInsightsDashboard = FeatureFlag(
+    //     key: "newInsightsDashboard",
+    //     title: "New Insights Dashboard",
+    //     details: "Replaces the trends tab with the redesigned dashboard."
+    // )
+
+    /// Every flag surfaced in Beta Features, in display order.
+    static let all: [FeatureFlag] = [
+        // .newInsightsDashboard,
+    ]
+}
+
+/// Accessor for reading flags from app logic and views.
+enum FeatureFlags {
+    static func isEnabled(_ flag: FeatureFlag) -> Bool {
+        guard UserDefaults.standard.object(forKey: flag.storageKey) != nil else {
+            return flag.defaultValue
+        }
+        return UserDefaults.standard.bool(forKey: flag.storageKey)
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Settings/BetaFeaturesScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/BetaFeaturesScreen.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+/// Top-level Settings category (pre-release builds only) collecting tools meant
+/// for evaluators and internal testing: experimental feature flags, sample-data
+/// loading, and similar affordances. Gated behind `BuildEnvironment.isPreRelease`
+/// at the call site so it never appears in App Store builds.
+struct BetaFeaturesScreen: View {
+    var body: some View {
+        List {
+            FeatureFlagsSectionView()
+            SampleDataSectionView()
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Beta Features")
+        .readableContentWidth()
+    }
+}
+
+/// Renders a toggle for every registered `FeatureFlag`. Shows an empty state
+/// when no flags are currently defined.
+struct FeatureFlagsSectionView: View {
+    var body: some View {
+        Section {
+            if FeatureFlag.all.isEmpty {
+                Text("No experimental features are available right now.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(FeatureFlag.all) { flag in
+                    FeatureFlagToggle(flag: flag)
+                }
+            }
+        } header: {
+            Text("Feature Flags")
+        } footer: {
+            Text("Opt in to in-progress features. These are experimental, may be "
+                + "incomplete, and only appear in test builds.")
+        }
+    }
+}
+
+/// A single feature-flag toggle, persisted under the flag's namespaced key.
+private struct FeatureFlagToggle: View {
+    let flag: FeatureFlag
+
+    @State private var isOn: Bool
+
+    init(flag: FeatureFlag) {
+        self.flag = flag
+        _isOn = State(initialValue: FeatureFlags.isEnabled(flag))
+    }
+
+    var body: some View {
+        Toggle(isOn: $isOn) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(flag.title)
+                Text(flag.details)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityIdentifier("feature-flag-\(flag.key)")
+        .onChange(of: isOn) { _, newValue in
+            UserDefaults.standard.set(newValue, forKey: flag.storageKey)
+        }
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Settings/DataSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/DataSettingsScreen.swift
@@ -31,17 +31,10 @@ struct DataSettingsScreen: View {
                     }
                 }
                 .disabled(isExporting)
-                DoctorSummaryExportButton { isGenerating in
-                    HStack {
-                        Label("Doctor Visit Summary (PDF)", systemImage: "doc.richtext")
-                        Spacer()
-                        if isGenerating { ProgressView() }
-                    }
-                }
             } header: {
                 Text("Export")
             } footer: {
-                Text("Export your data as JSON for sharing with healthcare providers, or a one-page PDF summary for a doctor's visit — headache days, medication usage, and preventative compliance.")
+                Text("Export your data as JSON for sharing with healthcare providers.")
             }
 
             Section("Backup") {

--- a/mobile-apps/ios/MigraLog/Views/Settings/LicensesScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/LicensesScreen.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+/// One open-source dependency and its license, shown under Settings → Open
+/// Source Licenses. Keep `OpenSourceLicense.all` in sync with the packages
+/// declared in `project.yml`. Versions are deliberately omitted: the weekly
+/// dependency bump (swift-deps-update.yml) would silently make a hard-coded
+/// version stale, and the attribution + license text are what matter here.
+struct OpenSourceLicense: Identifiable {
+    let name: String
+    let url: String
+    let licenseName: String
+    let licenseText: String
+
+    var id: String { name }
+
+    static let all: [OpenSourceLicense] = [
+        OpenSourceLicense(
+            name: "GRDB.swift",
+            url: "https://github.com/groue/GRDB.swift",
+            licenseName: "MIT License",
+            licenseText: mitLicense(copyright: "Copyright (C) 2015-2025 Gwendal Roué")
+        ),
+        OpenSourceLicense(
+            name: "Sentry (sentry-cocoa)",
+            url: "https://github.com/getsentry/sentry-cocoa",
+            licenseName: "MIT License",
+            licenseText: mitLicense(copyright: "Copyright (c) 2015 Sentry")
+        )
+    ]
+
+    /// The standard MIT license body with the given copyright line.
+    private static func mitLicense(copyright: String) -> String {
+        """
+        The MIT License (MIT)
+
+        \(copyright)
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy \
+        of this software and associated documentation files (the "Software"), to deal \
+        in the Software without restriction, including without limitation the rights \
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell \
+        copies of the Software, and to permit persons to whom the Software is \
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all \
+        copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR \
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, \
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE \
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER \
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, \
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE \
+        SOFTWARE.
+        """
+    }
+}
+
+/// Lists the open-source packages MigraLog ships with; each row opens the full
+/// license text.
+struct LicensesScreen: View {
+    var body: some View {
+        List {
+            Section {
+                ForEach(OpenSourceLicense.all) { license in
+                    NavigationLink {
+                        LicenseDetailScreen(license: license)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(license.name)
+                            Text(license.licenseName)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .accessibilityIdentifier("license-\(license.id)")
+                }
+            } footer: {
+                Text("MigraLog is built with these open source packages. "
+                    + "Thank you to their authors and contributors.")
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Open Source Licenses")
+        .readableContentWidth()
+    }
+}
+
+/// Full, selectable license text for a single dependency.
+struct LicenseDetailScreen: View {
+    let license: OpenSourceLicense
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if let url = URL(string: license.url) {
+                    Link(destination: url) {
+                        Label(license.url, systemImage: "link")
+                            .font(.footnote)
+                    }
+                }
+
+                Text(license.licenseText)
+                    .font(.footnote)
+                    .textSelection(.enabled)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+        }
+        .navigationTitle(license.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .readableContentWidth()
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Settings/LiveActivitiesScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/LiveActivitiesScreen.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// Live Activities settings, surfaced as its own top-level row under the
+/// Notifications category rather than buried at the bottom of the notification
+/// toggles. Controls whether live episode status appears on the Lock Screen and
+/// in the Dynamic Island while an episode is active.
+struct LiveActivitiesScreen: View {
+    @State private var viewModel = NotificationSettingsViewModel()
+
+    var body: some View {
+        List {
+            Section {
+                Toggle("Live Activities", isOn: $viewModel.liveActivitiesEnabled)
+                    .onChange(of: viewModel.liveActivitiesEnabled) { _, _ in
+                        viewModel.saveSettings()
+                        viewModel.applyLiveActivitiesSettingChange()
+                    }
+                    .accessibilityIdentifier("live-activities-toggle")
+            } footer: {
+                Text("Show live episode status on the Lock Screen and in the Dynamic Island while an episode is active.")
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Live Activities")
+        .readableContentWidth()
+        .task {
+            viewModel.loadSettings()
+        }
+    }
+}

--- a/mobile-apps/ios/MigraLog/Views/Settings/NotificationSettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/NotificationSettingsScreen.swift
@@ -80,17 +80,6 @@ struct NotificationSettingsScreen: View {
                     }
                 }
             }
-
-            Section {
-                Toggle("Live Activities", isOn: $viewModel.liveActivitiesEnabled)
-                    .onChange(of: viewModel.liveActivitiesEnabled) { _, _ in
-                        viewModel.saveSettings()
-                        viewModel.applyLiveActivitiesSettingChange()
-                    }
-                    .accessibilityIdentifier("live-activities-toggle")
-            } footer: {
-                Text("Show live episode status on the Lock Screen and in the Dynamic Island while an episode is active.")
-            }
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Notification Settings")

--- a/mobile-apps/ios/MigraLog/Views/Settings/SettingsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/SettingsScreen.swift
@@ -19,20 +19,39 @@ struct SettingsScreen: View {
                     Label("Notifications", systemImage: "bell")
                 }
                 .accessibilityIdentifier("notification-settings")
+
+                NavigationLink {
+                    LiveActivitiesScreen()
+                } label: {
+                    Label("Live Activities", systemImage: "dot.radiowaves.left.and.right")
+                }
+                .accessibilityIdentifier("live-activities-settings")
             }
 
-            // Tracking
+            // Tracking — each pick list gets its own row, plus the medication
+            // safety limits that govern dose tracking.
             Section("Tracking") {
                 NavigationLink {
-                    TrackingOptionsScreen()
+                    TrackingOptionsScreen(category: .symptom)
                 } label: {
-                    Label("Tracking Options", systemImage: "slider.horizontal.3")
+                    Label("Symptoms", systemImage: "list.bullet.clipboard")
                 }
-                .accessibilityIdentifier("tracking-options")
-            }
+                .accessibilityIdentifier("tracking-symptoms")
 
-            // Medication Safety
-            Section("Medication Safety") {
+                NavigationLink {
+                    TrackingOptionsScreen(category: .trigger)
+                } label: {
+                    Label("Triggers", systemImage: "exclamationmark.triangle")
+                }
+                .accessibilityIdentifier("tracking-triggers")
+
+                NavigationLink {
+                    TrackingOptionsScreen(category: .painQuality)
+                } label: {
+                    Label("Pain Qualities", systemImage: "waveform.path.ecg")
+                }
+                .accessibilityIdentifier("tracking-pain-qualities")
+
                 NavigationLink {
                     CategorySafetyRulesScreen()
                 } label: {
@@ -52,6 +71,15 @@ struct SettingsScreen: View {
 
             // Data
             Section("Data") {
+                DoctorSummaryExportButton { isGenerating in
+                    HStack {
+                        Label("Doctor Visit Summary", systemImage: "doc.richtext")
+                        Spacer()
+                        if isGenerating { ProgressView() }
+                    }
+                }
+                .accessibilityIdentifier("settings-doctor-summary")
+
                 NavigationLink {
                     DataSettingsScreen()
                 } label: {
@@ -65,10 +93,18 @@ struct SettingsScreen: View {
                 }
             }
 
-            // Sample Data (test builds only) — lets evaluators explore the app
-            // with realistic data without hand-entering it.
+            // Beta Features (test builds only) — feature flags, sample data, and
+            // other tools for evaluators and internal testing. Hidden in App
+            // Store builds via BuildEnvironment.isPreRelease.
             if BuildEnvironment.isPreRelease {
-                SampleDataSectionView()
+                Section("Beta") {
+                    NavigationLink {
+                        BetaFeaturesScreen()
+                    } label: {
+                        Label("Beta Features", systemImage: "flask")
+                    }
+                    .accessibilityIdentifier("beta-features")
+                }
             }
 
             // Developer Tools (unlocked by tapping the version row 7 times)
@@ -83,9 +119,27 @@ struct SettingsScreen: View {
                 }
             }
 
-            // Version
+            // App Information — version, source repo, and open source licenses.
             Section {
                 VersionSectionView(developerModeEnabled: $developerModeEnabled)
+
+                if let repoURL = URL(string: "https://github.com/vfilby/migralog") {
+                    Link(destination: repoURL) {
+                        Label("View Source on GitHub", systemImage: "chevron.left.forwardslash.chevron.right")
+                    }
+                    .accessibilityIdentifier("github-repo")
+                }
+
+                NavigationLink {
+                    LicensesScreen()
+                } label: {
+                    Label("Open Source Licenses", systemImage: "doc.text")
+                }
+                .accessibilityIdentifier("open-source-licenses")
+            } header: {
+                Text("App Information")
+            } footer: {
+                Text("MigraLog is open source. Browse the code, report issues, or contribute on GitHub.")
             }
         }
         .listStyle(.insetGrouped)
@@ -96,17 +150,127 @@ struct SettingsScreen: View {
 
 // MARK: - Theme Section
 
+/// Appearance picker rendered as three preview swatch cards (Light / Dark /
+/// System). Each card shows a fixed miniature of the app in that appearance —
+/// the colors are intentionally non-adaptive so a card always depicts its own
+/// theme regardless of the mode currently in effect. The selected card gets a
+/// tinted ring and a checkmark.
 struct ThemeSectionView: View {
     @AppStorage("selectedTheme") private var selectedTheme: ThemePreference = .system
 
     var body: some View {
-        Picker("Theme", selection: $selectedTheme) {
+        HStack(spacing: 12) {
             ForEach(ThemePreference.allCases) { theme in
-                Text(theme.displayName).tag(theme)
-                    .accessibilityIdentifier("theme-\(theme.rawValue)")
+                Button {
+                    withAnimation(.snappy) { selectedTheme = theme }
+                } label: {
+                    ThemeOptionCard(theme: theme, isSelected: selectedTheme == theme)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("theme-\(theme.rawValue)")
+                .accessibilityLabel(theme.displayName)
+                .accessibilityAddTraits(selectedTheme == theme ? [.isSelected] : [])
             }
         }
-        .pickerStyle(.segmented)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 4)
+    }
+}
+
+/// A single appearance option: a miniature preview tile, a selection ring +
+/// checkmark, and the theme's name.
+private struct ThemeOptionCard: View {
+    let theme: ThemePreference
+    let isSelected: Bool
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ThemePreviewTile(theme: theme)
+                .frame(height: 88)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(
+                            isSelected ? Color.accentColor : Color(.separator),
+                            lineWidth: isSelected ? 3 : 1
+                        )
+                }
+                .overlay(alignment: .bottomTrailing) {
+                    if isSelected {
+                        Image(systemName: "checkmark.circle.fill")
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(.white, Color.accentColor)
+                            .font(.title3)
+                            .padding(5)
+                    }
+                }
+
+            Text(theme.displayName)
+                .font(.subheadline)
+                .fontWeight(isSelected ? .semibold : .regular)
+                .foregroundStyle(isSelected ? Color.accentColor : .primary)
+        }
+        .contentShape(Rectangle())
+    }
+}
+
+/// Fixed (non-adaptive) miniature of the app used inside a `ThemeOptionCard`.
+/// `.system` overlays the dark palette on a diagonal so it reads as "auto".
+private struct ThemePreviewTile: View {
+    let theme: ThemePreference
+
+    // Fixed palettes so each swatch always depicts its own appearance.
+    private static let lightBG = Color.white
+    private static let lightTitle = Color(white: 0.45)
+    private static let lightCard = Color(white: 0.88)
+    private static let darkBG = Color(white: 0.12)
+    private static let darkTitle = Color(white: 0.78)
+    private static let darkCard = Color(white: 0.30)
+
+    var body: some View {
+        switch theme {
+        case .light:
+            tile(bg: Self.lightBG, title: Self.lightTitle, card: Self.lightCard)
+        case .dark:
+            tile(bg: Self.darkBG, title: Self.darkTitle, card: Self.darkCard)
+        case .system:
+            ZStack {
+                tile(bg: Self.lightBG, title: Self.lightTitle, card: Self.lightCard)
+                tile(bg: Self.darkBG, title: Self.darkTitle, card: Self.darkCard)
+                    .clipShape(DiagonalHalf())
+            }
+        }
+    }
+
+    private func tile(bg: Color, title: Color, card: Color) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .fill(title)
+                .frame(width: 26, height: 5)
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .fill(card)
+                .frame(height: 12)
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .fill(card)
+                .frame(width: 34, height: 8)
+            Spacer(minLength: 0)
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(bg)
+    }
+}
+
+/// The lower-right triangle of a rect, split along the anti-diagonal — used to
+/// reveal the dark half of the System preview.
+private struct DiagonalHalf: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.maxX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.closeSubpath()
+        return path
     }
 }
 

--- a/mobile-apps/ios/MigraLog/Views/Settings/TrackingOptionsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/TrackingOptionsScreen.swift
@@ -6,16 +6,30 @@ import SwiftUI
 /// swipe. Hiding or deleting an option never changes past episodes — it only
 /// affects what the episode-entry pickers offer.
 struct TrackingOptionsScreen: View {
+    /// When set, the screen shows only this category — used by the per-category
+    /// rows under Settings → Tracking (Symptoms, Triggers, Pain Qualities).
+    /// When nil, every category is shown in one combined list.
+    let category: TrackingOptionCategory?
+
     @State private var viewModel = TrackingOptionsViewModel()
     @State private var addingCategory: TrackingOptionCategory?
 
+    init(category: TrackingOptionCategory? = nil) {
+        self.category = category
+    }
+
+    private var categories: [TrackingOptionCategory] {
+        if let category { return [category] }
+        return TrackingOptionCategory.allCases
+    }
+
     var body: some View {
         List {
-            ForEach(TrackingOptionCategory.allCases) { category in
+            ForEach(categories) { category in
                 section(for: category)
             }
         }
-        .navigationTitle("Tracking Options")
+        .navigationTitle(category?.displayName ?? "Tracking Options")
         .readableContentWidth()
         .navigationBarTitleDisplayMode(.inline)
         .task {
@@ -54,9 +68,15 @@ struct TrackingOptionsScreen: View {
             }
             .accessibilityIdentifier("tracking-options-add-\(category.rawValue)")
         } header: {
-            Text(category.displayName)
+            // In the combined list each section needs its own header; when the
+            // screen is scoped to one category the navigation title already names it.
+            if self.category == nil {
+                Text(category.displayName)
+            }
         } footer: {
-            if category == .trigger {
+            // Show the "only affects the pickers" note once: under Triggers in the
+            // combined list, or on every scoped per-category screen.
+            if self.category != nil || category == .trigger {
                 // swiftlint:disable:next line_length
                 Text("Hiding or deleting an option only changes which choices the pickers offer — episodes you already logged keep their values.")
                     .font(.footnote)

--- a/mobile-apps/ios/MigraLogUITests/BetaFeaturesUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/BetaFeaturesUITests.swift
@@ -1,0 +1,65 @@
+import XCTest
+
+/// Verifies the pre-release-only "Beta Features" Settings category: it is
+/// reachable from Settings and surfaces the feature-flags section plus the
+/// sample-data loader.
+final class BetaFeaturesUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = UITestHelpers.launchCleanDashboard()
+        UITestHelpers.waitForDashboard(in: app)
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    func testBetaFeaturesCategoryOpensAndShowsTools() throws {
+        openSettings()
+
+        // The Beta category appears in pre-release builds (DEBUG includes UI
+        // tests). It sits near the bottom of Settings, so scroll it into view —
+        // a virtualized List doesn't surface off-screen rows to the a11y tree.
+        let betaLink = app.buttons["beta-features"]
+        let list = app.collectionViews.firstMatch
+        if list.exists {
+            UITestHelpers.scrollToElement(betaLink, in: list)
+        }
+        UITestHelpers.waitForHittable(betaLink)
+        betaLink.tap()
+
+        // Landed on the Beta Features screen.
+        let title = app.navigationBars.staticTexts["Beta Features"]
+        UITestHelpers.waitForElement(title)
+
+        // Feature Flags section header + empty-state copy (no flags registered yet).
+        UITestHelpers.waitForElement(app.staticTexts["Feature Flags"])
+        XCTAssertTrue(
+            app.staticTexts["No experimental features are available right now."].exists,
+            "Empty feature-flags state should be shown when no flags are registered"
+        )
+
+        // Sample data loader moved under Beta Features.
+        UITestHelpers.waitForElement(app.buttons["load-sample-data"])
+
+        // Capture a screenshot for visual review of the new category.
+        let shot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: shot)
+        attachment.name = "beta-features-screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    // MARK: - Helpers
+
+    private func openSettings() {
+        let settingsButton = app.buttons["settings-button"]
+        UITestHelpers.waitForHittable(settingsButton)
+        settingsButton.tap()
+
+        let settingsTitle = app.navigationBars.staticTexts["Settings"]
+        UITestHelpers.waitForElement(settingsTitle)
+    }
+}

--- a/mobile-apps/ios/MigraLogUITests/TrackingOptionsUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/TrackingOptionsUITests.swift
@@ -18,8 +18,8 @@ final class TrackingOptionsUITests: XCTestCase {
     }
 
     func testCustomTriggerAppearsInNewEpisodePicker() throws {
-        // Step 1: Settings → Tracking Options
-        openTrackingOptions()
+        // Step 1: Settings → Tracking → Triggers
+        openTrackingCategory(rowID: "tracking-triggers", title: "Triggers")
 
         // Step 2: Add a trigger from the suggested catalog via autocomplete
         let addTrigger = app.buttons["tracking-options-add-trigger"]
@@ -83,7 +83,7 @@ final class TrackingOptionsUITests: XCTestCase {
     }
 
     func testManageOptions_duplicateRejected_deleteCustom_reshowBuiltIn() throws {
-        openTrackingOptions()
+        openTrackingCategory(rowID: "tracking-symptoms", title: "Symptoms")
 
         // Step 1: Adding a symptom that duplicates a built-in display name is rejected
         let addSymptom = app.buttons["tracking-options-add-symptom"]
@@ -124,15 +124,17 @@ final class TrackingOptionsUITests: XCTestCase {
         deleteButton.tap()
         UITestHelpers.waitForElementToDisappear(customRow)
 
-        // Step 3: Hide a built-in pain quality, then re-show it.
-        // Pain Qualities is the first section — scroll back up to it.
+        // Step 3: Pain Qualities is now its own screen — back out to Settings
+        // and open it, then hide a built-in pain quality and re-show it.
+        app.navigationBars.buttons.firstMatch.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        let painQualities = app.buttons["tracking-pain-qualities"]
+        scrollToInList(painQualities)
+        UITestHelpers.waitForHittable(painQualities)
+        painQualities.tap()
+        UITestHelpers.waitForElement(app.navigationBars.staticTexts["Pain Qualities"])
+
         let dullToggle = toggleElement("tracking-option-pain_quality-dull")
-        let listView = app.collectionViews.firstMatch.exists
-            ? app.collectionViews.firstMatch
-            : app.tables.firstMatch
-        if !dullToggle.isHittable && listView.exists {
-            UITestHelpers.scrollUpToElement(dullToggle, in: listView)
-        }
         UITestHelpers.waitForHittable(dullToggle)
         turnOff(dullToggle)
         setToggle(dullToggle, on: true)
@@ -140,19 +142,30 @@ final class TrackingOptionsUITests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func openTrackingOptions() {
+    private func openSettings() {
         let settingsButton = app.buttons["settings-button"]
         UITestHelpers.waitForHittable(settingsButton)
         settingsButton.tap()
-        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
 
-        let trackingOptions = app.buttons["tracking-options"]
-        scrollToInList(trackingOptions)
-        UITestHelpers.waitForHittable(trackingOptions)
-        trackingOptions.tap()
+        // Wait for the Settings list to settle before scrolling/querying — the
+        // collection view isn't queryable mid-transition.
+        let settingsTitle = app.navigationBars.staticTexts["Settings"]
+        UITestHelpers.waitForElement(settingsTitle)
+    }
 
-        let title = app.navigationBars.staticTexts["Tracking Options"]
-        UITestHelpers.waitForElement(title)
+    /// Open a single tracking category screen (Symptoms / Triggers / Pain
+    /// Qualities) from Settings. Each pick list is its own top-level row under
+    /// the Tracking category.
+    private func openTrackingCategory(rowID: String, title: String) {
+        openSettings()
+
+        let row = app.buttons[rowID]
+        scrollToInList(row)
+        UITestHelpers.waitForHittable(row)
+        row.tap()
+
+        let titleElement = app.navigationBars.staticTexts[title]
+        UITestHelpers.waitForElement(titleElement)
     }
 
     /// SwiftUI Toggles in a List usually surface as `.switch` elements, but the


### PR DESCRIPTION
## Summary
Reorganizes the iOS Settings screen for clearer top-level grouping.

- **Beta** category (pre-release only, gated by `BuildEnvironment.isPreRelease`) → **Beta Features**: a feature-flag scaffold (`FeatureFlag` registry, empty until flags are registered) plus the existing **Sample Data** loader, moved here.
- **Live Activities** lifted out of the buried Notification Settings list into its own top-level row under **Notifications**.
- **Doctor Visit Summary** promoted to a top-level row under **Data** (removed the duplicate inside Backup & Export; the Trends export button is untouched).
- **Tracking** split into per-category rows — **Symptoms**, **Triggers**, **Pain Qualities** — and **Medication Safety Limits** moved into the Tracking category (its standalone section is gone). `TrackingOptionsScreen` is now parameterized by category.
- Theme picker replaced with **preview swatch cards** (Light / Dark / diagonal-split System) with a tinted ring + checkmark on the selection.
- New **App Information** group at the bottom: app version, a **View Source on GitHub** link (open-source note), and **Open Source Licenses** (GRDB + Sentry, MIT, full license text).

## Testing
- `BetaFeaturesUITests` (new), `ThemeSwitchingUITests`, `TrackingOptionsUITests` (updated for per-category navigation) all pass locally on iPhone 17 Pro (iOS 26.5).

## Notes
- License list omits version numbers on purpose — deps are auto-bumped weekly, so a hard-coded version would go stale; attribution + license text are what matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)