### PR TITLE
docs(legal): finalize privacy policy (#565)

### DIFF
--- a/legal/privacy-policy.md
+++ b/legal/privacy-policy.md
@@ -11,7 +11,7 @@ you have.
 In plain terms: **your health records stay on your device and in your own iCloud
 account.** We do not run servers that collect them, we do not sell or share them,
 and the only information the app sends anywhere automatically is opt-out
-diagnostic data that has your health details stripped out first.
+diagnostic data that removes health details before sending.
 
 ## Your health data stays on your device
 

--- a/legal/privacy-policy.md
+++ b/legal/privacy-policy.md
@@ -1,56 +1,131 @@
 # Privacy Policy
 
-> **Draft / placeholder.** This document is a starting point and has **not** been
-> reviewed for legal or regulatory compliance. Replace it with a finalized policy
-> before release.
+_Last updated: June 30, 2026_
 
-_Last updated: TBD_
+MigraLog ("the app", "we", "us") helps you track migraines, medications, and
+related health information. Your health information is sensitive, and we have
+built the app to keep it under your control. This policy explains what the app
+stores, the limited information that ever leaves your device, and the choices
+you have.
 
-MigraLog ("the app") helps you track migraines, medications, and related health
-information. We take the privacy of that information seriously. This policy
-explains what the app stores, where it goes, and the choices you have.
+In plain terms: **your health records stay on your device and in your own iCloud
+account.** We do not run servers that collect them, we do not sell or share them,
+and the only information the app sends anywhere automatically is opt-out
+diagnostic data that has your health details stripped out first.
 
 ## Your health data stays on your device
 
-The episodes, medications, daily statuses, and notes you record are stored
-locally on your device. If you enable iCloud Sync, that data is synced through
-**your own private iCloud account** so it is available across your devices. We do
-not operate servers that collect or store your health records.
+The episodes, medications, doses, daily statuses, intensity readings, symptoms,
+triggers, locations, and notes you record are stored locally on your device in
+an encrypted database. We do not operate any server that collects or stores your
+health records.
 
-## Crash and error reporting
+If you turn on **iCloud Sync**, that data is synced through **your own private
+iCloud account** so it is available across your devices. It travels to Apple's
+iCloud under your Apple Account, not to us — we never receive it and cannot read
+it. Sync uses your private iCloud database only; nothing is written to a shared
+or public location. You can turn iCloud Sync on or off in **Settings → Data**.
 
-To find and fix problems, the app can send anonymous crash and error reports.
-These reports **never include your health data** — medication names and doses,
-intensity, symptoms, notes, dates, and locations are removed before anything is
-sent.
+## Diagnostic and crash reporting
 
-You can turn crash reporting off at any time in **Settings → Privacy → Crash
-Reporting**.
+To find and fix crashes, errors, and performance problems, the app can send
+**diagnostic reports** to Sentry, a third-party error- and
+performance-monitoring service that processes this data on our behalf. This is
+the only information the app transmits automatically, and you can turn it off.
+
+These reports can include:
+
+- Crash and error details, including stack traces and the app's internal log
+  messages.
+- App stability and performance diagnostics, and basic usage events such as
+  which screens were visited and that an action occurred — used to reproduce
+  problems. These do **not** include the contents of your entries.
+- Technical information about your device: device model, operating-system
+  version, app version, and general network information (such as your IP
+  address, which can indicate an approximate region). A random identifier is
+  used to group reports from the same app installation; it is not your name and
+  is not linked to your identity.
+
+These reports **never include your health data.** Before anything is sent, the
+app strips out medication names and doses, intensity, pain locations, symptoms,
+triggers, notes, the specific dates and times of episodes or doses, and
+location coordinates. The app also never attaches screenshots, because the
+screen routinely shows health details.
+
+Diagnostic reporting is on by default. You can turn it off at any time in
+**Settings → Privacy → Crash Reporting**; turning it off stops all reporting
+immediately.
 
 ## Location
 
-If you grant location access, the app may attach approximate location to entries
-to help you spot environmental patterns. Location is part of your health record
-and is treated with the same protections; it is never included in crash reports.
-You can disable location in **Settings → Privacy → Location Services**.
+If you grant location access, the app can attach an **approximate** location
+(accurate to roughly 100 metres) to entries to help you spot environmental
+patterns. Location is captured only when you record an entry — the app does not
+track you in the background.
+
+Location is part of your health record: it is stored on your device, synced only
+through your own iCloud account if you enable iCloud Sync, and stripped out of
+diagnostic reports along with the rest of your health data. You can turn location
+off at any time in **Settings → Privacy → Location Services**, and you can also
+revoke the permission in the iOS Settings app.
+
+## Notifications
+
+The app can send you reminders for medications and daily check-ins. These are
+local notifications scheduled on your device. The app does not use push
+notifications and does not send notification tokens or reminder contents to any
+server.
 
 ## What we do not do
 
-- We do not sell your data.
-- We do not use your data for advertising.
-- We do not share your health records with third parties.
+- We do not sell your data or share it with data brokers.
+- We do not use your data for advertising, and the app contains no advertising
+  or marketing trackers.
+- We do not use third-party analytics SDKs.
+- We do not use advertising identifiers (such as the IDFA) and do not track you
+  across other apps or websites.
+- We do not require an account, and we do not assign you a user identity.
+- We do not share your health records with any third party.
 
-## Your choices
+## Your choices and rights
 
-- Turn **Crash Reporting** on or off in Settings → Privacy.
-- Turn **Location Services** on or off in Settings → Privacy.
-- Export or delete your data from **Settings → Data**.
+- **Diagnostic reporting:** turn Crash Reporting on or off in
+  **Settings → Privacy**.
+- **Location:** turn Location Services on or off in **Settings → Privacy**.
+- **iCloud Sync:** turn syncing on or off in **Settings → Data**.
+- **Access and portability:** export your full history as JSON from
+  **Settings → Data → Backup & Export**.
+- **Deletion:** erase everything with **Reset Database** in **Settings**, or
+  delete the app. Because your records live on your device and in your own
+  iCloud account, removing them there removes them — we hold no copy to delete.
+
+Depending on where you live, you may have additional rights over your personal
+information, such as the right to access, correct, export, or delete it (for
+example under the EU/UK GDPR or the California CCPA/CPRA). Because the app keeps
+your health records on your device and in your own iCloud account, you can
+exercise these directly using the controls above. For questions or requests, use
+the contact details below.
+
+## Children
+
+MigraLog is not directed to children under 13 (or the equivalent minimum age in
+your country), and we do not knowingly collect personal information from them.
+
+## A note on health information
+
+MigraLog is a personal tool for your own use; it is not a healthcare provider and
+does not transmit your records to one. We are not acting as a HIPAA "covered
+entity" or "business associate" with respect to the data you keep in the app.
+That said, we treat the health information you enter with care, which is why it
+stays on your device and in your own iCloud account and is removed from
+diagnostic reports.
+
+## Changes to this policy
+
+If we make material changes to this policy, we will update the "Last updated"
+date above and publish the revised policy in the app and at migralog.app.
 
 ## Contact
 
-Questions about this policy can be sent via the contact page at migralog.app.
-
----
-
-_This placeholder will be replaced with a reviewed, finalized privacy policy. The
-same source will publish to migralog.app and ship inside the app._
+Questions or requests about this policy and your data can be sent via the contact
+page at migralog.app.


### PR DESCRIPTION
Closes #565 (policy-content + offsite-data-audit portion).

## What
Final pass on the bundled privacy policy (`legal/privacy-policy.md`, shown in-app at Settings → Privacy → Privacy Policy and intended as the single source for migralog.app). Removed the draft/placeholder callout and set a real "Last updated" date.

## Offsite-data audit (the main ask)
Audited the iOS app for **every automatic / third-party data flow that leaves the device** (excluding user-initiated shares). Findings:

| Flow | Destination | Automatic? |
|---|---|---|
| **Sentry** crash + performance tracing (100%) + profiling + session + user-interaction telemetry | sentry.io | Yes (opt-out) |
| **iCloud / CloudKit** — *private* database only (`iCloud.com.eff3.migralog`) | User's own iCloud | Only if user enables Sync |
| Location (approx ~100m, foreground-only) | Local + private iCloud; **scrubbed from Sentry** | User-initiated |
| GRDB | Local SQLite, no network | — |
| GitHub / license / repo links | User-tapped only | — |

**Sentry is the only automatic egress.** No third-party analytics, no IDFA/ad trackers, no APNs/push token, no user accounts.

### Policy gap this fixes
The old draft described Sentry as only "crash and error reports." With `tracesSampleRate = 1.0`, profiling, auto session tracking, and user-interaction tracing all enabled, it also sends performance/diagnostic + basic usage-interaction telemetry and technical metadata (device model, OS/app version, IP→approx region, per-install identifier). The new "Diagnostic and crash reporting" section states this honestly while keeping and detailing the PHI-never-sent guarantee (`beforeSend` scrubber + screenshots disabled).

Also added explicit no-analytics / no-IDFA / no-ad-trackers / no-account / local-notifications-only statements and brief GDPR/CCPA + HIPAA-context notes, and corrected the Settings paths to the real UI.

## Not in this PR (issue checkboxes that remain)
- [ ] **Formal legal review** — I can't perform this; flagging that the content is engineering-accurate but not lawyer-reviewed.
- [ ] **Publish to migralog.app** (`privacy.html` + footer link) — separate website deploy pipeline; happy to do as a follow-up.

## Discrepancy worth fixing separately
`Info.plist` declares `NSHealthShareUsageDescription` + `NSHealthUpdateUsageDescription`, but there is **zero HealthKit code** in the app — so the App Store will show a Health permission the app never uses. Left out of the policy (won't document a non-existent feature); recommend removing the unused plist keys in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)