### PR TITLE
feat(ios): time picker on Log Update screen to backdate updates

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/Episodes/LogUpdateScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/LogUpdateScreen.swift
@@ -12,6 +12,7 @@ struct LogUpdateScreen: View {
     @State private var selectedSymptoms: Set<Symptom> = []
     @State private var initialSymptoms: Set<Symptom> = []
     @State private var noteText: String = ""
+    @State private var timestamp = Date()
     @State private var isSaving = false
     @State private var didLoadState = false
 
@@ -19,6 +20,14 @@ struct LogUpdateScreen: View {
         Form {
             Section("Pain Intensity") {
                 PainIntensitySlider(intensity: $intensity)
+            }
+
+            Section("Time") {
+                DatePicker(
+                    "Time",
+                    selection: $timestamp,
+                    in: (viewModel.episode?.startDate ?? .distantPast)...Date()
+                )
             }
 
             Section("Pain Locations") {
@@ -113,12 +122,12 @@ struct LogUpdateScreen: View {
     private func save() async {
         isSaving = true
         defer { isSaving = false }
-        let now = TimestampHelper.now
+        let updateTimestamp = TimestampHelper.fromDate(timestamp)
 
         // Add intensity reading
         await viewModel.addIntensityReading(
             intensity: intensity,
-            timestamp: now
+            timestamp: updateTimestamp
         )
 
         // Add symptom logs only for newly added symptoms
@@ -126,7 +135,7 @@ struct LogUpdateScreen: View {
         for symptom in newSymptoms {
             await viewModel.addSymptomLog(
                 symptom: symptom,
-                timestamp: now
+                timestamp: updateTimestamp
             )
         }
 
@@ -134,7 +143,7 @@ struct LogUpdateScreen: View {
         if selectedLocations != initialLocations {
             await viewModel.addPainLocationLog(
                 locations: Array(selectedLocations),
-                timestamp: now
+                timestamp: updateTimestamp
             )
         }
 
@@ -142,7 +151,7 @@ struct LogUpdateScreen: View {
         if !noteText.isEmpty {
             await viewModel.addEpisodeNote(
                 note: noteText,
-                timestamp: now
+                timestamp: updateTimestamp
             )
         }
 

--- a/mobile-apps/ios/MigraLogUITests/LogUpdateTimePickerUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/LogUpdateTimePickerUITests.swift
@@ -1,0 +1,150 @@
+import XCTest
+
+/// Verifies the Log Update screen's Time picker: an update can be backdated
+/// and the backdated time appears on the episode timeline.
+final class LogUpdateTimePickerUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = UITestHelpers.launchCleanDashboard()
+        UITestHelpers.waitForDashboard(in: app)
+    }
+
+    override func tearDownWithError() throws {
+        if let app {
+            let screenshot = XCTAttachment(screenshot: app.screenshot())
+            screenshot.name = "final-state"
+            screenshot.lifetime = .keepAlways
+            add(screenshot)
+        }
+        app = nil
+    }
+
+    func testLogUpdateCanBeBackdated() throws {
+        let now = Date()
+        let episodeStart = now.addingTimeInterval(-2 * 60 * 60)
+        let updateTime = now.addingTimeInterval(-30 * 60)
+
+        // === Create an episode started 2 hours ago ===
+        let startButton = app.buttons["start-episode-button"]
+        let saveButton = app.buttons["save-episode-button"]
+        UITestHelpers.tapToPresent(startButton, expecting: saveButton)
+
+        let startPicker = app.datePickers.firstMatch
+        XCTAssertTrue(startPicker.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+                      "New episode screen should have a start time picker")
+        setTime(of: startPicker, to: episodeStart)
+
+        UITestHelpers.waitForHittable(saveButton)
+        saveButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // === Open episode detail and the Log Update sheet ===
+        let activeEpisodeCard = app.buttons["active-episode-card"]
+        UITestHelpers.waitForHittable(activeEpisodeCard)
+        activeEpisodeCard.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        let logUpdateButton = app.buttons["log-update-button"]
+        let detailScroll = app.scrollViews.firstMatch
+        if !logUpdateButton.isHittable {
+            UITestHelpers.scrollToElement(logUpdateButton, in: detailScroll)
+        }
+        UITestHelpers.waitForHittable(logUpdateButton)
+        logUpdateButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // === Time picker is present on the Log Update screen ===
+        let updatePicker = app.datePickers.firstMatch
+        XCTAssertTrue(updatePicker.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+                      "Log Update screen should have a Time picker")
+        attach(name: "log-update-time-picker")
+
+        // === Backdate the update by 30 minutes ===
+        setTime(of: updatePicker, to: updateTime)
+        XCTAssertTrue(
+            timeButton(of: updatePicker, matching: updateTime)
+                .waitForExistence(timeout: UITestHelpers.defaultTimeout),
+            "Time picker should show the backdated time \(shortTime(updateTime))"
+        )
+        attach(name: "log-update-backdated-time")
+
+        let saveUpdateButton = app.buttons["Save"]
+        UITestHelpers.waitForHittable(saveUpdateButton)
+        saveUpdateButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // === Timeline shows the intensity reading at the backdated time ===
+        let backdatedEntry = app.staticTexts[shortTime(updateTime)].firstMatch
+        if !backdatedEntry.exists {
+            UITestHelpers.scrollToElement(backdatedEntry, in: detailScroll)
+        }
+        XCTAssertTrue(backdatedEntry.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+                      "Timeline should show an entry at the backdated time \(shortTime(updateTime))")
+        attach(name: "timeline-backdated-entry")
+    }
+
+    // MARK: - Compact DatePicker helpers
+
+    /// The compact DatePicker's time segment button (label like "5:45 PM").
+    private func timeButton(of picker: XCUIElement) -> XCUIElement {
+        picker.buttons
+            .matching(NSPredicate(format: "label MATCHES %@", ".*[0-9]{1,2}:[0-9]{2}.*"))
+            .firstMatch
+    }
+
+    /// The time segment button only if it displays the given time.
+    private func timeButton(of picker: XCUIElement, matching date: Date) -> XCUIElement {
+        picker.buttons
+            .matching(NSPredicate(format: "label CONTAINS %@", shortTime(date)))
+            .firstMatch
+    }
+
+    /// Opens the compact picker's time popover and sets the wheels to `date`'s time.
+    private func setTime(of picker: XCUIElement, to date: Date) {
+        let button = timeButton(of: picker)
+        XCTAssertTrue(button.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+                      "Compact date picker should expose a time button")
+        button.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        let hourWheel = app.pickerWheels.element(boundBy: 0)
+        XCTAssertTrue(hourWheel.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+                      "Tapping the time button should show picker wheels")
+        hourWheel.adjust(toPickerWheelValue: component(of: date, format: "h"))
+        app.pickerWheels.element(boundBy: 1)
+            .adjust(toPickerWheelValue: component(of: date, format: "mm"))
+        if app.pickerWheels.count > 2 {
+            app.pickerWheels.element(boundBy: 2)
+                .adjust(toPickerWheelValue: component(of: date, format: "a"))
+        }
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // Dismiss the popover by tapping outside it
+        app.windows.firstMatch
+            .coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.08))
+            .tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+    }
+
+    private func component(of date: Date, format: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = format
+        return formatter.string(from: date)
+    }
+
+    private func shortTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    private func attach(name: String) {
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = name
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+    }
+}


### PR DESCRIPTION
## Summary
Addresses TestFlight feedback (build 1.1.227, iPhone 18,3 / iOS 26.3):

> From this screen when I click "log update" it doesn't give me an option to change the time of the update. I know that after I log the update, I can go to the episode and edit the time, but it would be nice to do from the "log update" screen.

- Adds a **Time** section with a `DatePicker` to `LogUpdateScreen`, following the existing `LogMedicationScreen` pattern
- Picker is bounded between the episode's start time and now
- The picked time flows through the existing `timestamp:`-aware `EpisodeDetailViewModel.add*` calls (intensity reading, symptom logs, pain location log, note) — no store-layer changes needed

## Testing
- Full unit suite: 1054 tests, 0 failures
- New UI test `LogUpdateTimePickerUITests.testLogUpdateCanBeBackdated`: starts an episode backdated 2h, logs an update backdated 30m via the picker, and asserts the timeline shows the entry at the backdated time (passed, with screenshot evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)