### PR TITLE
fix(ios): show migraine duration in minutes, not ticking seconds

### DIFF
--- a/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivity.swift
+++ b/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivity.swift
@@ -38,12 +38,14 @@ struct EpisodeLiveActivity: Widget {
                 .foregroundStyle(tint(for: context.state))
                 .accessibilityHidden(true)
         } compactTrailing: {
-            // No accessibilityLabel here: it would override the live timer's
+            // No accessibilityLabel here: it would override the live duration's
             // spoken value. VoiceOver reads the elapsed time, and the minimal
             // presentation already labels the activity as a migraine episode.
             DurationText(attributes: context.attributes, state: context.state)
                 .font(.caption2.monospacedDigit())
-                .frame(maxWidth: 52)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .frame(maxWidth: 78)
         } minimal: {
             PulsingDot(color: tint(for: context.state))
         }

--- a/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivityComponents.swift
+++ b/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivityComponents.swift
@@ -4,8 +4,13 @@ import WidgetKit
 
 // MARK: - Duration
 
-/// Live-ticking duration. While active it counts up from the episode start via
-/// `Text(_:style:.timer)`; once ended it shows the frozen total.
+/// Live-updating duration. While active it counts up from the episode start via
+/// `Text(_:style:.relative)` — seconds in the first minute, then minutes/hours
+/// (e.g. "6 min", "2 hr, 14 min"). We deliberately avoid `.timer`'s per-second
+/// HH:MM:SS readout: watching it tick for hours during a long migraine is
+/// disheartening, and minute granularity is what matters past the first minute.
+/// `.relative` also self-updates without the host app pushing changes. Once
+/// ended it shows the frozen total in the compact "4h 20m" form.
 struct DurationText: View {
     let attributes: EpisodeActivityAttributes
     let state: EpisodeActivityAttributes.ContentState
@@ -14,7 +19,7 @@ struct DurationText: View {
         if let endedAt = state.endedAt {
             Text(LiveActivityStyle.durationLabel(from: attributes.startDate, to: endedAt))
         } else {
-            Text(attributes.startDate, style: .timer)
+            Text(attributes.startDate, style: .relative)
         }
     }
 }


### PR DESCRIPTION
## What

The active-episode Live Activity rendered elapsed time with `Text(_:style:.timer)` — a per-second `HH:MM:SS` counter. As the user put it: during a migraine that's been going for hours, watching it tick by the second is depressing. Seconds make sense for the first minute or so; after that, minute granularity is what matters.

## Change

- `DurationText` (used by lock screen, compact + expanded Dynamic Island) now uses `Text(_:style:.relative)` for the active state: shows seconds in the first minute, then rolls up to `"6 min"` → `"2 hr, 14 min"`. It self-updates without the host app pushing changes, same as `.timer` did.
- The **ended** state is unchanged — it still freezes to the compact `"4h 20m"` form (`durationLabel`).
- Relaxed the compact Dynamic Island trailing pill width (`52 → 78pt`) and added `lineLimit(1)` + `minimumScaleFactor(0.7)` so the longer relative string fits instead of clipping.

## Notes

- Considered an exact "seconds for first 10 min, then our own `Xh Ym` format" hybrid, but a widget view body can't re-run to flip itself at the 10-min mark, and a host-app push at +10min is unreliable while the phone is suspended in a pocket. `.relative` is the self-updating style that gets the spirit for free.
- Tests: existing `LiveActivityContentStateTests` cover content-state assembly (privacy/medication names), not duration rendering — no changes needed. Build succeeds (app + widget extension).
- Worth a quick on-device glance: the compact Dynamic Island pill with a long relative string (`2 hr, 14 min`) — the scale-factor safety net should handle it, but it's the one tight spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)