### PR TITLE
fix(ios): don't report expected ActivityKit start declines to Sentry (#572)

### DIFF
--- a/mobile-apps/ios/MigraLog/LiveActivity/LiveActivityManager.swift
+++ b/mobile-apps/ios/MigraLog/LiveActivity/LiveActivityManager.swift
@@ -69,6 +69,18 @@ final class LiveActivityManager: LiveActivityManaging {
                 content: ActivityContent(state: state, staleDate: nil),
                 pushType: nil
             )
+        } catch let error as ActivityAuthorizationError {
+            // ActivityKit declined the start. Every code here is an environmental
+            // or user-configuration condition — the app wasn't visible/foreground
+            // at request time (`.visibility`), the user disabled Live Activities
+            // (`.denied`), a system limit was hit, etc. — not a bug. The recovery
+            // path (`ensureActivityForCurrentEpisode()`) retries on the next
+            // foreground, so log locally for diagnostics but don't report it to
+            // Sentry as an error (#572).
+            AppLogger.shared.warn(
+                "Live Activity start declined by ActivityKit",
+                context: ["service": "LiveActivityManager", "code": "\(error)"]
+            )
         } catch {
             ErrorLogger.shared.logError(error, context: ["service": "LiveActivityManager", "action": "start"])
         }

--- a/mobile-apps/ios/MigraLogTests/Utils/AnalyticsInsightsTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Utils/AnalyticsInsightsTests.swift
@@ -834,14 +834,22 @@ final class AnalyticsInsightsTests: XCTestCase {
     // MARK: - monthlyHeadacheDays
 
     func testMonthlyHeadacheDays_bucketsDaysByMonthAndClipsRange() {
-        // Two days this month plus one day 40 days ago (prior month).
-        let days: Set<String> = [dayString(daysAgo: 0), dayString(daysAgo: 1), dayString(daysAgo: 40)]
-        let from = date(daysAgo: 60)
-        let result = AnalyticsInsights.monthlyHeadacheDays(headacheDays: days, from: from, to: now, calendar: calendar)
+        // Anchor to a fixed mid-month reference date rather than the real "now":
+        // the "two days this month" premise fails on the first of a month, where
+        // daysAgo:0 and daysAgo:1 straddle a month boundary and land in separate
+        // buckets. A fixed anchor keeps this deterministic on every run date.
+        let anchor = calendar.date(from: DateComponents(year: 2026, month: 3, day: 15, hour: 12))!
+        func day(_ offset: Int) -> String {
+            TimestampHelper.dateString(from: calendar.date(byAdding: .day, value: offset, to: anchor)!)
+        }
+        // Two days in the anchor month plus one day 40 days earlier (prior month).
+        let days: Set<String> = [day(0), day(-1), day(-40)]
+        let from = calendar.date(byAdding: .day, value: -60, to: anchor)!
+        let result = AnalyticsInsights.monthlyHeadacheDays(headacheDays: days, from: from, to: anchor, calendar: calendar)
 
         XCTAssertEqual(result.map(\.headacheDayCount).reduce(0, +), 3)
-        // The current month's bucket holds the two recent days.
-        let currentMonthKey = String(dayString(daysAgo: 0).prefix(7))
+        // The anchor month's bucket holds the two recent days.
+        let currentMonthKey = String(day(0).prefix(7))
         let currentBucket = result.first { String(TimestampHelper.dateString(from: $0.monthStart).prefix(7)) == currentMonthKey }
         XCTAssertEqual(currentBucket?.headacheDayCount, 2)
     }


### PR DESCRIPTION
## Summary
`LiveActivityManager.start(for:)` was reporting `ActivityAuthorizationError` from `Activity.request` to Sentry as an error. This is the source of **[#572 / MIGRALOG-1B](https://eff3.sentry.io/issues/MIGRALOG-1B)** — `com.apple.ActivityKit.ActivityAuthorization: visibility (Code: 7)`, 12 events across 2 users on build 1.1.206.

`.visibility` means the OS declined the start because the app wasn't in a visible/foreground state at request time — hit on the launch/foreground recovery paths (`reconcileOnLaunch` / `ensureActivityForCurrentEpisode`). That, along with the other `ActivityAuthorizationError` codes (`.denied` = user disabled Live Activities, system-limit codes, etc.), is an **environmental / user-configuration condition, not a bug**. The recovery path already retries the start on the next foreground.

## Change
- Catch `ActivityAuthorizationError` separately in `start(for:)` and log it locally as a warning (with the case name for diagnostics) instead of capturing it to Sentry.
- Genuinely unexpected errors still flow to `ErrorLogger`/Sentry unchanged.

## Testing
- `xcodebuild build` — **BUILD SUCCEEDED** (iPhone 17 Pro, iOS 26.0)
- `LiveActivityContentStateTests` — 4/4 passed
- SwiftLint — no error-level violations

Fixes MIGRALOG-1B
Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)