### PR TITLE
feat(ios): let users exclude medications from category safety warnings

### DIFF
--- a/mobile-apps/ios/.claude/skills/verify/SKILL.md
+++ b/mobile-apps/ios/.claude/skills/verify/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: verify
+description: Verify iOS app changes end-to-end by driving the simulator UI via XCUITest and capturing screenshot evidence. Use after changing MigraLog product code.
+---
+
+# Verifying MigraLog iOS changes at runtime
+
+The runtime surface is the iOS simulator UI. The repo's handle for driving it
+is **XCUITest** (`MigraLogUITests`), which already has launch-arg fixtures and
+navigation helpers — write (or extend) a UI test for the flow, run it, and
+export its screenshots as evidence.
+
+## Build / run
+
+```bash
+cd mobile-apps/ios
+xcodegen generate   # no committed .xcodeproj; required in fresh worktrees
+env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+    PATH="/Applications/Xcode.app/Contents/Developer/usr/bin:$PATH" \
+    xcodebuild test -scheme MigraLog \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' \
+    -only-testing:MigraLogUITests/<YourTestClass> \
+    -resultBundlePath /tmp/verify.xcresult
+```
+
+- `DEVELOPER_DIR` is required (machine default is CommandLineTools) and the
+  PATH prefix keeps `simctl` findable for the test runner.
+- Simulator OS is 26.5 even though CLAUDE.md says 26.0.
+
+## Driving the app
+
+- `UITestHelpers.launchWithFixtures()` launches with `--uitesting
+  --load-fixtures` (onboarding skipped; seeds Test Topiramate, Test Magnesium,
+  Test Ibuprofen [category otc] + one closed episode). Fixture data lives in
+  `MigraLog/App/MigraLogApp.swift` (`loadFixtureData`).
+- Navigation: `UITestHelpers.navigateTo(tab:in:)`; Settings is the
+  `settings-button` gear on the Dashboard, not a tab.
+- SwiftUI Form pickers render as menu buttons: tap the picker's identifier,
+  then tap the option's label text.
+- Sheets with `.presentationDetents([.medium, .large])` open at medium and
+  Forms are lazy — off-screen rows don't exist in the hierarchy yet. Swipe up
+  (`app.swipeUp()`) to expand the detent, then
+  `UITestHelpers.scrollToElement(_:in: app.collectionViews.firstMatch)`.
+- Rescue-med "Log Dose" opens a confirmation sheet — tap its `Log` button;
+  preventative meds log immediately.
+- System permission alerts: `UITestHelpers.handleSystemAlert(in:buttonLabel:)`.
+
+## Evidence
+
+Attach screenshots in the test (`XCTAttachment(screenshot: app.screenshot())`,
+`lifetime = .keepAlways`, set `.name`), then export:
+
+```bash
+xcrun xcresulttool export attachments --path /tmp/verify.xcresult \
+    --output-path /tmp/verify-att   # manifest.json maps names → files
+```
+
+Every failed run also auto-records an .mp4 of the whole session (no local
+ffmpeg to grab frames — prefer named screenshot attachments). A teardown block
+that attaches a final screenshot makes stall failures diagnosable.

--- a/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
+++ b/mobile-apps/ios/MigraLog/App/MigraLogApp.swift
@@ -307,11 +307,13 @@ final class AppState {
                     VALUES (?, ?, '08:00', ?, 1.0, 1, 1)
                     """, arguments: [magScheduleId, magId, TimeZone.current.identifier])
 
-                // Create rescue medication: Test Ibuprofen (400mg, as needed)
+                // Create rescue medication: Test Ibuprofen (400mg, as needed).
+                // Categorized (otc) so category safety-rule UI tests have a medication
+                // to list in the rule editor's inclusion checklist.
                 let ibuId = "fixture-med-ibuprofen"
                 try database.execute(sql: """
-                    INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, default_quantity, active, created_at, updated_at)
-                    VALUES (?, 'Test Ibuprofen', 'rescue', 400.0, 'mg', 1.0, 1, ?, ?)
+                    INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, default_quantity, active, category, created_at, updated_at)
+                    VALUES (?, 'Test Ibuprofen', 'rescue', 400.0, 'mg', 1.0, 1, 'otc', ?, ?)
                     """, arguments: [ibuId, now, now])
 
                 // Create closed episode from yesterday (4h duration, intensity 3->7->4)

--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager+Schema.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager+Schema.swift
@@ -6,7 +6,7 @@ import GRDB
 // queue ownership and the migration registry (and under the file_length limit).
 extension DatabaseManager {
     /// Create the v25 baseline schema. Later registered migrations evolve it to the
-    /// current version; see spec/schemas/sqlite/schema-v36.sql for the current end-state.
+    /// current version; see spec/schemas/sqlite/schema-v37.sql for the current end-state.
     // swiftlint:disable:next function_body_length
     static func createSchema(in db: Database) throws {
         // Episodes table
@@ -99,7 +99,8 @@ extension DatabaseManager {
                 category TEXT CHECK(category IS NULL OR category IN ('otc', 'nsaid', 'triptan', 'cgrp', 'preventive', 'supplement', 'other')),
                 created_at INTEGER NOT NULL CHECK(created_at > 0),
                 updated_at INTEGER NOT NULL CHECK(updated_at > 0),
-                min_interval_hours REAL CHECK(min_interval_hours IS NULL OR min_interval_hours > 0)
+                min_interval_hours REAL CHECK(min_interval_hours IS NULL OR min_interval_hours > 0),
+                excluded_from_safety_warnings INTEGER CHECK(excluded_from_safety_warnings IS NULL OR excluded_from_safety_warnings IN (0, 1))
             )
             """)
 

--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -24,7 +24,7 @@ enum DatabaseInitializationError: Error {
 /// Central database manager. Owns the DatabaseQueue and handles schema creation/migration.
 final class DatabaseManager: Sendable {
     /// The current schema version
-    static let schemaVersion = 36
+    static let schemaVersion = 37
 
     /// Shared singleton for the app's main database
     static let shared = DatabaseManager()
@@ -350,6 +350,30 @@ final class DatabaseManager: Sendable {
         // backfill rows synced before the upgrade.
         migrator.registerMigration("v36") { db in
             try DatabaseManager.addLastSyncedSchemaColumn(in: db)
+        }
+
+        // v37: add `excluded_from_safety_warnings` to medications — user-controlled
+        // opt-out of a medication's doses counting toward its category's safety
+        // warnings (e.g. a daily preventative CGRP shouldn't trip the CGRP usage
+        // limit). Nullable so sync payloads from older app versions still apply
+        // (see spec/ios/icloud-sync.md). The synced-column change means the
+        // DELETE-capture triggers must be rebuilt with the new column baked in
+        // (v34 precedent).
+        migrator.registerMigration("v37") { db in
+            let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(medications)")
+            let hasColumn = columns.contains { (row: Row) in
+                (row["name"] as String?) == "excluded_from_safety_warnings"
+            }
+            if !hasColumn {
+                try db.execute(sql: "ALTER TABLE medications ADD COLUMN excluded_from_safety_warnings INTEGER CHECK(excluded_from_safety_warnings IS NULL OR excluded_from_safety_warnings IN (0, 1))")
+            }
+            // createSyncCaptureTriggers uses CREATE TRIGGER IF NOT EXISTS, so the
+            // stale medications triggers must be dropped first or upgrades keep
+            // the old column list (v34 precedent).
+            for suffix in ["insert", "update", "delete"] {
+                try db.execute(sql: "DROP TRIGGER IF EXISTS sync_capture_medications_\(suffix)")
+            }
+            try DatabaseManager.createSyncCaptureTriggers(in: db, includePayload: true)
         }
 
         return migrator

--- a/mobile-apps/ios/MigraLog/Models/DomainModels.swift
+++ b/mobile-apps/ios/MigraLog/Models/DomainModels.swift
@@ -103,6 +103,10 @@ struct Medication: Identifiable, Equatable, Sendable {
     var notes: String?
     var category: MedicationCategory?
     var minIntervalHours: Double?
+    /// When true, this medication's doses don't count toward its category's
+    /// safety warnings (usage limits and cooldowns), and those warnings are not
+    /// shown on this medication. User-controlled per category rule editor.
+    var excludedFromSafetyWarnings: Bool = false
     let createdAt: Int64
     var updatedAt: Int64
 }

--- a/mobile-apps/ios/MigraLog/Repositories/CategorySafetyRuleRepository.swift
+++ b/mobile-apps/ios/MigraLog/Repositories/CategorySafetyRuleRepository.swift
@@ -121,6 +121,7 @@ final class CategorySafetyRuleRepository: CategorySafetyRuleRepositoryProtocol {
                     FROM medication_doses d
                     INNER JOIN medications m ON m.id = d.medication_id
                     WHERE m.category = ?
+                      AND COALESCE(m.excluded_from_safety_warnings, 0) = 0
                       AND d.status = 'taken'
                       AND d.timestamp >= ?
                       AND d.timestamp <= ?

--- a/mobile-apps/ios/MigraLog/Repositories/MedicationRepository.swift
+++ b/mobile-apps/ios/MigraLog/Repositories/MedicationRepository.swift
@@ -18,8 +18,8 @@ final class MedicationRepository: MedicationRepositoryProtocol {
                 sql: """
                     INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, default_quantity,
                         schedule_frequency, photo_uri, active, notes, category, created_at, updated_at,
-                        min_interval_hours)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        min_interval_hours, excluded_from_safety_warnings)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                 arguments: [
                     medication.id,
@@ -35,7 +35,8 @@ final class MedicationRepository: MedicationRepositoryProtocol {
                     medication.category?.rawValue,
                     medication.createdAt,
                     medication.updatedAt,
-                    medication.minIntervalHours
+                    medication.minIntervalHours,
+                    medication.excludedFromSafetyWarnings ? 1 : 0
                 ]
             )
         }
@@ -87,7 +88,7 @@ final class MedicationRepository: MedicationRepositoryProtocol {
                         name = ?, type = ?, dosage_amount = ?, dosage_unit = ?,
                         default_quantity = ?, schedule_frequency = ?, photo_uri = ?,
                         active = ?, notes = ?, category = ?, updated_at = ?,
-                        min_interval_hours = ?
+                        min_interval_hours = ?, excluded_from_safety_warnings = ?
                     WHERE id = ?
                     """,
                 arguments: [
@@ -103,6 +104,7 @@ final class MedicationRepository: MedicationRepositoryProtocol {
                     updated.category?.rawValue,
                     updated.updatedAt,
                     updated.minIntervalHours,
+                    updated.excludedFromSafetyWarnings ? 1 : 0,
                     updated.id
                 ]
             )
@@ -212,6 +214,7 @@ final class MedicationRepository: MedicationRepositoryProtocol {
                     FROM medication_doses d
                     INNER JOIN medications m ON m.id = d.medication_id
                     WHERE m.category = ?
+                      AND COALESCE(m.excluded_from_safety_warnings, 0) = 0
                       AND d.status = 'taken'
                       AND d.timestamp <= ?
                     ORDER BY d.timestamp DESC
@@ -468,6 +471,7 @@ final class MedicationRepository: MedicationRepositoryProtocol {
             notes: row["notes"],
             category: (row["category"] as String?).flatMap { MedicationCategory(rawValue: $0) },
             minIntervalHours: row["min_interval_hours"],
+            excludedFromSafetyWarnings: ((row["excluded_from_safety_warnings"] as Int?) ?? 0) != 0,
             createdAt: row["created_at"],
             updatedAt: row["updated_at"]
         )

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncableTable.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncableTable.swift
@@ -85,7 +85,8 @@ enum SyncableTable: String, CaseIterable, Sendable {
         case .medications:
             return ["id", "name", "type", "dosage_amount", "dosage_unit", "default_quantity",
                     "schedule_frequency", "photo_uri", "active", "notes", "category",
-                    "created_at", "updated_at", "min_interval_hours"]
+                    "created_at", "updated_at", "min_interval_hours",
+                    "excluded_from_safety_warnings"]
         case .medicationSchedules:
             // notification_id is excluded (deviceLocalColumns).
             return ["id", "medication_id", "time", "timezone", "dosage", "enabled",

--- a/mobile-apps/ios/MigraLog/ViewModels/CategorySafetyRulesViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/CategorySafetyRulesViewModel.swift
@@ -9,14 +9,20 @@ import Observation
 final class CategorySafetyRulesViewModel {
     /// All configured rules, sorted by `(category, type)` to match the list UI.
     var rules: [CategorySafetyRule] = []
+    /// Active medications grouped by category, backing the rule editor's
+    /// per-category inclusion checklist.
+    var medicationsByCategory: [MedicationCategory: [Medication]] = [:]
     var error: String?
 
     private let repository: CategorySafetyRuleRepositoryProtocol
+    private let medicationRepository: MedicationRepositoryProtocol
 
     init(
-        repository: CategorySafetyRuleRepositoryProtocol = CategorySafetyRuleRepository(dbManager: DatabaseManager.shared)
+        repository: CategorySafetyRuleRepositoryProtocol = CategorySafetyRuleRepository(dbManager: DatabaseManager.shared),
+        medicationRepository: MedicationRepositoryProtocol = MedicationRepository(dbManager: DatabaseManager.shared)
     ) {
         self.repository = repository
+        self.medicationRepository = medicationRepository
     }
 
     /// Categories with at least one rule type still unconfigured.
@@ -37,21 +43,51 @@ final class CategorySafetyRulesViewModel {
         do {
             let all = try repository.getAllRules()
             rules = sorted(all)
+            var grouped: [MedicationCategory: [Medication]] = [:]
+            for medication in try medicationRepository.getActiveMedications() {
+                guard let category = medication.category else { continue }
+                grouped[category, default: []].append(medication)
+            }
+            medicationsByCategory = grouped
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "CategorySafetyRulesViewModel", "action": "loadRules"])
             self.error = error.localizedDescription
         }
     }
 
-    func saveRule(_ rule: CategorySafetyRule) {
+    /// Persists the rule plus the category's medication exclusion checklist.
+    /// `excludedMedicationIds` is the complete set of excluded medications for
+    /// the rule's category; any medication whose flag differs is updated (which
+    /// bumps `updated_at`, so the change syncs).
+    func saveRule(_ rule: CategorySafetyRule, excludedMedicationIds: Set<String> = []) {
         do {
             try repository.upsert(rule)
             rules.removeAll { $0.category == rule.category && $0.type == rule.type }
             rules.append(rule)
             rules = sorted(rules)
+            try applyExclusions(excludedMedicationIds, for: rule.category)
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "CategorySafetyRulesViewModel", "action": "saveRule"])
             self.error = error.localizedDescription
+        }
+    }
+
+    private func applyExclusions(_ excludedIds: Set<String>, for category: MedicationCategory) throws {
+        guard let medications = medicationsByCategory[category] else { return }
+        var changedAny = false
+        var updatedList = medications
+        for (index, medication) in medications.enumerated() {
+            let shouldExclude = excludedIds.contains(medication.id)
+            guard medication.excludedFromSafetyWarnings != shouldExclude else { continue }
+            var updated = medication
+            updated.excludedFromSafetyWarnings = shouldExclude
+            updatedList[index] = try medicationRepository.updateMedication(updated)
+            changedAny = true
+        }
+        if changedAny {
+            medicationsByCategory[category] = updatedList
+            // Dashboard / Log Medication recompute their category warnings on this.
+            NotificationCenter.default.post(name: .medicationDataChanged, object: nil)
         }
     }
 

--- a/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
@@ -316,6 +316,15 @@ final class DashboardViewModel {
         return items
     }
 
+    /// Category usage status to show on a specific medication's row. Excluded
+    /// medications never show their category's warning.
+    func categoryUsageStatus(for medication: Medication) -> CategoryUsageStatus {
+        guard !medication.excludedFromSafetyWarnings, let category = medication.category else {
+            return .noLimit
+        }
+        return categoryUsage[category] ?? .noLimit
+    }
+
     /// Computes the `CategoryUsageStatus` map for the given categories. Categories
     /// without a configured limit are omitted.
     private func computeCategoryUsage(
@@ -345,7 +354,7 @@ final class DashboardViewModel {
     ) -> [String: CategoryCooldown.Status] {
         var result: [String: CategoryCooldown.Status] = [:]
         for med in medications {
-            guard let category = med.category else { continue }
+            guard let category = med.category, !med.excludedFromSafetyWarnings else { continue }
             let rule = try? categoryLimitRepository.getRule(category: category, type: .cooldown)
             let last = try? medicationRepository.getLastTakenDoseInCategory(category, now: now)
             result[med.id] = CategoryCooldown.evaluate(

--- a/mobile-apps/ios/MigraLog/ViewModels/LogMedicationViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/LogMedicationViewModel.swift
@@ -55,6 +55,15 @@ final class LogMedicationViewModel {
         }
     }
 
+    /// Category usage status to show on a specific medication's row. Excluded
+    /// medications never show their category's warning.
+    func categoryUsageStatus(for medication: Medication) -> CategoryUsageStatus {
+        guard !medication.excludedFromSafetyWarnings, let category = medication.category else {
+            return .noLimit
+        }
+        return categoryUsage[category] ?? .noLimit
+    }
+
     /// Computes the `CategoryUsageStatus` map for the given categories.
     private func computeCategoryUsage(
         for categories: Set<MedicationCategory>,
@@ -82,7 +91,7 @@ final class LogMedicationViewModel {
     ) -> [String: CategoryCooldown.Status] {
         var result: [String: CategoryCooldown.Status] = [:]
         for med in medications {
-            guard let category = med.category else { continue }
+            guard let category = med.category, !med.excludedFromSafetyWarnings else { continue }
             let rule = try? categoryLimitRepository.getRule(category: category, type: .cooldown)
             let last = try? medicationRepository.getLastTakenDoseInCategory(category, now: now)
             result[med.id] = CategoryCooldown.evaluate(

--- a/mobile-apps/ios/MigraLog/ViewModels/MedicationDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/MedicationDetailViewModel.swift
@@ -112,7 +112,8 @@ final class MedicationDetailViewModel {
     /// Computes category MOH status for the given medication (if it has a category
     /// and a configured limit). Returns `.noLimit` otherwise.
     private func computeCategoryStatus(for medication: Medication?, now: Date) -> CategoryUsageStatus {
-        guard let category = medication?.category else { return .noLimit }
+        guard let medication, !medication.excludedFromSafetyWarnings,
+              let category = medication.category else { return .noLimit }
         guard let configured = (try? categoryLimitRepository.getRule(category: category, type: .periodLimit)) ?? nil else {
             return .noLimit
         }
@@ -135,7 +136,8 @@ final class MedicationDetailViewModel {
     /// Computes category cooldown status for the given medication. Returns an
     /// empty status when the medication has no category or evaluation fails.
     private func computeCategoryCooldown(for medication: Medication?, now: Date) -> CategoryCooldown.Status {
-        guard let category = medication?.category else { return Self.emptyCategoryCooldown }
+        guard let medication, !medication.excludedFromSafetyWarnings,
+              let category = medication.category else { return Self.emptyCategoryCooldown }
         let rule = try? categoryLimitRepository.getRule(category: category, type: .cooldown)
         let last = try? medicationRepository.getLastTakenDoseInCategory(category, now: now)
         return CategoryCooldown.evaluate(

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -427,8 +427,7 @@ struct MedicationScheduleRow: View {
     }
 
     private var categoryStatus: CategoryUsageStatus {
-        guard let category = item.medication.category else { return .noLimit }
-        return viewModel.categoryUsage[category] ?? .noLimit
+        viewModel.categoryUsageStatus(for: item.medication)
     }
 
     var body: some View {

--- a/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Medications/LogMedicationScreen.swift
@@ -56,7 +56,7 @@ struct LogMedicationScreen: View {
                 LogMedicationDetailSheet(
                     medication: med,
                     lastDose: viewModel.lastDoseByMedication[med.id],
-                    categoryStatus: med.category.flatMap { viewModel.categoryUsage[$0] } ?? .noLimit,
+                    categoryStatus: viewModel.categoryUsageStatus(for: med),
                     categoryCooldown: viewModel.categoryCooldowns[med.id]
                 ) { dose in
                     Task {
@@ -113,7 +113,7 @@ struct LogMedicationScreen: View {
         LogMedicationCard(
             medication: med,
             lastDose: viewModel.lastDoseByMedication[med.id],
-            categoryStatus: med.category.flatMap { viewModel.categoryUsage[$0] } ?? .noLimit,
+            categoryStatus: viewModel.categoryUsageStatus(for: med),
             categoryCooldown: viewModel.categoryCooldowns[med.id],
             onQuickLog: {
                 Task {

--- a/mobile-apps/ios/MigraLog/Views/Settings/CategorySafetyRuleEditorSheet.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/CategorySafetyRuleEditorSheet.swift
@@ -5,6 +5,10 @@ import SwiftUI
 /// (category → addable types) options; the form auto-fills with the category's
 /// preset for the chosen type when one exists. In edit mode both category and
 /// type are locked.
+///
+/// Also exposes the category's medication checklist: unchecking a medication
+/// excludes its doses from ALL safety warnings for the category (both rule
+/// types) and hides those warnings on that medication.
 struct CategorySafetyRuleEditorSheet: View {
     enum Mode: Equatable {
         case add(available: [MedicationCategory: [CategorySafetyRuleType]])
@@ -12,7 +16,9 @@ struct CategorySafetyRuleEditorSheet: View {
     }
 
     let mode: Mode
-    let onSave: (CategorySafetyRule) -> Void
+    /// Active medications grouped by category, backing the checklist.
+    var medicationsByCategory: [MedicationCategory: [Medication]] = [:]
+    let onSave: (CategorySafetyRule, Set<String>) -> Void
 
     @Environment(\.dismiss) private var dismiss
 
@@ -22,6 +28,7 @@ struct CategorySafetyRuleEditorSheet: View {
     @State private var maxDaysText: String = ""
     @State private var windowDaysText: String = ""
     @State private var cooldownHoursText: String = ""
+    @State private var excludedMedicationIds: Set<String> = []
 
     var body: some View {
         NavigationStack {
@@ -30,6 +37,7 @@ struct CategorySafetyRuleEditorSheet: View {
                 typeSection
                 if resolvedType == .periodLimit { periodLimitSection }
                 if resolvedType == .cooldown { cooldownSection }
+                medicationsSection
             }
             .navigationTitle(navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
@@ -45,7 +53,7 @@ struct CategorySafetyRuleEditorSheet: View {
                 }
             }
             .onAppear(perform: configureInitialState)
-            .presentationDetents([.medium])
+            .presentationDetents([.medium, .large])
         }
     }
 
@@ -63,9 +71,10 @@ struct CategorySafetyRuleEditorSheet: View {
                     }
                 }
                 .accessibilityIdentifier("rule-editor-category-picker")
-                .onChange(of: selectedCategory) { _, _ in
+                .onChange(of: selectedCategory) { _, newValue in
                     selectedType = nil
                     clearFormFields()
+                    seedExcludedMedications(for: newValue)
                 }
             }
         case .edit(let existing):
@@ -156,6 +165,42 @@ struct CategorySafetyRuleEditorSheet: View {
         }
     }
 
+    /// Checklist of the category's medications. Unchecked medications are
+    /// excluded from every safety warning for the category.
+    @ViewBuilder
+    private var medicationsSection: some View {
+        if let category = resolvedCategory,
+           let medications = medicationsByCategory[category],
+           !medications.isEmpty {
+            Section {
+                ForEach(medications) { medication in
+                    Button {
+                        toggleExcluded(medication.id)
+                    } label: {
+                        HStack {
+                            Text(medication.name)
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            Image(systemName: excludedMedicationIds.contains(medication.id)
+                                  ? "circle" : "checkmark.circle.fill")
+                                .foregroundStyle(excludedMedicationIds.contains(medication.id)
+                                                 ? Color.secondary : Color.accentColor)
+                        }
+                    }
+                    .accessibilityIdentifier("rule-editor-medication-\(medication.id)")
+                    .accessibilityAddTraits(excludedMedicationIds.contains(medication.id) ? [] : [.isSelected])
+                }
+            } header: {
+                Text("Included Medications")
+            } footer: {
+                // swiftlint:disable:next line_length
+                Text("Unchecked medications don't count toward \(category.displayName) warnings and won't show them — e.g. a daily preventative you don't want counted. Applies to all \(category.displayName) safety rules.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
     // MARK: - Derived state
 
     private var navigationTitle: String {
@@ -224,6 +269,24 @@ struct CategorySafetyRuleEditorSheet: View {
             case .cooldown:
                 cooldownHoursText = formatHours(existing.periodHours)
             }
+            seedExcludedMedications(for: existing.category)
+        }
+    }
+
+    /// Seeds the checklist from the medications' current exclusion flags.
+    private func seedExcludedMedications(for category: MedicationCategory?) {
+        guard let category, let medications = medicationsByCategory[category] else {
+            excludedMedicationIds = []
+            return
+        }
+        excludedMedicationIds = Set(medications.filter(\.excludedFromSafetyWarnings).map(\.id))
+    }
+
+    private func toggleExcluded(_ medicationId: String) {
+        if excludedMedicationIds.contains(medicationId) {
+            excludedMedicationIds.remove(medicationId)
+        } else {
+            excludedMedicationIds.insert(medicationId)
         }
     }
 
@@ -286,7 +349,7 @@ struct CategorySafetyRuleEditorSheet: View {
             )
         }
 
-        onSave(rule)
+        onSave(rule, excludedMedicationIds)
         dismiss()
     }
 

--- a/mobile-apps/ios/MigraLog/Views/Settings/CategorySafetyRulesScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/CategorySafetyRulesScreen.swift
@@ -31,8 +31,11 @@ struct CategorySafetyRulesScreen: View {
             }
         }
         .sheet(item: $editorMode) { mode in
-            CategorySafetyRuleEditorSheet(mode: mode) { rule in
-                viewModel.saveRule(rule)
+            CategorySafetyRuleEditorSheet(
+                mode: mode,
+                medicationsByCategory: viewModel.medicationsByCategory
+            ) { rule, excludedMedicationIds in
+                viewModel.saveRule(rule, excludedMedicationIds: excludedMedicationIds)
             }
         }
         .task {

--- a/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
@@ -189,7 +189,7 @@ final class DatabaseManagerTests: XCTestCase {
     // MARK: - Schema Version
 
     func testSchemaVersionIsTracked() throws {
-        XCTAssertEqual(DatabaseManager.schemaVersion, 36)
+        XCTAssertEqual(DatabaseManager.schemaVersion, 37)
     }
 
     func testMigrationIsRecordedInGRDB() throws {
@@ -272,6 +272,29 @@ final class DatabaseManagerTests: XCTestCase {
             let identifiers = try Row.fetchAll(db, sql: "SELECT identifier FROM grdb_migrations")
                 .map { $0["identifier"] as String }
             XCTAssertTrue(identifiers.contains("v33"), "Migration v33 should be recorded")
+        }
+    }
+
+    /// v37 adds medications.excluded_from_safety_warnings and rebuilds the
+    /// capture triggers so the DELETE tombstone payload includes the new column.
+    func testV37AddsExclusionColumnAndRebuildsMedicationTriggers() throws {
+        try dbManager.dbQueue.read { db in
+            let names = try Row.fetchAll(db, sql: "PRAGMA table_info(medications)")
+                .compactMap { $0["name"] as String? }
+            XCTAssertTrue(names.contains("excluded_from_safety_warnings"))
+
+            let triggerSql = try String.fetchOne(
+                db,
+                sql: "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'sync_capture_medications_delete'"
+            )
+            XCTAssertTrue(
+                triggerSql?.contains("excluded_from_safety_warnings") == true,
+                "delete tombstone trigger should snapshot the new synced column"
+            )
+
+            let identifiers = try Row.fetchAll(db, sql: "SELECT identifier FROM grdb_migrations")
+                .map { $0["identifier"] as String }
+            XCTAssertTrue(identifiers.contains("v37"), "Migration v37 should be recorded")
         }
     }
 

--- a/mobile-apps/ios/MigraLogTests/MockRepositories.swift
+++ b/mobile-apps/ios/MigraLogTests/MockRepositories.swift
@@ -837,6 +837,7 @@ enum TestFixtures {
         category: MedicationCategory? = .nsaid,
         scheduleFrequency: ScheduleFrequency? = nil,
         minIntervalHours: Double? = nil,
+        excludedFromSafetyWarnings: Bool = false,
         createdAt: Int64 = now
     ) -> Medication {
         Medication(
@@ -852,6 +853,7 @@ enum TestFixtures {
             notes: nil,
             category: category,
             minIntervalHours: minIntervalHours,
+            excludedFromSafetyWarnings: excludedFromSafetyWarnings,
             createdAt: createdAt,
             updatedAt: now
         )

--- a/mobile-apps/ios/MigraLogTests/Repositories/CategorySafetyRuleRepositoryTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Repositories/CategorySafetyRuleRepositoryTests.swift
@@ -141,4 +141,62 @@ final class CategorySafetyRuleRepositoryTests: XCTestCase {
         let count = try repo.countUsageDays(category: .nsaid, windowDays: 30, now: Date(timeIntervalSince1970: 1_775_500_000))
         XCTAssertEqual(count, 2)
     }
+
+    func test_countUsageDays_ignores_doses_of_excluded_medications() throws {
+        // A daily preventative (e.g. Qulipta) excluded from safety warnings must
+        // not inflate its category's usage-day count; other meds still count.
+        try dbManager.dbQueue.write { db in
+            try db.execute(sql: """
+                INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, active,
+                                          category, created_at, updated_at, excluded_from_safety_warnings)
+                VALUES ('qulipta','Qulipta','preventative',60,'mg',1,'cgrp',1,1,1),
+                       ('ubrelvy','Ubrelvy','rescue',100,'mg',1,'cgrp',1,1,0)
+                """)
+            let base = Int64(1_775_304_000) * 1000
+            var doses: [(String, Int64)] = []
+            // Excluded preventative taken daily for 5 days.
+            for day in 0..<5 {
+                doses.append(("qulipta", base + Int64(day) * 86_400_000))
+            }
+            // Rescue med taken on 2 of those days.
+            doses.append(("ubrelvy", base))
+            doses.append(("ubrelvy", base + 3 * 86_400_000))
+            for (medId, ts) in doses {
+                try db.execute(
+                    sql: """
+                        INSERT INTO medication_doses (id, medication_id, timestamp, quantity,
+                                                       status, created_at, updated_at)
+                        VALUES (?, ?, ?, 1, 'taken', 1, 1)
+                        """,
+                    arguments: [UUID().uuidString, medId, ts]
+                )
+            }
+        }
+
+        let count = try repo.countUsageDays(category: .cgrp, windowDays: 30, now: Date(timeIntervalSince1970: 1_775_800_000))
+        XCTAssertEqual(count, 2, "only the non-excluded rescue med's days should count")
+    }
+
+    func test_countUsageDays_treats_null_exclusion_flag_as_included() throws {
+        // Rows synced from older app versions have NULL in the new column —
+        // they must count exactly as before the migration.
+        try dbManager.dbQueue.write { db in
+            try db.execute(sql: """
+                INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, active,
+                                          category, created_at, updated_at, excluded_from_safety_warnings)
+                VALUES ('m1','Advil','rescue',200,'mg',1,'nsaid',1,1,NULL)
+                """)
+            try db.execute(
+                sql: """
+                    INSERT INTO medication_doses (id, medication_id, timestamp, quantity,
+                                                   status, created_at, updated_at)
+                    VALUES (?, 'm1', ?, 1, 'taken', 1, 1)
+                    """,
+                arguments: [UUID().uuidString, Int64(1_775_304_000) * 1000]
+            )
+        }
+
+        let count = try repo.countUsageDays(category: .nsaid, windowDays: 30, now: Date(timeIntervalSince1970: 1_775_500_000))
+        XCTAssertEqual(count, 1)
+    }
 }

--- a/mobile-apps/ios/MigraLogTests/Repositories/MedicationRepositoryTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Repositories/MedicationRepositoryTests.swift
@@ -497,4 +497,52 @@ final class MedicationRepositoryTests: XCTestCase {
         let result = try repo.getLastTakenDoseInCategory(.nsaid, now: Date())
         XCTAssertNil(result)
     }
+
+    func test_getLastTakenDoseInCategory_skips_excluded_medications() throws {
+        try dbManager.dbQueue.write { db in
+            try db.execute(sql: """
+                INSERT INTO medications (id, name, type, dosage_amount, dosage_unit, active,
+                                          category, created_at, updated_at, excluded_from_safety_warnings)
+                VALUES ('qulipta','Qulipta','preventative',60,'mg',1,'cgrp',1,1,1),
+                       ('ubrelvy','Ubrelvy','rescue',100,'mg',1,'cgrp',1,1,0)
+                """)
+            try db.execute(sql: """
+                INSERT INTO medication_doses (id, medication_id, timestamp, quantity, status, created_at, updated_at)
+                VALUES ('d1','ubrelvy',1000,1,'taken',1,1),
+                       ('d2','qulipta',2000,1,'taken',1,1)
+                """)
+        }
+
+        // The excluded med's later dose must not drive the category cooldown.
+        let result = try repo.getLastTakenDoseInCategory(.cgrp, now: Date(timeIntervalSince1970: 1_000_000))
+        XCTAssertEqual(result?.medicationName, "Ubrelvy")
+        XCTAssertEqual(result?.dose.medicationId, "ubrelvy")
+    }
+
+    // MARK: - excludedFromSafetyWarnings persistence
+
+    func test_excludedFromSafetyWarnings_roundtrips_and_defaults_false() throws {
+        let included = makeMedication(id: "inc")
+        var excluded = makeMedication(id: "exc", name: "Qulipta", type: .preventative, category: .cgrp)
+        excluded.excludedFromSafetyWarnings = true
+        _ = try repo.createMedication(included)
+        _ = try repo.createMedication(excluded)
+
+        XCTAssertEqual(try repo.getMedicationById("inc")?.excludedFromSafetyWarnings, false)
+        XCTAssertEqual(try repo.getMedicationById("exc")?.excludedFromSafetyWarnings, true)
+    }
+
+    func test_updateMedication_persists_excludedFromSafetyWarnings() throws {
+        let med = makeMedication(id: "m1")
+        _ = try repo.createMedication(med)
+
+        var updated = med
+        updated.excludedFromSafetyWarnings = true
+        _ = try repo.updateMedication(updated)
+        XCTAssertEqual(try repo.getMedicationById("m1")?.excludedFromSafetyWarnings, true)
+
+        updated.excludedFromSafetyWarnings = false
+        _ = try repo.updateMedication(updated)
+        XCTAssertEqual(try repo.getMedicationById("m1")?.excludedFromSafetyWarnings, false)
+    }
 }

--- a/mobile-apps/ios/MigraLogTests/ViewModels/CategorySafetyRulesViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/CategorySafetyRulesViewModelTests.swift
@@ -31,7 +31,7 @@ final class CategorySafetyRulesViewModelTests: XCTestCase {
             CategorySafetyRule(id: "2", category: .triptan, type: .cooldown,
                                periodHours: 2, maxCount: nil, createdAt: Date())
         ]
-        let vm = CategorySafetyRulesViewModel(repository: repo)
+        let vm = CategorySafetyRulesViewModel(repository: repo, medicationRepository: MockMedicationRepository())
         vm.loadRules()
         XCTAssertEqual(vm.rules.count, 2)
     }
@@ -42,7 +42,7 @@ final class CategorySafetyRulesViewModelTests: XCTestCase {
             CategorySafetyRule(id: "1", category: .nsaid, type: .periodLimit,
                                periodHours: 720, maxCount: 15, createdAt: Date())
         ]
-        let vm = CategorySafetyRulesViewModel(repository: repo)
+        let vm = CategorySafetyRulesViewModel(repository: repo, medicationRepository: MockMedicationRepository())
         vm.loadRules()
 
         let nsaidTypes = vm.addableTypes(for: .nsaid)
@@ -60,7 +60,7 @@ final class CategorySafetyRulesViewModelTests: XCTestCase {
             CategorySafetyRule(id: "2", category: .nsaid, type: .cooldown,
                                periodHours: 4, maxCount: nil, createdAt: Date())
         ]
-        let vm = CategorySafetyRulesViewModel(repository: repo)
+        let vm = CategorySafetyRulesViewModel(repository: repo, medicationRepository: MockMedicationRepository())
         vm.loadRules()
 
         XCTAssertFalse(vm.addableCategories.contains(.nsaid))
@@ -69,7 +69,7 @@ final class CategorySafetyRulesViewModelTests: XCTestCase {
 
     func test_saveRule_persists_and_updates_state() async {
         let repo = StubRepo()
-        let vm = CategorySafetyRulesViewModel(repository: repo)
+        let vm = CategorySafetyRulesViewModel(repository: repo, medicationRepository: MockMedicationRepository())
         let rule = CategorySafetyRule(id: "x", category: .nsaid, type: .cooldown,
                                       periodHours: 4, maxCount: nil, createdAt: Date())
         vm.saveRule(rule)
@@ -77,12 +77,80 @@ final class CategorySafetyRulesViewModelTests: XCTestCase {
         XCTAssertTrue(vm.rules.contains(where: { $0.id == "x" }))
     }
 
+    private func makeMedication(
+        id: String,
+        name: String = "Med",
+        type: MedicationType = .rescue,
+        category: MedicationCategory? = .cgrp,
+        excluded: Bool = false
+    ) -> Medication {
+        Medication(
+            id: id, name: name, type: type, dosageAmount: 10, dosageUnit: "mg",
+            defaultQuantity: 1, scheduleFrequency: nil, photoUri: nil, active: true,
+            notes: nil, category: category, minIntervalHours: nil,
+            excludedFromSafetyWarnings: excluded, createdAt: 1, updatedAt: 1
+        )
+    }
+
+    func test_loadRules_groups_active_medications_by_category() async {
+        let medRepo = MockMedicationRepository()
+        medRepo.medications = [
+            makeMedication(id: "qulipta", name: "Qulipta", type: .preventative, category: .cgrp),
+            makeMedication(id: "ubrelvy", name: "Ubrelvy", category: .cgrp),
+            makeMedication(id: "advil", name: "Advil", category: .nsaid),
+            makeMedication(id: "uncategorized", name: "Other", category: nil)
+        ]
+        let vm = CategorySafetyRulesViewModel(repository: StubRepo(), medicationRepository: medRepo)
+        vm.loadRules()
+
+        XCTAssertEqual(Set(vm.medicationsByCategory[.cgrp]?.map(\.id) ?? []), Set(["qulipta", "ubrelvy"]))
+        XCTAssertEqual(vm.medicationsByCategory[.nsaid]?.map(\.id), ["advil"])
+        XCTAssertNil(vm.medicationsByCategory[.other])
+    }
+
+    func test_saveRule_applies_exclusion_checklist_to_category_medications() async {
+        let medRepo = MockMedicationRepository()
+        medRepo.medications = [
+            makeMedication(id: "qulipta", name: "Qulipta", type: .preventative, category: .cgrp),
+            makeMedication(id: "ubrelvy", name: "Ubrelvy", category: .cgrp),
+            makeMedication(id: "advil", name: "Advil", category: .nsaid)
+        ]
+        let vm = CategorySafetyRulesViewModel(repository: StubRepo(), medicationRepository: medRepo)
+        vm.loadRules()
+
+        let rule = CategorySafetyRule(id: "r", category: .cgrp, type: .periodLimit,
+                                      periodHours: 720, maxCount: 10, createdAt: Date())
+        vm.saveRule(rule, excludedMedicationIds: ["qulipta"])
+
+        XCTAssertEqual(medRepo.medications.first { $0.id == "qulipta" }?.excludedFromSafetyWarnings, true)
+        XCTAssertEqual(medRepo.medications.first { $0.id == "ubrelvy" }?.excludedFromSafetyWarnings, false)
+        // Other categories are untouched.
+        XCTAssertEqual(medRepo.medications.first { $0.id == "advil" }?.excludedFromSafetyWarnings, false)
+        // The VM's cache reflects the change so reopening the editor shows it.
+        XCTAssertEqual(vm.medicationsByCategory[.cgrp]?.first { $0.id == "qulipta" }?.excludedFromSafetyWarnings, true)
+    }
+
+    func test_saveRule_reincludes_previously_excluded_medication() async {
+        let medRepo = MockMedicationRepository()
+        medRepo.medications = [
+            makeMedication(id: "qulipta", name: "Qulipta", type: .preventative, category: .cgrp, excluded: true)
+        ]
+        let vm = CategorySafetyRulesViewModel(repository: StubRepo(), medicationRepository: medRepo)
+        vm.loadRules()
+
+        let rule = CategorySafetyRule(id: "r", category: .cgrp, type: .periodLimit,
+                                      periodHours: 720, maxCount: 10, createdAt: Date())
+        vm.saveRule(rule, excludedMedicationIds: [])
+
+        XCTAssertEqual(medRepo.medications.first { $0.id == "qulipta" }?.excludedFromSafetyWarnings, false)
+    }
+
     func test_deleteRule_removes_from_state_and_repo() async {
         let repo = StubRepo()
         let rule = CategorySafetyRule(id: "x", category: .nsaid, type: .cooldown,
                                       periodHours: 4, maxCount: nil, createdAt: Date())
         repo.rules = [rule]
-        let vm = CategorySafetyRulesViewModel(repository: repo)
+        let vm = CategorySafetyRulesViewModel(repository: repo, medicationRepository: MockMedicationRepository())
         vm.loadRules()
 
         vm.deleteRule(id: "x")

--- a/mobile-apps/ios/MigraLogTests/ViewModels/LogMedicationViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/LogMedicationViewModelTests.swift
@@ -38,6 +38,28 @@ final class LogMedicationViewModelTests: XCTestCase {
         XCTAssertFalse(sut.isLoading)
     }
 
+    func testCategoryUsageStatus_gatesExcludedMedications() async {
+        let included = TestFixtures.makeMedication(id: "inc", name: "Ubrelvy", category: .cgrp)
+        let excluded = TestFixtures.makeMedication(
+            id: "exc", name: "Qulipta", type: .preventative, category: .cgrp,
+            excludedFromSafetyWarnings: true
+        )
+        mockMedRepo.medications = [included, excluded]
+        mockCategoryLimitRepo.rules = ["r": CategorySafetyRule(
+            id: "r", category: .cgrp, type: .periodLimit,
+            periodHours: 720, maxCount: 10, createdAt: Date()
+        )]
+        mockCategoryLimitRepo.dayCounts = [.cgrp: 10]
+
+        await sut.loadMedications()
+
+        // Category is at its limit: the included med warns, the excluded doesn't.
+        XCTAssertTrue(sut.categoryUsageStatus(for: included).isWarning)
+        XCTAssertEqual(sut.categoryUsageStatus(for: excluded), .noLimit)
+        // No category cooldown entry is computed for excluded medications.
+        XCTAssertNil(sut.categoryCooldowns["exc"])
+    }
+
     func testLoadMedications_rescueSortedByUsageCount() async {
         let medA = TestFixtures.makeMedication(id: "a", name: "Ibuprofen", type: .rescue)
         let medB = TestFixtures.makeMedication(id: "b", name: "Sumatriptan", type: .rescue)

--- a/mobile-apps/ios/MigraLogTests/ViewModels/MedicationDetailViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/MedicationDetailViewModelTests.swift
@@ -43,6 +43,36 @@ final class MedicationDetailViewModelTests: XCTestCase {
         XCTAssertNotNil(sut.medication)
     }
 
+    func testLoadMedication_categoryStatus_warnsForIncludedMedication() async throws {
+        mockCategoryLimitRepo.rules = ["r": CategorySafetyRule(
+            id: "r", category: .nsaid, type: .periodLimit,
+            periodHours: 720, maxCount: 15, createdAt: Date()
+        )]
+        mockCategoryLimitRepo.dayCounts = [.nsaid: 15]
+
+        await sut.loadMedication()
+
+        XCTAssertTrue(sut.categoryStatus.isWarning)
+    }
+
+    func testLoadMedication_categoryStatus_noLimitForExcludedMedication() async throws {
+        // Same rule and usage as above, but the medication is excluded from
+        // safety warnings — its detail screen must not show the category warning.
+        mockCategoryLimitRepo.rules = ["r": CategorySafetyRule(
+            id: "r", category: .nsaid, type: .periodLimit,
+            periodHours: 720, maxCount: 15, createdAt: Date()
+        )]
+        mockCategoryLimitRepo.dayCounts = [.nsaid: 15]
+        mockRepo.medications = [TestFixtures.makeMedication(
+            id: "med-1", name: "Ibuprofen", excludedFromSafetyWarnings: true
+        )]
+
+        await sut.loadMedication()
+
+        XCTAssertEqual(sut.categoryStatus, .noLimit)
+        XCTAssertFalse(sut.categoryCooldown.isOnCooldown)
+    }
+
     func testLoadMedication_notFound_stateEmpty() async throws {
         sut = MedicationDetailViewModel(
             medicationId: "nonexistent",

--- a/mobile-apps/ios/MigraLogUITests/CategorySafetyRulesUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/CategorySafetyRulesUITests.swift
@@ -1,0 +1,187 @@
+import XCTest
+
+/// Category safety rules: the rule editor's medication inclusion checklist.
+/// A medication unchecked in the checklist is excluded from its category's
+/// safety warnings — its doses don't count and the warning is not shown on it.
+final class CategorySafetyRulesUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = UITestHelpers.launchWithFixtures()
+        UITestHelpers.waitForDashboard(in: app)
+        addTeardownBlock { [self] in
+            attachScreenshot(named: "teardown-state")
+        }
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    /// End-to-end: log a dose, add an OTC usage-limit rule (1 day / 30) and see
+    /// the warning on the Log Medication card, then exclude the medication via
+    /// the rule editor checklist and see the warning disappear.
+    func testExcludingMedicationSilencesCategoryWarning() throws {
+        // Step 1: Log a dose of Test Ibuprofen (category: otc) so the OTC
+        // usage count is 1 day.
+        UITestHelpers.navigateTo(tab: .medications, in: app)
+        let medCard = app.buttons["medication-card-Test Ibuprofen"]
+        UITestHelpers.waitForHittable(medCard)
+        medCard.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        let logDoseButton = app.buttons["log-dose-button"]
+        UITestHelpers.waitForHittable(logDoseButton)
+        logDoseButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        // Rescue medications confirm the dose via a "Log Dose" sheet.
+        let confirmLog = app.buttons["Log"]
+        if confirmLog.waitForExistence(timeout: 3) {
+            confirmLog.tap()
+            Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        }
+        // Logging a dose reschedules notifications, which can raise the system
+        // notification-permission alert on a fresh simulator.
+        UITestHelpers.handleSystemAlert(in: app, buttonLabel: "Allow")
+
+        // Step 2: Create an OTC usage-limit rule (max 1 day in 30) with the
+        // medication checklist left at its default (all included).
+        UITestHelpers.navigateTo(tab: .dashboard, in: app)
+        openSafetyLimits()
+        let addButton = app.buttons["category-rules-empty-add"].exists
+            ? app.buttons["category-rules-empty-add"]
+            : app.buttons["category-rules-add"]
+        UITestHelpers.waitForHittable(addButton)
+        addButton.tap()
+
+        pickMenuOption(picker: "rule-editor-category-picker", option: "OTC")
+        pickMenuOption(picker: "rule-editor-type-picker", option: "Usage limit")
+
+        let maxDays = app.textFields["rule-editor-max-days"]
+        UITestHelpers.waitForHittable(maxDays)
+        maxDays.tap()
+        maxDays.typeText("1")
+        let windowDays = app.textFields["rule-editor-window-days"]
+        windowDays.tap()
+        windowDays.typeText("30")
+
+        // The checklist lists the category's medication, included by default.
+        let checklistRow = revealChecklistRow()
+        XCTAssertTrue(checklistRow.isSelected, "medications default to included (checked)")
+        attachScreenshot(named: "rule-editor-checklist-included")
+
+        app.buttons["rule-editor-save"].tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // Step 3: The Log Medication sheet shows the OTC warning on the card.
+        openLogMedicationSheet()
+        let warning = app.staticTexts["category-warning-fixture-med-ibuprofen"]
+        XCTAssertTrue(warning.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+                      "OTC usage warning should show when the medication is included")
+        XCTAssertTrue(warning.label.contains("OTC used 1 of 1 days"),
+                      "unexpected warning text: \(warning.label)")
+        attachScreenshot(named: "warning-shown-when-included")
+        app.buttons["Cancel"].firstMatch.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // Step 4: Exclude the medication via the rule editor checklist.
+        openSafetyLimits()
+        let ruleRow = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'rule-row-'")
+        ).firstMatch
+        UITestHelpers.waitForHittable(ruleRow)
+        ruleRow.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        let editChecklistRow = revealChecklistRow()
+        editChecklistRow.tap()
+        XCTAssertFalse(editChecklistRow.isSelected, "tapping the row should uncheck it")
+        attachScreenshot(named: "rule-editor-checklist-excluded")
+        app.buttons["rule-editor-save"].tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // Step 5: The warning is gone from the Log Medication card.
+        openLogMedicationSheet()
+        let card = app.staticTexts["Test Ibuprofen"].firstMatch
+        XCTAssertTrue(card.waitForExistence(timeout: UITestHelpers.defaultTimeout))
+        XCTAssertFalse(app.staticTexts["category-warning-fixture-med-ibuprofen"].exists,
+                       "excluded medication must not show its category's usage warning")
+        attachScreenshot(named: "warning-gone-when-excluded")
+
+        // Step 6: Reopen the editor — the exclusion persisted.
+        app.buttons["Cancel"].firstMatch.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        openSafetyLimits()
+        UITestHelpers.waitForHittable(ruleRow)
+        ruleRow.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        let reopenedChecklistRow = revealChecklistRow()
+        XCTAssertFalse(reopenedChecklistRow.isSelected, "exclusion should persist across edits")
+    }
+
+    // MARK: - Helpers
+
+    /// The rule editor opens at the medium detent and its Form is lazy, so the
+    /// medications checklist may not exist in the hierarchy yet. Swipe up to
+    /// expand the sheet, then scroll until the row is hittable.
+    private func revealChecklistRow() -> XCUIElement {
+        let row = app.buttons["rule-editor-medication-fixture-med-ibuprofen"]
+        if !row.isHittable {
+            app.swipeUp()
+            Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        }
+        if !row.isHittable {
+            UITestHelpers.scrollToElement(row, in: app.collectionViews.firstMatch)
+        }
+        UITestHelpers.waitForHittable(row)
+        return row
+    }
+
+    /// Dashboard → settings gear → Medication Safety Limits.
+    private func openSafetyLimits() {
+        UITestHelpers.navigateTo(tab: .dashboard, in: app)
+        // Pop any pushed screens left from a previous visit.
+        let settingsButton = app.buttons["settings-button"]
+        UITestHelpers.waitForHittable(settingsButton)
+        settingsButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        let limitsRow = app.buttons["medication-safety-limits"]
+        let listView = app.tables.firstMatch.exists ? app.tables.firstMatch : app.collectionViews.firstMatch
+        if !limitsRow.isHittable && listView.exists {
+            UITestHelpers.scrollToElement(limitsRow, in: listView)
+        }
+        UITestHelpers.waitForHittable(limitsRow)
+        limitsRow.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+    }
+
+    /// Dashboard → "Log Medication" button → sheet.
+    private func openLogMedicationSheet() {
+        UITestHelpers.navigateTo(tab: .dashboard, in: app)
+        let logButton = app.buttons["log-medication-button"]
+        let scroll = app.scrollViews.firstMatch
+        if !logButton.isHittable && scroll.exists {
+            UITestHelpers.scrollToElement(logButton, in: scroll)
+        }
+        UITestHelpers.waitForHittable(logButton)
+        logButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+    }
+
+    /// SwiftUI Form pickers render as menu buttons: tap the picker, then the option.
+    private func pickMenuOption(picker identifier: String, option: String) {
+        let pickerButton = app.buttons[identifier]
+        UITestHelpers.waitForHittable(pickerButton)
+        pickerButton.tap()
+        let optionButton = app.buttons[option]
+        UITestHelpers.waitForHittable(optionButton)
+        optionButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+    }
+
+    private func attachScreenshot(named name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/spec/DATA_MODEL.md
+++ b/spec/DATA_MODEL.md
@@ -214,6 +214,7 @@ Stored in `pain_location_logs` table
   endDate?: number;               // When medication ended
   active: boolean;                // Currently taking?
   notes?: string;                 // User notes (max 5000 chars)
+  excludedFromSafetyWarnings?: boolean; // Doses don't count toward category safety warnings (default false)
   createdAt: number;              // Record creation timestamp
   updatedAt: number;              // Last modification timestamp
 }

--- a/spec/schemas/sqlite/schema-v37.sql
+++ b/spec/schemas/sqlite/schema-v37.sql
@@ -1,4 +1,4 @@
--- MigraLog SQLite Schema v36
+-- MigraLog SQLite Schema v37
 -- Canonical schema definition for the migraine tracking database.
 -- Source of truth: mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
 --   (createSchema + registered migrations). This .sql is a formal mirror and
@@ -28,6 +28,11 @@
 --   columns) stamped after each completed pull. A mismatch (a migration added synced
 --   columns) makes the sync engine reset the zone change token once and re-pull,
 --   backfilling columns that migrate-on-read dropped before the upgrade.
+-- v37: added the nullable `excluded_from_safety_warnings` column to medications —
+--   user-controlled opt-out of a medication's doses counting toward its category's
+--   safety warnings (usage limits + cooldowns), set via the rule editor's medication
+--   checklist. Nullable (NULL = included) so payloads from older app versions apply.
+--   Synced; capture triggers rebuilt to include it.
 --
 -- Conventions:
 --   - All IDs are TEXT (UUIDs)
@@ -115,7 +120,8 @@ CREATE TABLE IF NOT EXISTS medications (
   category TEXT CHECK(category IS NULL OR category IN ('otc', 'nsaid', 'triptan', 'cgrp', 'preventive', 'supplement', 'other')),
   created_at INTEGER NOT NULL CHECK(created_at > 0),
   updated_at INTEGER NOT NULL CHECK(updated_at > 0),
-  min_interval_hours REAL CHECK(min_interval_hours IS NULL OR min_interval_hours > 0)  -- v26: per-med dose cooldown
+  min_interval_hours REAL CHECK(min_interval_hours IS NULL OR min_interval_hours > 0),  -- v26: per-med dose cooldown
+  excluded_from_safety_warnings INTEGER CHECK(excluded_from_safety_warnings IS NULL OR excluded_from_safety_warnings IN (0, 1))  -- v37: opt-out of category safety warnings
 );
 
 -- Medication schedules table


### PR DESCRIPTION
## Problem

Taking a daily CGRP preventative (e.g. Qulipta) in a category with a configured usage limit inflates the category's MOH usage-day count and shows the overuse warning on the preventative itself — the warning pipeline keyed off `MedicationCategory` only and never consulted anything else.

## Approach

Rather than silently hard-coding "preventatives don't count", this puts the decision in the user's hands: the category safety-rule editor now shows an **Included Medications** checklist for the rule's category. All medications are **checked (included) by default**; unchecking one excludes it from every safety warning for that category — its doses stop counting toward the usage limit and cooldown, and those warnings stop appearing on its rows (Dashboard, Log Medication, Log Dose sheet, medication detail).


## Implementation

- New `medications.excluded_from_safety_warnings` column — **v37 migration**, nullable so payloads from older app versions still apply (migrate-on-read); delete-capture triggers rebuilt with the new column baked in (v34 precedent); column added to `SyncableTable.syncedColumns` (drift test covers it).
- **No CloudKit schema change** — the field travels inside the opaque `SyncRecord` payload; the manifest mechanism auto re-pulls once to backfill older rows.
- `countUsageDays` and `getLastTakenDoseInCategory` filter `COALESCE(m.excluded_from_safety_warnings, 0) = 0`.
- View models gate per-medication display (`categoryUsageStatus(for:)`, cooldown map skips excluded meds).
- `CategorySafetyRulesViewModel.saveRule` persists checklist changes via `updateMedication` (bumps `updated_at` → syncs) and posts `.medicationDataChanged`.

## Testing

- Unit: query filters (mixed included/excluded, NULL-flag tolerance), flag round-trip, VM gating, v37 migration + trigger rebuild. Full `MigraLogTests` bundle green locally (1053 tests).
- End-to-end XCUITest (`CategorySafetyRulesUITests`): logs a dose, creates an OTC 1/30 rule, sees the red "OTC used 1 of 1 days in last 30" warning on the Log Medication card, excludes the med via the checklist, sees the warning disappear, and confirms the exclusion persists across editor sessions. Verified on iPhone 17 Pro sim with screenshots.
- Neighboring fixture-dependent UI suites (MedicationDose/Tracking/Archiving) pass with the fixture's new `category` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
