### PR TITLE
feat(ios): add Qulipta + common missing medications to preset catalog

### DIFF
--- a/mobile-apps/ios/MigraLog/Utils/PresetMedications.swift
+++ b/mobile-apps/ios/MigraLog/Utils/PresetMedications.swift
@@ -37,7 +37,8 @@ enum PresetMedications {
         // CGRP
         PresetMedication(name: "Ubrelvy (ubrogepant)", type: .rescue, dosageAmount: 50, dosageUnit: "mg", category: .cgrp, scheduleFrequency: nil),
         PresetMedication(name: "Nurtec (rimegepant)", type: .rescue, dosageAmount: 75, dosageUnit: "mg", category: .cgrp, scheduleFrequency: nil),
-        PresetMedication(name: "Qulipta (atogepant)", type: .preventative, dosageAmount: 60, dosageUnit: "mg", category: .cgrp, scheduleFrequency: .daily),
+        PresetMedication(name: "Qulipta (atogepant) 30 mg", type: .preventative, dosageAmount: 30, dosageUnit: "mg", category: .cgrp, scheduleFrequency: .daily),
+        PresetMedication(name: "Qulipta (atogepant) 60 mg", type: .preventative, dosageAmount: 60, dosageUnit: "mg", category: .cgrp, scheduleFrequency: .daily),
         PresetMedication(name: "Aimovig (erenumab)", type: .preventative, dosageAmount: 70, dosageUnit: "mg", category: .cgrp, scheduleFrequency: .monthly),
         PresetMedication(name: "Ajovy (fremanezumab)", type: .preventative, dosageAmount: 225, dosageUnit: "mg", category: .cgrp, scheduleFrequency: .monthly),
         PresetMedication(name: "Emgality (galcanezumab)", type: .preventative, dosageAmount: 120, dosageUnit: "mg", category: .cgrp, scheduleFrequency: .monthly),

--- a/mobile-apps/ios/MigraLog/Utils/PresetMedications.swift
+++ b/mobile-apps/ios/MigraLog/Utils/PresetMedications.swift
@@ -17,11 +17,18 @@ enum PresetMedications {
         PresetMedication(name: "Rizatriptan", type: .rescue, dosageAmount: 10, dosageUnit: "mg", category: .triptan, scheduleFrequency: nil),
         PresetMedication(name: "Zolmitriptan", type: .rescue, dosageAmount: 2.5, dosageUnit: "mg", category: .triptan, scheduleFrequency: nil),
         PresetMedication(name: "Eletriptan", type: .rescue, dosageAmount: 40, dosageUnit: "mg", category: .triptan, scheduleFrequency: nil),
+        PresetMedication(name: "Naratriptan", type: .rescue, dosageAmount: 2.5, dosageUnit: "mg", category: .triptan, scheduleFrequency: nil),
+        PresetMedication(name: "Frovatriptan", type: .rescue, dosageAmount: 2.5, dosageUnit: "mg", category: .triptan, scheduleFrequency: nil),
+        PresetMedication(name: "Almotriptan", type: .rescue, dosageAmount: 12.5, dosageUnit: "mg", category: .triptan, scheduleFrequency: nil),
+
+        // Ditan (acute — 5-HT1F agonist; no dedicated category)
+        PresetMedication(name: "Reyvow (lasmiditan)", type: .rescue, dosageAmount: 100, dosageUnit: "mg", category: .other, scheduleFrequency: nil),
 
         // NSAIDs
         PresetMedication(name: "Ibuprofen", type: .rescue, dosageAmount: 400, dosageUnit: "mg", category: .nsaid, scheduleFrequency: nil),
         PresetMedication(name: "Naproxen", type: .rescue, dosageAmount: 500, dosageUnit: "mg", category: .nsaid, scheduleFrequency: nil),
         PresetMedication(name: "Aspirin", type: .rescue, dosageAmount: 500, dosageUnit: "mg", category: .nsaid, scheduleFrequency: nil),
+        PresetMedication(name: "Diclofenac", type: .rescue, dosageAmount: 50, dosageUnit: "mg", category: .nsaid, scheduleFrequency: nil),
 
         // OTC
         PresetMedication(name: "Acetaminophen", type: .rescue, dosageAmount: 500, dosageUnit: "mg", category: .otc, scheduleFrequency: nil),
@@ -30,22 +37,33 @@ enum PresetMedications {
         // CGRP
         PresetMedication(name: "Ubrelvy (ubrogepant)", type: .rescue, dosageAmount: 50, dosageUnit: "mg", category: .cgrp, scheduleFrequency: nil),
         PresetMedication(name: "Nurtec (rimegepant)", type: .rescue, dosageAmount: 75, dosageUnit: "mg", category: .cgrp, scheduleFrequency: nil),
+        PresetMedication(name: "Qulipta (atogepant)", type: .preventative, dosageAmount: 60, dosageUnit: "mg", category: .cgrp, scheduleFrequency: .daily),
         PresetMedication(name: "Aimovig (erenumab)", type: .preventative, dosageAmount: 70, dosageUnit: "mg", category: .cgrp, scheduleFrequency: .monthly),
         PresetMedication(name: "Ajovy (fremanezumab)", type: .preventative, dosageAmount: 225, dosageUnit: "mg", category: .cgrp, scheduleFrequency: .monthly),
         PresetMedication(name: "Emgality (galcanezumab)", type: .preventative, dosageAmount: 120, dosageUnit: "mg", category: .cgrp, scheduleFrequency: .monthly),
         PresetMedication(name: "Vyepti (eptinezumab)", type: .preventative, dosageAmount: 100, dosageUnit: "mg", category: .cgrp, scheduleFrequency: .quarterly),
 
+        // Botox (chronic-migraine preventive; ~every 12 weeks)
+        PresetMedication(name: "Botox (onabotulinumtoxinA)", type: .preventative, dosageAmount: 155, dosageUnit: "units", category: .preventive, scheduleFrequency: .quarterly),
+
         // Preventive
         PresetMedication(name: "Topiramate", type: .preventative, dosageAmount: 50, dosageUnit: "mg", category: .preventive, scheduleFrequency: .daily),
         PresetMedication(name: "Propranolol", type: .preventative, dosageAmount: 80, dosageUnit: "mg", category: .preventive, scheduleFrequency: .daily),
+        PresetMedication(name: "Metoprolol", type: .preventative, dosageAmount: 50, dosageUnit: "mg", category: .preventive, scheduleFrequency: .daily),
         PresetMedication(name: "Amitriptyline", type: .preventative, dosageAmount: 25, dosageUnit: "mg", category: .preventive, scheduleFrequency: .daily),
+        PresetMedication(name: "Nortriptyline", type: .preventative, dosageAmount: 25, dosageUnit: "mg", category: .preventive, scheduleFrequency: .daily),
         PresetMedication(name: "Venlafaxine", type: .preventative, dosageAmount: 75, dosageUnit: "mg", category: .preventive, scheduleFrequency: .daily),
         PresetMedication(name: "Valproate", type: .preventative, dosageAmount: 500, dosageUnit: "mg", category: .preventive, scheduleFrequency: .daily),
+        PresetMedication(name: "Gabapentin", type: .preventative, dosageAmount: 300, dosageUnit: "mg", category: .preventive, scheduleFrequency: .daily),
+        PresetMedication(name: "Candesartan", type: .preventative, dosageAmount: 8, dosageUnit: "mg", category: .preventive, scheduleFrequency: .daily),
 
         // Supplements
         PresetMedication(name: "Magnesium", type: .preventative, dosageAmount: 400, dosageUnit: "mg", category: .supplement, scheduleFrequency: .daily),
         PresetMedication(name: "Riboflavin (B2)", type: .preventative, dosageAmount: 400, dosageUnit: "mg", category: .supplement, scheduleFrequency: .daily),
         PresetMedication(name: "CoQ10", type: .preventative, dosageAmount: 100, dosageUnit: "mg", category: .supplement, scheduleFrequency: .daily),
+        PresetMedication(name: "Melatonin", type: .preventative, dosageAmount: 3, dosageUnit: "mg", category: .supplement, scheduleFrequency: .daily),
+        PresetMedication(name: "Feverfew", type: .preventative, dosageAmount: 100, dosageUnit: "mg", category: .supplement, scheduleFrequency: .daily),
+        PresetMedication(name: "Butterbur", type: .preventative, dosageAmount: 75, dosageUnit: "mg", category: .supplement, scheduleFrequency: .daily),
     ]
 
     static func search(_ query: String) -> [PresetMedication] {


### PR DESCRIPTION
## Summary

Adds **Qulipta (atogepant)** to the medication preset catalog — it was missing entirely — and, per request, audits the catalog for other commonly prescribed migraine medications and fills the notable gaps.

The catalog lives in `PresetMedications.swift` as a compiled-in Swift array (no DB/JSON seed), so this is a pure data addition.

## What was added (14 medications)

| Category | Added | Notes |
|---|---|---|
| Gepant (preventive) | **Qulipta (atogepant)** 60 mg daily | Requested — first daily oral preventive gepant; categorized `.cgrp` like the other gepants |
| Triptans | Naratriptan, Frovatriptan, Almotriptan | Completes the common triptan class (had 4 of 7) |
| Ditan (acute) | Reyvow (lasmiditan) 100 mg | New 5-HT1F acute class; no dedicated category exists → `.other` |
| NSAID | Diclofenac 50 mg | FDA-approved for acute migraine (Cambia) |
| Preventive (injectable) | **Botox (onabotulinumtoxinA)** 155 units, ~q12w | Major gap — standard chronic-migraine preventive |
| Preventives (oral) | Metoprolol, Nortriptyline, Gabapentin, Candesartan | Common beta-blocker / TCA / off-label / ARB |
| Supplements | Melatonin, Feverfew, Butterbur | Common evidence-supported supplements |

Doses use standard/typical starting values. All entries satisfy the existing `PresetMedicationsTests` invariants (unique names, positive dose, category present, preventatives have a frequency, rescues have none).

## Notes / judgment calls
- **Category coverage gaps in the model** (not changed here): there is no dedicated `gepant` or `ditan` category. Gepants continue to be filed under `.cgrp` (matching existing Ubrelvy/Nurtec), and lasmiditan lands in `.other`. If you'd prefer new categories, that's a follow-up.
- Botox is filed as `.preventive` (it isn't CGRP) with `.quarterly` frequency (the closest option to every-12-weeks).

## Test
`xcodebuild test -only-testing:MigraLogTests/PresetMedicationsTests` → **21 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)