### PR TITLE
docs(user-guide): add initial user guide content

### DIFF
--- a/user-guide/README.md
+++ b/user-guide/README.md
@@ -1,0 +1,46 @@
+# MigraLog User Guide
+
+Single source of truth for MigraLog's user-facing help documentation.
+
+The Markdown files in this folder are the **canonical** content for how to use
+the app. The goal is to author the guide here once and "compile" it into both:
+
+- **Web** — a `/help` (or similar) section on `migralog.app`, built and deployed
+  by the website pipeline.
+- **In-app** — bundled into the iOS app and rendered in a help/guide view.
+
+## Status
+
+Early scaffold. The compile/build pipeline to web and app is **not built yet** —
+this folder establishes the content home so writing can start independently of
+the tooling.
+
+## Structure
+
+```
+user-guide/
+├── README.md          # this file
+└── guide/             # the guide content, one Markdown file per topic
+    ├── tracking-philosophy.md
+    ├── medications.md
+    ├── calendar.md
+    └── trends-and-analytics.md
+```
+
+## Pages
+
+1. [How tracking works](guide/tracking-philosophy.md) — the timeline-based
+   philosophy and the three layers of tracking (episodes, timeline, daily status).
+2. [Medications](guide/medications.md) — adding medications, and setting
+   cooldowns and overuse safety limits.
+3. [The calendar](guide/calendar.md) — the day-status colours; migraine days are
+   automatic, other days are logged as Clear or Not Clear.
+4. [Trends and analytics](guide/trends-and-analytics.md) — insights, charts,
+   medication response, and the Doctor Visit Summary export.
+
+## Authoring guidelines
+
+- One topic per file; keep filenames kebab-case (e.g. `logging-an-episode.md`).
+- Write for end users, not developers — no implementation detail.
+- Health data is sensitive: never include real personal health information in
+  examples or screenshots.

--- a/user-guide/guide/calendar.md
+++ b/user-guide/guide/calendar.md
@@ -1,0 +1,81 @@
+# The calendar
+
+The calendar gives you a month-at-a-glance view of how you have been. Each day
+carries a colour that summarises its status, so over time you can see clusters of
+good days and difficult ones without reading a single entry.
+
+You will find the calendar in the **Trends** area, under the **Calendar** view.
+
+## The day colours
+
+Every day is shown in one of four states:
+
+| Colour | Status | Meaning |
+| --- | --- | --- |
+| 🔴 **Red** | Migraine day | An episode occurred on this day. **Set automatically.** |
+| 🟢 **Green** | Clear | No symptoms or concerns. You log this. |
+| 🟡 **Yellow** | Not Clear | Not a full attack, but not a clear day either. You log this. |
+| ⚪️ **Grey** | Not logged | No episode and no status recorded yet. |
+
+Colour is always paired with the day number and, where relevant, a label, so the
+states remain distinguishable regardless of colour vision.
+
+## Red days are automatic
+
+You never mark a day as a migraine day yourself. Whenever an episode covers a
+day, MigraLog marks that day **red** for you — and if an episode spans several
+days, every day it touches turns red.
+
+Because a logged migraine is the strongest signal about a day, **episodes take
+priority over manual status**. If you had marked a day as Clear and later log an
+episode covering it, the day becomes red. If that episode is later removed, the
+day reverts to whatever you had logged manually (or to grey if nothing was
+logged).
+
+This is why you only ever log the *other* days by hand — the migraine days take
+care of themselves the moment you track an episode.
+
+## Logging a day as Clear or Not Clear
+
+For any day without an episode, tap it to open its details and record how it went:
+
+- **Clear** — a good day, no symptoms or concerns.
+- **Not Clear** — something was off, but it was not a full attack. You can
+  optionally choose a type to be more specific:
+  - **Prodrome** — early warning signs before an attack.
+  - **Postdrome** — the recovery period after an attack.
+  - **Anxiety** — worry about a possible attack.
+  - **Other** — anything else.
+
+You can add a **note**, then save. To change a day later, reopen it and edit it,
+or remove the status to return it to grey. Future dates cannot be logged.
+
+> Keeping the in-between days up to date matters as much as logging attacks. The
+> ratio of clear to not-clear to migraine days is what shows whether things are
+> improving overall — see [Trends and analytics](trends-and-analytics.md).
+
+## What a day shows when you open it
+
+Tapping a day opens its details, which may include:
+
+- Its **status** and any note you have added.
+- Any **episodes** that overlap the day, with their time range and duration — tap
+  one to open the full episode and its timeline.
+- Any **overlays** that span the day (see below).
+- Buttons to **log**, **edit**, or **remove** the day's status — except on red
+  days, which are governed by their episode and cannot be edited directly.
+
+## Overlays — adding context
+
+**Overlays** let you mark stretches of time that might be relevant to your
+migraines but are not migraines themselves — for example travel, illness, a
+period of high stress, a menstrual cycle, or starting a new medication.
+
+An overlay spans a date range and appears as a small marker beneath the affected
+days, so you can visually line life events up against your attacks. You manage
+overlays from the **Calendar** view: add one with the **+** button, then tap it
+later to edit its dates or notes.
+
+Overlays are kept separate from your statistics. If you want, you can flag a
+period to be **excluded from stats** — useful for stretches like travel or
+illness that would otherwise distort your trends.

--- a/user-guide/guide/medications.md
+++ b/user-guide/guide/medications.md
@@ -1,0 +1,121 @@
+# Medications
+
+MigraLog keeps a record of the medications you use, lets you log each dose, and
+can warn you when you are taking a medication too soon after the last one or too
+often over time. This page explains how to add a medication and how to set up
+**cooldowns** and **safety limits**.
+
+## Adding a medication
+
+Open **Add Medication** (you can reach it from the Log Medication screen). As you 
+type a name, MigraLog suggests common medications for you.
+
+**Required details**
+
+- **Name** — what you call the medication.
+- **Type** — one of:
+  - **Rescue** — taken to treat an attack in progress.
+  - **Preventative** — taken on a schedule to reduce how often attacks occur.
+  - **Other** — anything that does not fit the above.
+- **Dose amount** and **unit** — for example `500` and `mg`, or `1` and
+  `tablet`.
+
+**Optional details**
+
+- **Default quantity** — how many you usually take at once (for example `2`
+  tablets). This is used for quick logging.
+- **Category** — the medication class: **OTC**, **NSAID**, **Triptan**,
+  **CGRP**, **Preventive**, **Supplement**, or **Other**. The category is
+  important: it is what allows you to apply class-wide cooldowns and
+  overuse limits (see below).
+- **Minimum time between doses** — a per-medication cooldown, in hours.
+- **Notes** — anything else you want to remember.
+
+**For preventative medications** you can also set a **schedule** (daily, monthly,
+or quarterly) and a **reminder time**, and turn the reminder on or off. Reminders can be sent as time sensitive, and optionally you have have a critical follow up notification set that will alert you even if your phone is in do not distrub.
+
+## Logging a dose
+
+From **Log Medication**, each medication appears as a card. You have two ways to
+record a dose:
+
+- **Quick log** — tap the dose button on the card to record your default
+  quantity at the current time.
+- **Details** — open the sheet to adjust the **quantity**, set the **time** (you
+  can backdate a dose you forgot to log), and add **notes**.
+
+If you log a dose while an episode is ongoing, MigraLog associates it with that
+episode so it appears on the episode timeline.
+
+## Cooldowns — spacing out doses
+
+A **cooldown** is a minimum amount of time you want between doses. It
+never prevents you from logging a dose; it simply shows a clear warning so you
+can make an informed decision. There are two kinds.
+
+### Per-medication cooldown
+
+Set the **Minimum time between doses** (in hours) on an individual medication.
+When you have taken that medication recently, its card shows how long ago the
+last dose was and, if you are still inside the cooldown, how long remains — for
+example *"Last dose 2h ago — wait 4h"*, highlighted in amber.
+
+This is set on the medication itself and is independent of the category rules in
+**Settings → Medication Safety Limits** — it neither appears there nor is
+affected by them.
+
+### Per-category cooldown
+
+You can also require a gap between *any* medications in the same class — useful
+for triptans, for instance, where the concern is the class as a whole rather than
+one specific drug.
+
+Set this in **Settings → Medication Safety Limits**: add a rule, choose a
+**category**, choose the **Cooldown** rule type, and enter the minimum hours
+between doses. MigraLog suggests common defaults (for example, two hours between
+triptans) which you can accept or change.
+
+When a category cooldown is active, the warning names the medication that
+triggered it — for example *"Last Triptan (Sumatriptan) 1h ago — wait 1h"* —
+even if you are about to log a different medication in that class.
+
+## Safety limits — avoiding overuse
+
+Taking acute (rescue) medication on too many days can, over time, lead to
+medication-overuse headache. MigraLog can track this for you against the class
+guidelines used in clinical practice.
+
+Set a limit in **Settings → Medication Safety Limits**: add a rule, choose a
+**category**, choose the **Period Limit** rule type, and set **"max days taken"**
+within a **rolling window** of a given number of days. Suggested defaults follow
+common guidance — for example, NSAIDs no more than 15 days in any 30, and
+triptans no more than 10 days in any 30.
+
+The suggested defaults are general starting points, not a recommendation for your
+situation. **Consult your neurologist to determine the right limits for you** —
+the appropriate thresholds depend on your medications, your history, and your
+care plan, and your clinician's guidance always takes precedence.
+
+A few things worth knowing about how limits are counted:
+
+- Limits count **days of use**, not the number of doses. Two doses on the same
+  day count as one day.
+- The window is **rolling** — "the last 30 days" from today, not the current
+  calendar month.
+
+As you approach a limit, the medication shows an **amber** warning (for example
+*"NSAIDs used 13 of 15 days in last 30"*). At or over the limit, the warning
+turns **red**.
+
+> **These warnings are informational only.** They do not block you from taking or
+> logging anything, and they are not medical advice. They are there to help you
+> notice a pattern and to give you something concrete to discuss with your
+> doctor. Always follow your clinician's guidance over any in-app warning.
+
+## Where to see it all together
+
+Each medication has a detail screen showing its information, its schedule and
+reminders (for preventatives), recent doses, and any active safety warnings. Your
+medication use over time — including overuse-risk trends and how quickly each
+rescue medication tends to work — appears in
+[Trends and analytics](trends-and-analytics.md).

--- a/user-guide/guide/tracking-philosophy.md
+++ b/user-guide/guide/tracking-philosophy.md
@@ -1,0 +1,98 @@
+# How tracking works in MigraLog
+
+MigraLog is built around a simple idea: a migraine is not a single moment, it is
+a **course of events over time**. Rather than asking you to summarise an attack
+after it is over, MigraLog lets you record what is happening *as it happens* and
+assembles those moments into a continuous timeline.
+
+## Why a timeline
+
+A migraine changes from hour to hour. The pain may begin in one place and move,
+intensity rises and falls, symptoms come and go, and the medication you take has
+an effect that unfolds over the following hours.
+
+A single end-of-day note cannot capture any of that. A timeline can. By recording
+each change with its own timestamp, MigraLog can reconstruct the **shape** of an
+attack — when it started, how it built, what you did about it, and how it
+responded. That shape is what reveals patterns, and it is what a clinician can
+actually use.
+
+## The three layers of tracking
+
+MigraLog records your health at three levels of detail. They work together, and
+each answers a different question.
+
+### 1. Episodes — the detailed record of an attack
+
+An **episode** is a single migraine, tracked from start to finish. It is the
+heart of the app.
+
+- **Start Episode** begins tracking. You can start an episode the moment one
+  begins, or backdate the start time if you are catching up later.
+- While an episode is ongoing it has no end time and is shown as **Ongoing**.
+  The main action on the dashboard becomes **Log Update**, inviting you to keep
+  adding to the record as things change.
+- **End Episode** closes it and sets the final time. If you close one by
+  mistake, you can reopen it and carry on.
+
+An episode can span more than one day — for example beginning late one night and
+ending the following afternoon. MigraLog handles this correctly across the whole
+duration.
+
+### 2. The episode timeline — moments within an attack
+
+Inside an ongoing episode you can record events as they occur. Every event is
+timestamped independently and merged into one chronological **Timeline**:
+
+- **Intensity updates** — your pain level on a 0–10 scale, logged as often as it
+  changes. These also drive a sparkline that shows the attack's intensity
+  trajectory at a glance.
+- **Symptoms** — recorded with an onset time, and marked as resolved when they
+  pass (for example, "Nausea — onset" and later "Nausea — resolved").
+- **Pain locations** — where the pain is, and how that changes during the
+  attack.
+- **Medications taken** — rescue and other doses logged against the episode, so
+  you can see exactly when you treated and how the attack responded afterwards.
+- **Notes** — free text for anything else worth remembering.
+
+Because everything shares a single timeline, you can see medication timing,
+symptom changes, and intensity peaks all in relation to one another.
+
+To correct or update an entry, **press and hold** it on the timeline and choose
+to edit it. Nothing is set in stone — if you logged the wrong time, intensity, or
+detail, you can fix it after the fact.
+
+### 3. Daily status — the day-by-day overview
+
+Not every day contains a full migraine, and the days *between* attacks matter
+too. **Daily status** captures each day at a glance:
+
+- Days with an episode are recorded automatically as migraine days.
+- Other days can be logged as **Clear** or **Not Clear** — the latter covering
+  states such as prodrome (warning signs), postdrome (recovery), or anxiety
+  about an attack.
+
+This is the layer you see in the calendar, and it is what turns scattered
+episodes into a long-term picture of how often you are well. See
+[The calendar](calendar.md) for how day status is shown and logged.
+
+## What you are encouraged to capture
+
+You do not have to log everything, and partial records are still useful. But the
+app is most valuable when you treat an episode as a living record:
+
+- Log the **start** as early as you reasonably can.
+- Add an **intensity update** whenever the pain meaningfully changes.
+- Record **medications** at the time you take them.
+- Note **symptoms** as they appear and resolve.
+- **End** the episode when it is over.
+
+Captured this way, your history becomes something you can genuinely learn from —
+and something your clinician can read in minutes. The patterns that emerge are
+covered in [Trends and analytics](trends-and-analytics.md).
+
+## A note on your data
+
+MigraLog treats your records as sensitive health information. Tracking is for
+your own insight and for sharing with your care team on your terms; it is not a
+diagnostic tool and does not replace medical advice.

--- a/user-guide/guide/trends-and-analytics.md
+++ b/user-guide/guide/trends-and-analytics.md
@@ -1,0 +1,114 @@
+# Trends and analytics
+
+The **Trends** area turns your day-to-day logging into a longer view: how often
+attacks happen, how severe they are, when they tend to strike, which symptoms
+recur, and how your medications are working. It also produces a one-page summary
+you can take to a medical appointment.
+
+Nothing here requires extra work — it is built entirely from the episodes,
+medications, and daily statuses you already record. The more consistently you
+log, the more reliable these figures become.
+
+Trends is organised into three views, selected at the top of the screen:
+**Calendar**, **Insights**, and **Med Response**.
+
+## Calendar
+
+The monthly calendar with its colour-coded days, plus overlays for life events.
+This is covered in full in [The calendar](calendar.md).
+
+## Insights
+
+The main analytics view. Choose a time range at the top — **14, 30, 60, or 90
+days**, or a **custom** range — and the charts below update to match.
+
+### At-a-glance counts
+
+- **Day statistics** — how many days in the range were migraine, not-clear,
+  clear, or unlogged.
+- **Duration metrics** — your shortest, longest, and average episode length.
+
+### Warning signs
+
+MigraLog highlights patterns that may be worth attention, based on widely used
+clinical thresholds. These can include:
+
+- **Headache days reaching the chronic range** — 15 or more headache days in a
+  trailing 28-day window (the ICHD-3 definition), or 10–14 days as it approaches.
+- **Medication-overuse risk** — rescue-medication use approaching or exceeding
+  class guidelines (for example, triptans on 10 or more days, or OTC/NSAIDs on 15
+  or more days, in a 28-day window).
+- **Rising rescue use** — a notable increase compared with the previous period.
+- **Increasing intensity** — average peak intensity trending upward.
+
+These are observations to help you and your clinician spot trends. They are not
+diagnoses.
+
+### The charts
+
+- **Headache burden** — headache days in a rolling 28-day window over time, with
+  a reference line at 15 days (the chronic-migraine range).
+- **Medication overuse risk** — for each acute medication class, the trend in
+  the number of days used, against its guideline line.
+- **Severity by week** — episodes each week, stacked and coloured by peak
+  intensity (mild, moderate, severe, very severe), so you can see whether attacks
+  are getting harder independently of how often they occur.
+- **Time of day** — when your episodes tend to begin, grouped into three-hour
+  bands. A consistent onset time can point at causes such as sleep, caffeine, or
+  medication wearing off.
+- **Symptom frequency** — your most common symptoms and the share of episodes
+  each appears in.
+- **Pain location frequency** — where pain is recorded most often across your
+  episodes.
+- **Preventative adherence** — the percentage of your scheduled preventative
+  doses you actually logged, by week.
+- **Monthly summary** — a month-by-month table of episodes, episode days, rescue
+  doses and days, and per-medication use, for a precise reference.
+
+> A note on counting: most trends use a **rolling 28-day window** rather than
+> calendar months, and a "day of use" counts a day on which you took a medication
+> at least once, regardless of how many doses. This matches how overuse
+> guidelines are defined.
+
+## Med Response
+
+This view answers a practical question: **which of my rescue medications works,
+and how quickly?**
+
+- **Time to relief compared** — a ranked chart of how long each rescue
+  medication typically takes to bring your intensity down, measured as the median
+  time from a dose to the first drop in pain. Faster medications appear at the
+  top.
+- **Per-medication detail** — a card for each rescue medication showing its
+  class, how many doses fall in the range, and its median time to relief.
+
+For this to be meaningful, MigraLog needs enough data: a medication needs at
+least **three doses with measurable relief** before it is rated. Logging your
+intensity during an attack, and the medications you take, is what makes this
+view possible.
+
+## The Doctor Visit Summary
+
+From the **Insights** view you can tap **Export Doctor Visit Summary** to
+generate a **one-page PDF** designed for a medical appointment. It always covers
+the **last 30 days and the 6-month trend**, regardless of the range selected on
+screen, so it presents a consistent, clinically useful snapshot.
+
+The summary brings together:
+
+- **The last 30 days at a glance** — headache days, episodes logged, and
+  rescue-medication days.
+- **Headache burden over six months** — a month-by-month table of headache days,
+  flagging months in the chronic range.
+- **Acute / rescue medication** — each rescue medication with its type, dose
+  count, days used, and average dose over the last 30 days.
+- **Preventatives and compliance** — each scheduled preventative with its
+  schedule and how many doses you took against how many were expected.
+
+You can share or print the PDF like any other file — a concise, neutral handout
+that lets a clinician understand your recent history quickly.
+
+---
+
+These views are for insight and for conversations with your care team. MigraLog
+does not diagnose and is not a substitute for medical advice.


### PR DESCRIPTION
Adds a new top-level `user-guide/` folder — the single source for end-user help, intended to compile to both the web and in-app help.

## Pages

- **tracking-philosophy** — the timeline-based tracking model and the three layers (episodes → timeline → daily status); notes press-and-hold to edit timeline entries.
- **medications** — adding a medication; per-medication and per-category cooldowns; medication-overuse safety limits (with a note that the per-med cooldown is independent of the Settings limits, and guidance to consult your neurologist for the right limits).
- **calendar** — the red/green/yellow/grey day-status system, automatic migraine days, logging Clear / Not Clear, and overlays.
- **trends-and-analytics** — Calendar/Insights/Med Response views, the charts and warning signs, and the one-page Doctor Visit Summary PDF export.

Content is grounded in the actual app behaviour (verified against the code), in a clear, calm, clinical voice, with cross-links and non-diagnostic disclaimers. The `README.md` indexes the pages.

Docs-only; no app or website code is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)