### PR TITLE
fix(ios): deep-link "See your trends" tip into Insights, not Calendar

### DIFF
--- a/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
+++ b/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
@@ -129,6 +129,11 @@ final class AppState {
     /// Selection for the Medications split view (iPad regular width).
     var selectedMedicationId: String?
 
+    /// When set, the Trends tab should open on this section instead of its
+    /// default Calendar view (e.g. the "See your trends" tip deep-links to
+    /// Insights). The Trends screens consume and clear it so it fires once.
+    var pendingAnalyticsSection: AnalyticsSection?
+
     /// A surface an open Episode Detail should present once it loads, set when a
     /// Live Activity deep link asks for more than just opening the episode
     /// (log a rescue med, log intensity, or end the episode). `EpisodeDetailScreen`
@@ -145,6 +150,13 @@ final class AppState {
     func showMedication(_ medicationId: String) {
         selectedMedicationId = medicationId
         selectedTab = .medications
+    }
+
+    /// Switch to the Trends tab, optionally opening on a specific section
+    /// (e.g. `.insights`) rather than the default Calendar view.
+    func showTrends(section: AnalyticsSection? = nil) {
+        pendingAnalyticsSection = section
+        selectedTab = .trends
     }
 
     // MARK: - Deep links

--- a/mobile-apps/ios/MigraLog/Views/Analytics/AnalyticsScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Analytics/AnalyticsScreen.swift
@@ -34,6 +34,7 @@ struct AnalyticsSectionPicker: View {
 }
 
 struct AnalyticsScreen: View {
+    @Environment(AppState.self) private var appState
     @State private var viewModel = AnalyticsViewModel()
     @State private var showAddOverlay = false
     @State private var editingOverlay: CalendarOverlay?
@@ -84,6 +85,15 @@ struct AnalyticsScreen: View {
         .accessibilityIdentifier("trends-screen")
         .task {
             await viewModel.fetchData()
+        }
+        // Honor a deep link (e.g. the "See your trends" tip) that asks the
+        // Trends tab to open on a specific section. `initial: true` covers the
+        // first appearance; onChange covers later taps while the tab is alive.
+        .onChange(of: appState.pendingAnalyticsSection, initial: true) { _, section in
+            if let section {
+                selectedSection = section
+                appState.pendingAnalyticsSection = nil
+            }
         }
         .sheet(isPresented: $showAddOverlay, onDismiss: { Task { await viewModel.loadCalendarData(for: Date()) } }) {
             NavigationStack {
@@ -698,6 +708,7 @@ private struct OverlayListContent: View {
 
 /// Calendar and visualizations for the iPad wide pane.
 struct AnalyticsVisualizationPane: View {
+    @Environment(AppState.self) private var appState
     @Bindable var viewModel: AnalyticsViewModel
     @State private var selectedSection: AnalyticsSection = .calendar
 
@@ -726,6 +737,15 @@ struct AnalyticsVisualizationPane: View {
                     }
                 }
                 .padding()
+            }
+        }
+        // Honor a deep link (e.g. the "See your trends" tip) requesting a
+        // specific section. `initial: true` covers the first appearance;
+        // onChange covers later taps while the tab stays alive.
+        .onChange(of: appState.pendingAnalyticsSection, initial: true) { _, section in
+            if let section {
+                selectedSection = section
+                appState.pendingAnalyticsSection = nil
             }
         }
     }

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -222,10 +222,16 @@ struct DashboardScreen: View {
     private func handleTipAction(_ tip: Tip) {
         didYouKnowViewModel.registerAction(on: tip)
         switch tip.cta {
-        case .openCalendar, .openTrends, .exportDoctorSummary:
-            // The Trends tab opens on the calendar; the doctor-summary export
-            // lives at the bottom of that screen.
-            appState.selectedTab = .trends
+        case .openCalendar:
+            appState.showTrends(section: .calendar)
+        case .openTrends:
+            // Deep-link straight to Insights, not the Trends tab's default
+            // Calendar view, so the patterns the tip promises are on screen.
+            appState.showTrends(section: .insights)
+        case .exportDoctorSummary:
+            // The doctor-summary export lives at the bottom of the Trends
+            // screen regardless of section; the default Calendar view is fine.
+            appState.showTrends()
         }
     }
 

--- a/mobile-apps/ios/MigraLogTests/AppStateRoutingTests.swift
+++ b/mobile-apps/ios/MigraLogTests/AppStateRoutingTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import MigraLog
+
+@MainActor
+final class AppStateRoutingTests: XCTestCase {
+    func testShowTrends_defaultsToNoSection() {
+        let appState = AppState()
+        appState.showTrends()
+        XCTAssertEqual(appState.selectedTab, .trends)
+        XCTAssertNil(appState.pendingAnalyticsSection)
+    }
+
+    func testShowTrends_deepLinksToInsights() {
+        // The "See your trends" tip should land on Insights, not the default
+        // Calendar view of the Trends tab.
+        let appState = AppState()
+        appState.showTrends(section: .insights)
+        XCTAssertEqual(appState.selectedTab, .trends)
+        XCTAssertEqual(appState.pendingAnalyticsSection, .insights)
+    }
+
+    func testShowTrends_canTargetCalendar() {
+        let appState = AppState()
+        appState.showTrends(section: .calendar)
+        XCTAssertEqual(appState.selectedTab, .trends)
+        XCTAssertEqual(appState.pendingAnalyticsSection, .calendar)
+    }
+}


### PR DESCRIPTION
## Problem
The "See your trends" contextual tip (`seeTrends`) promised the user *patterns* but its CTA landed them on the Trends tab's default **Calendar** view, not the Insights charts.

## Fix
Route the tip's CTA to the Insights section specifically.

- `AppState` gains `pendingAnalyticsSection` + `showTrends(section:)`, mirroring the existing `showEpisode`/`showMedication` cross-tab navigation pattern.
- `handleTipAction`: `openTrends → .insights`, `openCalendar → .calendar`, `doctorSummary` keeps the default (its export button sits at the bottom of the screen regardless of section).
- Both the iPhone (`AnalyticsScreen`) and iPad (`AnalyticsVisualizationPane`) Trends screens consume and clear the pending section via `onChange(of:initial:true)` — covering both first appearance and later taps while the tab stays alive in the `TabView`.

## Tests
- New `AppStateRoutingTests` locking in the deep-link target.
- Build + `AppStateRoutingTests` / `TipSelectionTests` / `DidYouKnowViewModelTests` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)