### PR TITLE
feat(ios): sort dashboard meds by schedule time, show times for repeats

### DIFF
--- a/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
@@ -6,6 +6,9 @@ struct MedicationScheduleItem: Identifiable, Equatable {
     let medication: Medication
     let schedule: MedicationSchedule
     var dose: MedicationDose?
+    /// Whether to surface this row's scheduled time. Set when the medication has
+    /// more than one scheduled dose that day, so the rows can be told apart.
+    var showScheduleTime: Bool = false
 
     var id: String { schedule.id }
     var isTaken: Bool { dose?.status == .taken }
@@ -303,6 +306,25 @@ final class DashboardViewModel {
                 }
             }
         }
+        // Surface the scheduled time on a row only when its medication has more
+        // than one scheduled dose that day, so the otherwise-identical rows can
+        // be told apart.
+        let scheduleCounts = Dictionary(grouping: items, by: { $0.medication.id })
+            .mapValues(\.count)
+        for index in items.indices {
+            items[index].showScheduleTime = (scheduleCounts[items[index].medication.id] ?? 0) > 1
+        }
+
+        // Order the whole list by scheduled time. Times are stored as zero-padded
+        // "HH:mm", so a lexical compare is already chronological; fall back to the
+        // medication name so same-time doses keep a stable, alphabetical order.
+        items.sort { lhs, rhs in
+            if lhs.schedule.time != rhs.schedule.time {
+                return lhs.schedule.time < rhs.schedule.time
+            }
+            return lhs.medication.name.localizedCaseInsensitiveCompare(rhs.medication.name) == .orderedAscending
+        }
+
         let usage = computeCategoryUsage(for: usedCategories, now: Date())
         let cooldowns = computeCategoryCooldowns(
             for: activeMeds.filter { med in items.contains(where: { $0.medication.id == med.id }) },

--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -406,9 +406,17 @@ struct MedicationScheduleRow: View {
     @Environment(AppState.self) private var appState
 
     private var medicationNameLabel: some View {
-        Text(item.medication.name)
-            .font(.subheadline.weight(.medium))
-            .foregroundStyle(.primary)
+        VStack(alignment: .leading, spacing: 2) {
+            Text(item.medication.name)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.primary)
+            if item.showScheduleTime {
+                Text(DateFormatting.displayTime(from: item.schedule.time))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("schedule-time-\(item.schedule.id)")
+            }
+        }
     }
 
     private var doseLabel: String {

--- a/mobile-apps/ios/MigraLogTests/ViewModels/DashboardViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/DashboardViewModelTests.swift
@@ -271,4 +271,45 @@ final class DashboardViewModelTests: XCTestCase {
 
         XCTAssertNil(sut.categoryUsage[.nsaid])
     }
+
+    // MARK: - Ordering & schedule time display
+
+    func testLoadData_ordersMedicationsByScheduleTime() async throws {
+        // Alphabetical name order (Aaa, Zzz) is the opposite of schedule-time
+        // order (Zzz @ 08:00, Aaa @ 20:00), so a correct result proves we sort
+        // by time rather than by name.
+        let evening = TestFixtures.makeMedication(id: "med-a", name: "Aaa")
+        let morning = TestFixtures.makeMedication(id: "med-z", name: "Zzz")
+        mockMedRepo.medications = [evening, morning]
+        mockMedRepo.schedules = [
+            TestFixtures.makeSchedule(id: "s-a", medicationId: "med-a", time: "20:00"),
+            TestFixtures.makeSchedule(id: "s-z", medicationId: "med-z", time: "08:00"),
+        ]
+
+        await sut.loadData()
+
+        XCTAssertEqual(sut.todaysMedications.map(\.schedule.time), ["08:00", "20:00"])
+        XCTAssertEqual(sut.todaysMedications.map(\.medication.name), ["Zzz", "Aaa"])
+    }
+
+    func testLoadData_multipleSchedulesForMed_showScheduleTimeOnlyForThatMed() async throws {
+        let twice = TestFixtures.makeMedication(id: "med-twice", name: "Topiramate")
+        let once = TestFixtures.makeMedication(id: "med-once", name: "Amitriptyline")
+        mockMedRepo.medications = [twice, once]
+        mockMedRepo.schedules = [
+            TestFixtures.makeSchedule(id: "s-t1", medicationId: "med-twice", time: "08:00"),
+            TestFixtures.makeSchedule(id: "s-t2", medicationId: "med-twice", time: "20:00"),
+            TestFixtures.makeSchedule(id: "s-o1", medicationId: "med-once", time: "12:00"),
+        ]
+
+        await sut.loadData()
+
+        let flags = Dictionary(
+            uniqueKeysWithValues: sut.todaysMedications.map { ($0.schedule.id, $0.showScheduleTime) }
+        )
+        // The twice-daily med surfaces its time on both rows; the once-daily med does not.
+        XCTAssertEqual(flags["s-t1"], true)
+        XCTAssertEqual(flags["s-t2"], true)
+        XCTAssertEqual(flags["s-o1"], false)
+    }
 }


### PR DESCRIPTION
## What
On the dashboard's **Today's Medications** card:

1. **Sort by schedule time.** Rows were ordered by medication name (A→Z, grouped, then by time within a med), so an 8:00 PM dose could sort above an 8:00 AM one. The assembled list is now sorted globally by scheduled `HH:mm` time, with medication name as a stable tiebreaker for same-time doses.
2. **Show times for repeated meds.** When a medication has more than one scheduled dose that day, its scheduled time is shown under the name (via the existing `DateFormatting.displayTime`) so the otherwise-identical rows can be told apart. Single-schedule meds look unchanged.

## Why
Requested: scheduled meds on the home screen should read top-to-bottom in the order you actually take them, and multi-dose meds should show which row is which.

## Testing
- Added `testLoadData_ordersMedicationsByScheduleTime` (name order deliberately opposite time order, proving we sort by time not name) and `testLoadData_multipleSchedulesForMed_showScheduleTimeOnlyForThatMed`.
- `DashboardViewModelTests` — 22/22 pass locally (iPhone 17 Pro, iOS 26.5).

## Notes / follow-up (not in this PR)
Pre-existing: for a med with multiple daily schedules, dose matching keys only on medication id, so logging one dose currently marks all of that med's rows as taken. Out of scope here (sorting + display only), flagging for a possible follow-up on per-time dose tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)