### PR TITLE
fix(ci): limit TestFlight "What to Test" notes to iOS app commits

### DIFF
--- a/.github/scripts/changelog.mjs
+++ b/.github/scripts/changelog.mjs
@@ -4,15 +4,19 @@
 // extra secret. `feat:` commits become a "New" list, `fix:` commits a "Fixed"
 // list; trailing PR refs like "(#486)" are stripped for tester-facing prose.
 //
-// Two classes of commit are dropped as non-tester-facing: those whose scope is
-// in EXCLUDE_SCOPES (default "ci"), and those whose subject matches
-// EXCLUDE_PATTERN (default: test-infrastructure churn).
+// Only commits that touch the iOS app (INCLUDE_PATHS, default "mobile-apps/ios")
+// are eligible — website, tooling, and repo-script changes never reach testers,
+// whatever their scope says. On top of that, two classes of commit are dropped as
+// non-tester-facing: those whose scope is in EXCLUDE_SCOPES (default "ci"), and
+// those whose subject matches EXCLUDE_PATTERN (default: test-infrastructure churn).
 //
 // Used by:
 //   set-beta-notes.mjs      — upload-time notes for a single build (range: prev release..HEAD)
 //   promote-preflight.mjs   — rollup notes at promotion (range: last Pre-flight..promoted build)
 //
 // Env (read once at import):
+//   INCLUDE_PATHS     — optional; comma-separated pathspecs a commit must touch to be
+//                       listed (default "mobile-apps/ios"). Empty string disables the filter.
 //   EXCLUDE_SCOPES    — optional; comma-separated scopes to drop (default "ci")
 //   EXCLUDE_PATTERN   — optional; JS regex (case-insensitive) dropping matching subjects
 
@@ -32,6 +36,11 @@ const excludeScopes = new Set(
     .filter(Boolean),
 );
 const excludePattern = new RegExp(process.env.EXCLUDE_PATTERN || DEFAULT_EXCLUDE_PATTERN, 'i');
+
+const includePaths = (process.env.INCLUDE_PATHS ?? 'mobile-apps/ios')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
 
 function capitalize(s) {
   // Leave camelCase / brand tokens like iCloud, iPad, iOS untouched.
@@ -55,12 +64,16 @@ export function resolveVersionRef(version) {
   return null;
 }
 
-// Generate "What to Test" notes from feat/fix commits in (lowerRef, upperRef].
-// lowerRef null → from the start of history. Returns the notes string, or null
-// when the range contains no tester-facing feat/fix commits.
+// Generate "What to Test" notes from feat/fix commits in (lowerRef, upperRef]
+// that touch INCLUDE_PATHS. lowerRef null → from the start of history. Returns
+// the notes string, or null when the range contains no tester-facing feat/fix
+// commits.
 export function generateNotes(lowerRef, upperRef = 'HEAD') {
   const range = lowerRef ? `${lowerRef}..${upperRef}` : upperRef;
-  const raw = execSync(`git log --no-merges --format=%s ${range}`, { encoding: 'utf8' });
+  const pathspec = includePaths.length
+    ? ` -- ${includePaths.map((p) => `"${p}"`).join(' ')}`
+    : '';
+  const raw = execSync(`git log --no-merges --format=%s ${range}${pathspec}`, { encoding: 'utf8' });
   const subjects = raw.split('\n').map((s) => s.trim()).filter(Boolean);
 
   const features = [];

--- a/.github/scripts/set-beta-notes.mjs
+++ b/.github/scripts/set-beta-notes.mjs
@@ -1,9 +1,9 @@
 // Generates TestFlight "What to Test" notes from the commits since the previous
 // release and writes them to the just-uploaded build's betaBuildLocalizations.
 //
-// Note formatting (conventional-commit parsing, scope/pattern filtering, char
-// limit) lives in changelog.mjs and is shared with the Pre-flight promotion
-// rollup so both surfaces read identically.
+// Note formatting (conventional-commit parsing, iOS path filtering, scope/pattern
+// filtering, char limit) lives in changelog.mjs and is shared with the Pre-flight
+// promotion rollup so both surfaces read identically.
 //
 // Non-fatal by design: "What to Test" is cosmetic, so any failure (ASC hiccup,
 // build slow to process) logs a warning and exits 0 — it never blocks a deploy.
@@ -15,6 +15,7 @@
 //   PREVIOUS_VERSION  — marketing version of the previous release; lower bound for
 //                       the changelog range. Empty on the very first release.
 //   MAX_WAIT_SECONDS  — optional; how long to poll for the build to appear (default 1200)
+//   INCLUDE_PATHS     — optional; see changelog.mjs
 //   EXCLUDE_SCOPES    — optional; see changelog.mjs
 //   EXCLUDE_PATTERN   — optional; see changelog.mjs
 //   ASC_*             — via asc-client
@@ -51,7 +52,7 @@ async function main() {
 
   const notes = generateNotes(lowerRef);
   if (!notes) {
-    console.log('No feat/fix commits in range; leaving "What to Test" unset.');
+    console.log('No tester-facing iOS feat/fix commits in range; leaving "What to Test" unset.');
     return;
   }
   console.log(`Generated "What to Test":\n${notes}`);


### PR DESCRIPTION
## Summary
TestFlight "What to Test" was including every `feat:`/`fix:` commit in the repo — the 1.1.236 build's notes listed "Refresh app screenshots with current Swift build" from a `feat(web)` commit. The filter was an exclude-list (only scope `ci` + test-churn patterns), so any new non-iOS scope leaked through.

## Change
- `changelog.mjs`: only commits touching `mobile-apps/ios/` (configurable via `INCLUDE_PATHS`, comma-separated pathspecs; empty string disables) are eligible for notes. Existing scope/pattern excludes still apply on top.
- Applies to both surfaces sharing `generateNotes`: upload-time notes (`set-beta-notes.mjs`) and the Pre-flight promotion rollup (`promote-preflight.mjs`).

## Verification (against real git history)
- `deploy/1.1.235..deploy/1.1.236` (the range that leaked the web commit) → now produces no notes (left unset)
- `deploy/1.1.230..deploy/1.1.236` → iOS feat/fix commits still listed correctly
- `INCLUDE_PATHS=website` override and `INCLUDE_PATHS=` (filter disabled) both behave as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)