### PR TITLE
test(ios): retap Start Episode when the sheet-presenting tap is dropped (#580)

### DIFF
--- a/mobile-apps/ios/MigraLogUITests/AccessibilityUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/AccessibilityUITests.swift
@@ -79,15 +79,13 @@ final class AccessibilityUITests: XCTestCase {
         app = UITestHelpers.launchCleanDashboard()
         UITestHelpers.waitForDashboard(in: app)
 
-        // Step 1: Open New Episode screen
+        // Step 1: Open New Episode screen. The button flips a presentation binding,
+        // a tap SwiftUI can drop under reload churn, so retap until the form appears.
         let startButton = app.buttons["start-episode-button"]
-        UITestHelpers.waitForHittable(startButton)
-        startButton.tap()
-        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        let saveButton = app.buttons["save-episode-button"]
+        UITestHelpers.tapToPresent(startButton, expecting: saveButton)
 
         // Step 2: Save button has accessibility label
-        let saveButton = app.buttons["save-episode-button"]
-        UITestHelpers.waitForElement(saveButton)
         XCTAssertTrue(saveButton.isHittable, "Save button should be accessible")
 
         // Step 3: Cancel/back button has accessibility label

--- a/mobile-apps/ios/MigraLogUITests/DailyStatusUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/DailyStatusUITests.swift
@@ -93,11 +93,8 @@ final class DailyStatusUITests: XCTestCase {
         // Step 11: Go to Dashboard, start episode
         UITestHelpers.navigateTo(tab: .dashboard, in: app)
         let startButton = app.buttons["start-episode-button"]
-        UITestHelpers.waitForHittable(startButton)
-        startButton.tap()
-        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
-
         let saveEpisode = app.buttons["save-episode-button"]
+        UITestHelpers.tapToPresent(startButton, expecting: saveEpisode)
         UITestHelpers.waitForHittable(saveEpisode)
         saveEpisode.tap()
         Thread.sleep(forTimeInterval: UITestHelpers.animationWait)

--- a/mobile-apps/ios/MigraLogUITests/EpisodeLifecycleUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/EpisodeLifecycleUITests.swift
@@ -22,14 +22,12 @@ final class EpisodeLifecycleUITests: XCTestCase {
     func testCompleteEpisodeLifecycle() throws {
         // === Phase 1: Create ===
 
-        // Step 1: Tap "Start Episode"
+        // Step 1: Tap "Start Episode" (retap if the sheet-presenting tap is dropped)
         let startButton = app.buttons["start-episode-button"]
-        UITestHelpers.waitForHittable(startButton)
-        startButton.tap()
-        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        let saveButton = app.buttons["save-episode-button"]
+        UITestHelpers.tapToPresent(startButton, expecting: saveButton)
 
         // Step 2: Tap Save (accept defaults)
-        let saveButton = app.buttons["save-episode-button"]
         UITestHelpers.waitForHittable(saveButton)
         saveButton.tap()
         Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
@@ -351,11 +349,9 @@ final class EpisodeLifecycleUITests: XCTestCase {
 
     private func createActiveEpisode() {
         let startButton = app.buttons["start-episode-button"]
-        UITestHelpers.waitForHittable(startButton)
-        startButton.tap()
-        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
-
         let saveButton = app.buttons["save-episode-button"]
+        UITestHelpers.tapToPresent(startButton, expecting: saveButton)
+
         UITestHelpers.waitForHittable(saveButton)
         saveButton.tap()
         Thread.sleep(forTimeInterval: UITestHelpers.animationWait)

--- a/mobile-apps/ios/MigraLogUITests/TrackingOptionsUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/TrackingOptionsUITests.swift
@@ -56,11 +56,8 @@ final class TrackingOptionsUITests: XCTestCase {
 
         // Step 5: Start a new episode and check the trigger chips
         let startButton = app.buttons["start-episode-button"]
-        UITestHelpers.waitForHittable(startButton)
-        startButton.tap()
-
         let saveButton = app.buttons["save-episode-button"]
-        UITestHelpers.waitForElement(saveButton)
+        UITestHelpers.tapToPresent(startButton, expecting: saveButton)
 
         let formList = app.collectionViews.firstMatch.exists
             ? app.collectionViews.firstMatch

--- a/mobile-apps/ios/MigraLogUITests/UITestHelpers.swift
+++ b/mobile-apps/ios/MigraLogUITests/UITestHelpers.swift
@@ -162,6 +162,43 @@ enum UITestHelpers {
         return false
     }
 
+    /// Tap a button that presents a sheet/screen and wait for an element on that
+    /// destination to appear, retapping if it doesn't.
+    ///
+    /// The trigger flips a SwiftUI presentation binding (e.g. `showNewEpisode`)
+    /// rather than performing navigation directly. Under reload churn that tap can
+    /// be dropped — the binding never flips, the sheet never presents, and the
+    /// destination element never appears, failing an otherwise-valid flow within
+    /// the default 5s window (#580 nightly; same dropped-tap class as #488). Retap
+    /// only while the trigger is still hittable: once the sheet is up the trigger
+    /// is covered, so a slow-rendering destination is waited out instead of
+    /// double-presented.
+    static func tapToPresent(
+        _ trigger: XCUIElement,
+        expecting destination: XCUIElement,
+        maxAttempts: Int = 3,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        waitForHittable(trigger, timeout: 15, file: file, line: line)
+        for _ in 0..<maxAttempts {
+            // A covered trigger means a prior tap already presented the sheet; just
+            // keep waiting for the destination rather than tapping the backdrop.
+            if trigger.isHittable {
+                trigger.tap()
+                Thread.sleep(forTimeInterval: animationWait)
+            }
+            if destination.waitForExistence(timeout: defaultTimeout) {
+                return
+            }
+        }
+        XCTFail(
+            "Destination \(destination) did not appear after \(maxAttempts) taps on \(trigger)",
+            file: file,
+            line: line
+        )
+    }
+
     // MARK: - Flexible Element Finding
 
     /// Find an element by accessibility identifier across multiple element types.


### PR DESCRIPTION
## Summary
Fixes the nightly Full UI suite failure in issue #580.

`testFormAccessibility` failed with `save-episode-button did not appear within 5.0s`. The **Start Episode** button flips a SwiftUI presentation binding (`showNewEpisode`) rather than navigating directly; under reload churn that tap can be dropped, so the sheet never presents and the destination element never appears — the same dropped-tap class as #488's `TabView` tap-drop.

## Change
- Add `UITestHelpers.tapToPresent(_:expecting:)` — taps a sheet-presenting button and waits for a destination element, retapping while the trigger is still hittable. Once the sheet is up the trigger is covered, so a slow-rendering destination is waited out instead of double-presented.
- Route the five `Start Episode → Save` open sites (Accessibility, TrackingOptions, DailyStatus, EpisodeLifecycle ×2) through it.

## Verification
Ran locally on iPhone 17 Pro (iOS 26.0):
- `AccessibilityUITests/testFormAccessibility` — passed (7.2s)
- `TrackingOptionsUITests` (both tests, exercising the new helper) — passed
- `** TEST SUCCEEDED **`

🤖 Generated with [Claude Code](https://claude.com/claude-code)