### PR TITLE
fix(ios): keep current month flagged partial on its last calendar day

### DIFF
--- a/mobile-apps/ios/MigraLog/Utils/AnalyticsInsights.swift
+++ b/mobile-apps/ios/MigraLog/Utils/AnalyticsInsights.swift
@@ -469,7 +469,12 @@ enum AnalyticsInsights {
         while monthStart < rangeEndExclusive {
             guard let monthEnd = calendar.date(byAdding: .month, value: 1, to: monthStart) else { break }
             let monthKey = monthPrefix(of: monthStart, calendar: calendar)
-            let isPartial = monthStart < rangeStartDay || monthEnd > rangeEndExclusive
+            // A month is partial when the range doesn't fully cover it. Compare
+            // the trailing edge against `to` (not the day-rounded
+            // `rangeEndExclusive`): on the last calendar day of a month the
+            // rounded bound equals `monthEnd`, which would otherwise mark the
+            // still-running current month as complete.
+            let isPartial = monthStart < rangeStartDay || monthEnd > to
 
             let monthStartMs = TimestampHelper.fromDate(max(monthStart, rangeStartDay))
             let monthEndMs = TimestampHelper.fromDate(min(monthEnd, rangeEndExclusive))


### PR DESCRIPTION
## Problem

The `[iOS] Nightly UI suite` failed on 2026-06-30 in `AnalyticsInsightsTests.testMonthlySummaries_countsAndPartialFlags` (`isPartial` was `false`, expected `true`). It passed on prior nights — the failure only reproduces on the **last calendar day of a month**.

## Root cause

In `AnalyticsInsights.monthlySummaries` the partial check was:

```swift
let isPartial = monthStart < rangeStartDay || monthEnd > rangeEndExclusive
```

`rangeEndExclusive` rounds the range end up to the end of `to`'s day (`startOfDay(to) + 1 day`). On the last day of a month that rounded bound equals `monthEnd`, so the still-running current month is marked complete and loses its `*` partial marker in the Trends charts — presented as a full month despite having fewer days of data. This is a real product bug that surfaces once a month, not a flaky test.

## Fix

Compare the trailing edge against `to` directly — a month is complete only once it has fully elapsed relative to now:

```swift
let isPartial = monthStart < rangeStartDay || monthEnd > to
```

Data clipping (`min(monthEnd, rangeEndExclusive)`) is unchanged, so the full final day's data is still counted.

## Verification

All 51 `AnalyticsInsightsTests` pass locally on 2026-06-30 (the triggering date), including the previously-failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)