### PR TITLE
fix(ios): track each scheduled dose independently (per-schedule dose id)

### DIFF
--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager+Schema.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager+Schema.swift
@@ -126,6 +126,7 @@ extension DatabaseManager {
             CREATE TABLE IF NOT EXISTS medication_doses (
                 id TEXT PRIMARY KEY,
                 medication_id TEXT NOT NULL,
+                schedule_id TEXT,
                 timestamp INTEGER NOT NULL CHECK(timestamp > 0),
                 quantity REAL NOT NULL CHECK(quantity >= 0),
                 dosage_amount REAL,

--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -24,7 +24,7 @@ enum DatabaseInitializationError: Error {
 /// Central database manager. Owns the DatabaseQueue and handles schema creation/migration.
 final class DatabaseManager: Sendable {
     /// The current schema version
-    static let schemaVersion = 38
+    static let schemaVersion = 39
 
     /// Shared singleton for the app's main database
     static let shared = DatabaseManager()
@@ -386,6 +386,27 @@ final class DatabaseManager: Sendable {
         migrator.registerMigration("v38") { db in
             try DatabaseManager.createMedicationExpectationPeriodsTable(in: db)
             try DatabaseManager.backfillExpectationPeriods(in: db)
+            try DatabaseManager.createSyncCaptureTriggers(in: db, includePayload: true)
+        }
+
+        // v39: associate a logged dose with the specific scheduled occurrence it
+        // satisfies, so the dashboard can track each of a med's daily doses
+        // independently (#592). Existing doses keep schedule_id NULL and fall
+        // back to time-of-day matching; nothing backfills them. Fresh installs
+        // already create the column in v39's CREATE TABLE, so only ALTER when
+        // missing. Recreate the doses capture triggers so the DELETE tombstone
+        // carries the new column (v37 precedent).
+        migrator.registerMigration("v39") { db in
+            let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(medication_doses)")
+            let hasColumn = columns.contains { (row: Row) in
+                (row["name"] as String?) == "schedule_id"
+            }
+            if !hasColumn {
+                try db.execute(sql: "ALTER TABLE medication_doses ADD COLUMN schedule_id TEXT")
+            }
+            for suffix in ["insert", "update", "delete"] {
+                try db.execute(sql: "DROP TRIGGER IF EXISTS sync_capture_medication_doses_\(suffix)")
+            }
             try DatabaseManager.createSyncCaptureTriggers(in: db, includePayload: true)
         }
 

--- a/mobile-apps/ios/MigraLog/Models/DomainModels.swift
+++ b/mobile-apps/ios/MigraLog/Models/DomainModels.swift
@@ -164,6 +164,12 @@ struct MedicationExpectationPeriod: Identifiable, Equatable, Sendable {
 struct MedicationDose: Identifiable, Equatable, Sendable {
     let id: String
     let medicationId: String
+    /// The scheduled occurrence this dose satisfies, when it was logged against
+    /// one (dashboard schedule row or a reminder notification). `nil` for ad-hoc
+    /// / PRN doses and for doses created before this field existed. The dashboard
+    /// uses it to bind a dose to the right row for meds scheduled multiple times
+    /// a day, falling back to time-of-day matching when it's absent.
+    var scheduleId: String? = nil
     var timestamp: Int64
     var quantity: Double
     var dosageAmount: Double?

--- a/mobile-apps/ios/MigraLog/Repositories/MedicationRepository.swift
+++ b/mobile-apps/ios/MigraLog/Repositories/MedicationRepository.swift
@@ -146,14 +146,15 @@ final class MedicationRepository: MedicationRepositoryProtocol {
         try dbManager.dbQueue.write { db in
             try db.execute(
                 sql: """
-                    INSERT INTO medication_doses (id, medication_id, timestamp, quantity, dosage_amount,
+                    INSERT INTO medication_doses (id, medication_id, schedule_id, timestamp, quantity, dosage_amount,
                         dosage_unit, status, episode_id, effectiveness_rating, time_to_relief,
                         side_effects, notes, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                 arguments: [
                     dose.id,
                     dose.medicationId,
+                    dose.scheduleId,
                     dose.timestamp,
                     dose.quantity,
                     dose.dosageAmount,
@@ -603,6 +604,7 @@ final class MedicationRepository: MedicationRepositoryProtocol {
         MedicationDose(
             id: row["id"],
             medicationId: row["medication_id"],
+            scheduleId: row["schedule_id"],
             timestamp: row["timestamp"],
             quantity: row["quantity"],
             dosageAmount: row["dosage_amount"],

--- a/mobile-apps/ios/MigraLog/Services/NotificationResponseHandler.swift
+++ b/mobile-apps/ios/MigraLog/Services/NotificationResponseHandler.swift
@@ -339,6 +339,7 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
             let dose = MedicationDose(
                 id: UUID().uuidString,
                 medicationId: medicationId,
+                scheduleId: scheduleId,
                 timestamp: now,
                 quantity: medication.defaultQuantity ?? 1.0,
                 dosageAmount: medication.dosageAmount,

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncableTable.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncableTable.swift
@@ -93,7 +93,7 @@ enum SyncableTable: String, CaseIterable, Sendable {
             return ["id", "medication_id", "time", "timezone", "dosage", "enabled",
                     "reminder_enabled", "created_at", "updated_at"]
         case .medicationDoses:
-            return ["id", "medication_id", "timestamp", "quantity", "dosage_amount",
+            return ["id", "medication_id", "schedule_id", "timestamp", "quantity", "dosage_amount",
                     "dosage_unit", "status", "episode_id", "effectiveness_rating",
                     "time_to_relief", "side_effects", "notes", "created_at", "updated_at"]
         case .medicationExpectationPeriods:

--- a/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
@@ -279,6 +279,60 @@ final class DashboardViewModel {
         return recent
     }
 
+    /// Associates each of a medication's logged doses for the day with the
+    /// scheduled occurrence it belongs to, keyed by schedule id.
+    ///
+    /// Doses record the actual time taken and carry no schedule reference, so a
+    /// med scheduled more than once a day can't be matched by id alone (that
+    /// would attach the first dose to every row). Instead we match on time of
+    /// day: each dose is bound to the schedule whose "HH:mm" is nearest to when
+    /// it was logged, and every schedule and dose is used at most once. Closest
+    /// pairs bind first; midnight wrap is treated as circular. Ties break
+    /// deterministically by id so results are stable across reloads.
+    static func matchDosesToSchedules(
+        schedules: [MedicationSchedule],
+        doses: [MedicationDose]
+    ) -> [String: MedicationDose] {
+        guard !schedules.isEmpty, !doses.isEmpty else { return [:] }
+
+        func scheduleMinute(_ schedule: MedicationSchedule) -> Int {
+            guard let components = schedule.timeComponents else { return 0 }
+            return components.hour * 60 + components.minute
+        }
+        func doseMinute(_ dose: MedicationDose) -> Int {
+            let components = Calendar.current.dateComponents([.hour, .minute], from: dose.date)
+            return (components.hour ?? 0) * 60 + (components.minute ?? 0)
+        }
+        // Circular distance between two minute-of-day values (handles the case
+        // where, e.g., a 23:00 schedule is nearest a dose logged just after midnight).
+        func distance(_ lhs: Int, _ rhs: Int) -> Int {
+            let diff = abs(lhs - rhs)
+            return min(diff, (24 * 60) - diff)
+        }
+
+        var pairs: [(scheduleId: String, doseIndex: Int, distance: Int)] = []
+        for schedule in schedules {
+            let scheduleMin = scheduleMinute(schedule)
+            for (index, dose) in doses.enumerated() {
+                pairs.append((schedule.id, index, distance(scheduleMin, doseMinute(dose))))
+            }
+        }
+        pairs.sort { lhs, rhs in
+            if lhs.distance != rhs.distance { return lhs.distance < rhs.distance }
+            if lhs.scheduleId != rhs.scheduleId { return lhs.scheduleId < rhs.scheduleId }
+            return lhs.doseIndex < rhs.doseIndex
+        }
+
+        var result: [String: MedicationDose] = [:]
+        var usedDoseIndices: Set<Int> = []
+        for pair in pairs {
+            guard result[pair.scheduleId] == nil, !usedDoseIndices.contains(pair.doseIndex) else { continue }
+            result[pair.scheduleId] = doses[pair.doseIndex]
+            usedDoseIndices.insert(pair.doseIndex)
+        }
+        return result
+    }
+
     private func loadTodaysMedications() async throws -> [MedicationScheduleItem] {
         let activeMeds = try await medicationRepository.getActiveMedications()
         let today = TimestampHelper.dateString()
@@ -292,14 +346,18 @@ final class DashboardViewModel {
             if let last = try? medicationRepository.getLastDose(medicationId: med.id) {
                 lastDoses[med.id] = last
             }
-            for schedule in schedules where schedule.enabled {
-                let matchingDose = todayDoses.first { doseWithMed in
-                    doseWithMed.medication.id == med.id
-                }
+            let enabledSchedules = schedules.filter { $0.enabled }
+            // Attach each of the day's logged doses to the specific scheduled
+            // occurrence it belongs to, rather than the medication as a whole,
+            // so a med scheduled multiple times a day tracks each dose
+            // independently (logging one no longer marks every row taken).
+            let medDoses = todayDoses.filter { $0.medication.id == med.id }.map(\.dose)
+            let doseBySchedule = Self.matchDosesToSchedules(schedules: enabledSchedules, doses: medDoses)
+            for schedule in enabledSchedules {
                 items.append(MedicationScheduleItem(
                     medication: med,
                     schedule: schedule,
-                    dose: matchingDose?.dose
+                    dose: doseBySchedule[schedule.id]
                 ))
                 if let category = med.category {
                     usedCategories.insert(category)

--- a/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/DashboardViewModel.swift
@@ -140,6 +140,7 @@ final class DashboardViewModel {
         let dose = MedicationDose(
             id: UUID().uuidString,
             medicationId: scheduleItem.medication.id,
+            scheduleId: scheduleItem.schedule.id,
             timestamp: now,
             quantity: scheduleItem.medication.defaultQuantity ?? 1,
             dosageAmount: scheduleItem.medication.dosageAmount,
@@ -182,6 +183,7 @@ final class DashboardViewModel {
         let dose = MedicationDose(
             id: UUID().uuidString,
             medicationId: scheduleItem.medication.id,
+            scheduleId: scheduleItem.schedule.id,
             timestamp: now,
             quantity: 0,
             dosageAmount: nil,
@@ -280,20 +282,39 @@ final class DashboardViewModel {
     }
 
     /// Associates each of a medication's logged doses for the day with the
-    /// scheduled occurrence it belongs to, keyed by schedule id.
+    /// scheduled occurrence it belongs to, keyed by schedule id, so a med
+    /// scheduled more than once a day tracks each dose independently (#592).
     ///
-    /// Doses record the actual time taken and carry no schedule reference, so a
-    /// med scheduled more than once a day can't be matched by id alone (that
-    /// would attach the first dose to every row). Instead we match on time of
-    /// day: each dose is bound to the schedule whose "HH:mm" is nearest to when
-    /// it was logged, and every schedule and dose is used at most once. Closest
-    /// pairs bind first; midnight wrap is treated as circular. Ties break
-    /// deterministically by id so results are stable across reloads.
+    /// Doses logged against a schedule row (or a reminder notification) carry the
+    /// `scheduleId` they satisfy — that binding is authoritative. Ad-hoc / PRN
+    /// doses, and any logged before `scheduleId` existed, have none; those fall
+    /// back to time-of-day: each is bound to the still-unclaimed schedule whose
+    /// "HH:mm" is nearest to when it was logged. Every schedule and dose is used
+    /// at most once; closest pairs bind first; midnight wrap is circular; ties
+    /// break by id so results are stable across reloads.
     static func matchDosesToSchedules(
         schedules: [MedicationSchedule],
         doses: [MedicationDose]
     ) -> [String: MedicationDose] {
         guard !schedules.isEmpty, !doses.isEmpty else { return [:] }
+
+        var result: [String: MedicationDose] = [:]
+        let scheduleIds = Set(schedules.map(\.id))
+
+        // Phase 1: bind doses that name their schedule directly.
+        var unboundDoses: [MedicationDose] = []
+        for dose in doses {
+            if let scheduleId = dose.scheduleId, scheduleIds.contains(scheduleId), result[scheduleId] == nil {
+                result[scheduleId] = dose
+            } else {
+                unboundDoses.append(dose)
+            }
+        }
+        guard !unboundDoses.isEmpty else { return result }
+
+        // Phase 2: time-of-day fallback over schedules Phase 1 didn't claim.
+        let openSchedules = schedules.filter { result[$0.id] == nil }
+        guard !openSchedules.isEmpty else { return result }
 
         func scheduleMinute(_ schedule: MedicationSchedule) -> Int {
             guard let components = schedule.timeComponents else { return 0 }
@@ -311,9 +332,9 @@ final class DashboardViewModel {
         }
 
         var pairs: [(scheduleId: String, doseIndex: Int, distance: Int)] = []
-        for schedule in schedules {
+        for schedule in openSchedules {
             let scheduleMin = scheduleMinute(schedule)
-            for (index, dose) in doses.enumerated() {
+            for (index, dose) in unboundDoses.enumerated() {
                 pairs.append((schedule.id, index, distance(scheduleMin, doseMinute(dose))))
             }
         }
@@ -323,11 +344,10 @@ final class DashboardViewModel {
             return lhs.doseIndex < rhs.doseIndex
         }
 
-        var result: [String: MedicationDose] = [:]
         var usedDoseIndices: Set<Int> = []
         for pair in pairs {
             guard result[pair.scheduleId] == nil, !usedDoseIndices.contains(pair.doseIndex) else { continue }
-            result[pair.scheduleId] = doses[pair.doseIndex]
+            result[pair.scheduleId] = unboundDoses[pair.doseIndex]
             usedDoseIndices.insert(pair.doseIndex)
         }
         return result

--- a/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
@@ -190,7 +190,7 @@ final class DatabaseManagerTests: XCTestCase {
     // MARK: - Schema Version
 
     func testSchemaVersionIsTracked() throws {
-        XCTAssertEqual(DatabaseManager.schemaVersion, 38)
+        XCTAssertEqual(DatabaseManager.schemaVersion, 39)
     }
 
     func testMigrationIsRecordedInGRDB() throws {

--- a/mobile-apps/ios/MigraLogTests/MockRepositories.swift
+++ b/mobile-apps/ios/MigraLogTests/MockRepositories.swift
@@ -907,6 +907,7 @@ enum TestFixtures {
     static func makeDose(
         id: String = UUID().uuidString,
         medicationId: String,
+        scheduleId: String? = nil,
         timestamp: Int64? = nil,
         status: DoseStatus = .taken,
         quantity: Double = 1.0,
@@ -918,6 +919,7 @@ enum TestFixtures {
         return MedicationDose(
             id: id,
             medicationId: medicationId,
+            scheduleId: scheduleId,
             timestamp: ts,
             quantity: quantity,
             dosageAmount: 400,

--- a/mobile-apps/ios/MigraLogTests/ViewModels/DashboardViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/DashboardViewModelTests.swift
@@ -312,4 +312,90 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertEqual(flags["s-t2"], true)
         XCTAssertEqual(flags["s-o1"], false)
     }
+
+    // MARK: - Per-schedule dose matching (issue #592)
+
+    /// Local timestamp for today at the given hour/minute, so the mock's
+    /// today-range dose fetch includes it.
+    private func todayAt(_ hour: Int, _ minute: Int = 0) -> Int64 {
+        let calendar = Calendar.current
+        let date = calendar.date(
+            bySettingHour: hour, minute: minute, second: 0,
+            of: calendar.startOfDay(for: Date())
+        )!
+        return TimestampHelper.fromDate(date)
+    }
+
+    func testLoadData_multiScheduleMed_oneDose_marksOnlyNearestRowTaken() async throws {
+        // Twice-daily med; only the morning dose is logged. The evening row must
+        // stay pending rather than flipping to taken with it.
+        let med = TestFixtures.makeMedication(id: "med-1", name: "Topiramate")
+        mockMedRepo.medications = [med]
+        mockMedRepo.schedules = [
+            TestFixtures.makeSchedule(id: "s-am", medicationId: "med-1", time: "08:00"),
+            TestFixtures.makeSchedule(id: "s-pm", medicationId: "med-1", time: "20:00"),
+        ]
+        mockMedRepo.doses = [
+            TestFixtures.makeDose(id: "d-am", medicationId: "med-1", timestamp: todayAt(8, 5), status: .taken),
+        ]
+
+        await sut.loadData()
+
+        let byId = Dictionary(uniqueKeysWithValues: sut.todaysMedications.map { ($0.schedule.id, $0) })
+        XCTAssertEqual(byId["s-am"]?.isTaken, true)
+        XCTAssertEqual(byId["s-pm"]?.isPending, true)
+    }
+
+    func testLoadData_multiScheduleMed_bothDoses_markBothRowsByTime() async throws {
+        let med = TestFixtures.makeMedication(id: "med-1", name: "Topiramate")
+        mockMedRepo.medications = [med]
+        mockMedRepo.schedules = [
+            TestFixtures.makeSchedule(id: "s-am", medicationId: "med-1", time: "08:00"),
+            TestFixtures.makeSchedule(id: "s-pm", medicationId: "med-1", time: "20:00"),
+        ]
+        // Evening dose was skipped, morning taken — each must land on its own row.
+        mockMedRepo.doses = [
+            TestFixtures.makeDose(id: "d-am", medicationId: "med-1", timestamp: todayAt(7, 45), status: .taken),
+            TestFixtures.makeDose(id: "d-pm", medicationId: "med-1", timestamp: todayAt(21, 0), status: .skipped),
+        ]
+
+        await sut.loadData()
+
+        let byId = Dictionary(uniqueKeysWithValues: sut.todaysMedications.map { ($0.schedule.id, $0) })
+        XCTAssertEqual(byId["s-am"]?.dose?.id, "d-am")
+        XCTAssertEqual(byId["s-am"]?.isTaken, true)
+        XCTAssertEqual(byId["s-pm"]?.dose?.id, "d-pm")
+        XCTAssertEqual(byId["s-pm"]?.isSkipped, true)
+    }
+
+    func testMatchDosesToSchedules_bindsClosestFirstAndUsesEachOnce() {
+        let schedules = [
+            TestFixtures.makeSchedule(id: "s-am", medicationId: "med-1", time: "08:00"),
+            TestFixtures.makeSchedule(id: "s-pm", medicationId: "med-1", time: "20:00"),
+        ]
+        let doses = [
+            TestFixtures.makeDose(id: "d-pm", medicationId: "med-1", timestamp: todayAt(19, 30)),
+            TestFixtures.makeDose(id: "d-am", medicationId: "med-1", timestamp: todayAt(8, 30)),
+        ]
+
+        let result = DashboardViewModel.matchDosesToSchedules(schedules: schedules, doses: doses)
+
+        XCTAssertEqual(result["s-am"]?.id, "d-am")
+        XCTAssertEqual(result["s-pm"]?.id, "d-pm")
+    }
+
+    func testMatchDosesToSchedules_fewerDosesThanSchedules_leavesExtraRowUnmatched() {
+        let schedules = [
+            TestFixtures.makeSchedule(id: "s-am", medicationId: "med-1", time: "08:00"),
+            TestFixtures.makeSchedule(id: "s-pm", medicationId: "med-1", time: "20:00"),
+        ]
+        let doses = [
+            TestFixtures.makeDose(id: "d-1", medicationId: "med-1", timestamp: todayAt(19, 45)),
+        ]
+
+        let result = DashboardViewModel.matchDosesToSchedules(schedules: schedules, doses: doses)
+
+        XCTAssertNil(result["s-am"])
+        XCTAssertEqual(result["s-pm"]?.id, "d-1")
+    }
 }

--- a/mobile-apps/ios/MigraLogTests/ViewModels/DashboardViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/DashboardViewModelTests.swift
@@ -398,4 +398,57 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertNil(result["s-am"])
         XCTAssertEqual(result["s-pm"]?.id, "d-1")
     }
+
+    func testMatchDosesToSchedules_exactScheduleIdWinsOverTime() {
+        // The dose names the morning schedule but was logged near the evening
+        // one; the explicit scheduleId is authoritative and must win.
+        let schedules = [
+            TestFixtures.makeSchedule(id: "s-am", medicationId: "med-1", time: "08:00"),
+            TestFixtures.makeSchedule(id: "s-pm", medicationId: "med-1", time: "20:00"),
+        ]
+        let doses = [
+            TestFixtures.makeDose(
+                id: "d-am", medicationId: "med-1", scheduleId: "s-am", timestamp: todayAt(19, 55)
+            ),
+        ]
+
+        let result = DashboardViewModel.matchDosesToSchedules(schedules: schedules, doses: doses)
+
+        XCTAssertEqual(result["s-am"]?.id, "d-am")
+        XCTAssertNil(result["s-pm"])
+    }
+
+    func testMatchDosesToSchedules_mixesExactAndTimeFallback() {
+        // One dose names its schedule; a second, ad-hoc dose (no scheduleId)
+        // falls back to time and must take the remaining row.
+        let schedules = [
+            TestFixtures.makeSchedule(id: "s-am", medicationId: "med-1", time: "08:00"),
+            TestFixtures.makeSchedule(id: "s-pm", medicationId: "med-1", time: "20:00"),
+        ]
+        let doses = [
+            TestFixtures.makeDose(id: "d-pm", medicationId: "med-1", scheduleId: "s-pm", timestamp: todayAt(20, 10)),
+            TestFixtures.makeDose(id: "d-am", medicationId: "med-1", timestamp: todayAt(8, 15)),
+        ]
+
+        let result = DashboardViewModel.matchDosesToSchedules(schedules: schedules, doses: doses)
+
+        XCTAssertEqual(result["s-pm"]?.id, "d-pm")
+        XCTAssertEqual(result["s-am"]?.id, "d-am")
+    }
+
+    func testLogDose_stampsScheduleIdOnRecordedDose() async throws {
+        let med = TestFixtures.makeMedication(id: "med-1", name: "Topiramate")
+        mockMedRepo.medications = [med]
+        mockMedRepo.schedules = [
+            TestFixtures.makeSchedule(id: "s-am", medicationId: "med-1", time: "08:00"),
+            TestFixtures.makeSchedule(id: "s-pm", medicationId: "med-1", time: "20:00"),
+        ]
+        await sut.loadData()
+        let eveningRow = try XCTUnwrap(sut.todaysMedications.first { $0.schedule.id == "s-pm" })
+
+        await sut.logDose(scheduleItem: eveningRow)
+
+        let recorded = try XCTUnwrap(mockMedRepo.doses.first)
+        XCTAssertEqual(recorded.scheduleId, "s-pm")
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #592 — on the dashboard's **Today's Medications** card, logging a single dose for a medication scheduled **more than once a day** marked **every** row for that med as taken. Root cause: dose→row matching keyed on **medication id only**, so all schedule rows picked up the same dose.

## Approach
Make the schedule↔dose link **authoritative** rather than inferred.

Doses previously carried no reference to the schedule they satisfy — only `medicationId` + `timestamp`. This adds a nullable **`scheduleId`** to doses, set when a dose is logged from a schedule row or a reminder notification, and the dashboard binds each row to its dose by that id.

Doses without a `scheduleId` — **ad-hoc/PRN logging, and any dose logged before this column existed** — fall back to a **time-of-day match** (each unclaimed schedule takes the nearest-in-time dose, used once). So a single-schedule med still shows an ad-hoc dose as taken, and nothing regresses. The matcher is two-phase: exact `scheduleId` first, then time.

### Why CloudKit needed no schema change
The sync layer (`SyncPayloadCodec` / `SyncRecord`) carries each row as an **opaque JSON `payload`** on one generic CloudKit record type — deliberately decoupled from the CloudKit schema so the local schema can evolve freely. A new local column just flows through the payload. No CloudKit dashboard/field work.

## Changes
- **Migration `v39`**: nullable `schedule_id` on `medication_doses`, recreate the doses sync-capture triggers (follows the v37 add-column precedent); `schemaVersion` 38→39. **No backfill** — existing doses stay `NULL` by design (few beta users; time fallback covers them).
- `SyncableTable.syncedColumns`: add `schedule_id` (drift test enforces lockstep; `SyncedSchemaManifest` auto-forces a one-time re-pull to backfill peers).
- Thread `scheduleId` through `MedicationDose`, `createDose`, `doseFromRow`.
- Populate it in `DashboardViewModel.logDose`/`skipDose` and `NotificationResponseHandler`.
- Two-phase `matchDosesToSchedules` in `DashboardViewModel`.

## Tests
Added to `DashboardViewModelTests`: one-dose-marks-only-nearest-row, two-doses-by-time, exact-scheduleId-wins-over-time, exact+fallback mix, `logDose` stamps `scheduleId`, plus direct matcher unit tests. `DatabaseManagerTests` version bump. `SyncableTableSyncedColumnsTests` validates the new column against the live migrated schema.

Full suite green locally: **1082 unit tests (1 skipped, 0 failures)** + UITests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)