### PR TITLE
feat(ios): beta post-drome tracking for episodes

### DIFF
--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager+Schema.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager+Schema.swift
@@ -6,7 +6,7 @@ import GRDB
 // queue ownership and the migration registry (and under the file_length limit).
 extension DatabaseManager {
     /// Create the v25 baseline schema. Later registered migrations evolve it to the
-    /// current version; see spec/schemas/sqlite/schema-v38.sql for the current end-state.
+    /// current version; see spec/schemas/sqlite/schema-v40.sql for the current end-state.
     // swiftlint:disable:next function_body_length
     static func createSchema(in db: Database) throws {
         // Episodes table
@@ -25,7 +25,8 @@ extension DatabaseManager {
                 location_accuracy REAL CHECK(location_accuracy IS NULL OR location_accuracy >= 0),
                 location_timestamp INTEGER CHECK(location_timestamp IS NULL OR location_timestamp > 0),
                 created_at INTEGER NOT NULL CHECK(created_at > 0),
-                updated_at INTEGER NOT NULL CHECK(updated_at > 0)
+                updated_at INTEGER NOT NULL CHECK(updated_at > 0),
+                postdrome_start_time INTEGER CHECK(postdrome_start_time IS NULL OR postdrome_start_time > 0)
             )
             """)
 

--- a/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
@@ -24,7 +24,7 @@ enum DatabaseInitializationError: Error {
 /// Central database manager. Owns the DatabaseQueue and handles schema creation/migration.
 final class DatabaseManager: Sendable {
     /// The current schema version
-    static let schemaVersion = 39
+    static let schemaVersion = 40
 
     /// Shared singleton for the app's main database
     static let shared = DatabaseManager()
@@ -406,6 +406,28 @@ final class DatabaseManager: Sendable {
             }
             for suffix in ["insert", "update", "delete"] {
                 try db.execute(sql: "DROP TRIGGER IF EXISTS sync_capture_medication_doses_\(suffix)")
+            }
+            try DatabaseManager.createSyncCaptureTriggers(in: db, includePayload: true)
+        }
+
+        // v40: add `postdrome_start_time` to episodes for the beta post-drome
+        // tracking feature (FeatureFlags.postdromeTracking). When set on an
+        // active episode, the attack has subsided but the episode remains open
+        // to capture after effects; NULL means the feature was never used on
+        // that episode, so this is fully backward compatible and removable.
+        // Nullable so sync payloads from older app versions still apply.
+        // Synced-column change → rebuild the episodes capture triggers so the
+        // DELETE tombstone carries the new column (v37/v39 precedent).
+        migrator.registerMigration("v40") { db in
+            let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(episodes)")
+            let hasColumn = columns.contains { (row: Row) in
+                (row["name"] as String?) == "postdrome_start_time"
+            }
+            if !hasColumn {
+                try db.execute(sql: "ALTER TABLE episodes ADD COLUMN postdrome_start_time INTEGER CHECK(postdrome_start_time IS NULL OR postdrome_start_time > 0)")
+            }
+            for suffix in ["insert", "update", "delete"] {
+                try db.execute(sql: "DROP TRIGGER IF EXISTS sync_capture_episodes_\(suffix)")
             }
             try DatabaseManager.createSyncCaptureTriggers(in: db, includePayload: true)
         }

--- a/mobile-apps/ios/MigraLog/Models/DomainModels.swift
+++ b/mobile-apps/ios/MigraLog/Models/DomainModels.swift
@@ -17,8 +17,17 @@ struct Episode: Identifiable, Equatable, Sendable {
     var locationTimestamp: Int64?
     let createdAt: Int64
     var updatedAt: Int64
+    /// Beta post-drome tracking (FeatureFlag.postdromeTracking): when set, the
+    /// attack itself has subsided but the episode stays active to capture after
+    /// effects (meds, symptoms, notes — pain levels no longer meaningful).
+    /// Cleared if the user resumes the attack; ending the episode ends the
+    /// post-drome with it.
+    var postdromeStartTime: Int64? = nil
 
     var isActive: Bool { endTime == nil }
+
+    /// Active and transitioned into the post-drome (recovery) phase.
+    var isInPostdrome: Bool { endTime == nil && postdromeStartTime != nil }
 
     var startDate: Date {
         Date(timeIntervalSince1970: Double(startTime) / 1000.0)
@@ -26,6 +35,10 @@ struct Episode: Identifiable, Equatable, Sendable {
 
     var endDate: Date? {
         endTime.map { Date(timeIntervalSince1970: Double($0) / 1000.0) }
+    }
+
+    var postdromeStartDate: Date? {
+        postdromeStartTime.map { Date(timeIntervalSince1970: Double($0) / 1000.0) }
     }
 
     var durationMillis: Int64? {

--- a/mobile-apps/ios/MigraLog/Repositories/EpisodeRepository.swift
+++ b/mobile-apps/ios/MigraLog/Repositories/EpisodeRepository.swift
@@ -17,8 +17,9 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
             try db.execute(
                 sql: """
                     INSERT INTO episodes (id, start_time, end_time, locations, qualities, symptoms, triggers, notes,
-                        latitude, longitude, location_accuracy, location_timestamp, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        latitude, longitude, location_accuracy, location_timestamp, created_at, updated_at,
+                        postdrome_start_time)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                 arguments: [
                     episode.id,
@@ -34,7 +35,8 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
                     episode.locationAccuracy,
                     episode.locationTimestamp,
                     episode.createdAt,
-                    episode.updatedAt
+                    episode.updatedAt,
+                    episode.postdromeStartTime
                 ]
             )
         }
@@ -108,7 +110,7 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
                         start_time = ?, end_time = ?, locations = ?, qualities = ?,
                         symptoms = ?, triggers = ?, notes = ?,
                         latitude = ?, longitude = ?, location_accuracy = ?, location_timestamp = ?,
-                        updated_at = ?
+                        updated_at = ?, postdrome_start_time = ?
                     WHERE id = ?
                     """,
                 arguments: [
@@ -124,6 +126,7 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
                     updated.locationAccuracy,
                     updated.locationTimestamp,
                     updated.updatedAt,
+                    updated.postdromeStartTime,
                     updated.id
                 ]
             )
@@ -138,10 +141,11 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
                     UPDATE episodes SET
                         start_time = start_time + ?,
                         end_time = CASE WHEN end_time IS NOT NULL THEN end_time + ? ELSE NULL END,
+                        postdrome_start_time = CASE WHEN postdrome_start_time IS NOT NULL THEN postdrome_start_time + ? ELSE NULL END,
                         updated_at = ?
                     WHERE id = ?
                     """,
-                arguments: [offset, offset, TimestampHelper.now, episodeId]
+                arguments: [offset, offset, offset, TimestampHelper.now, episodeId]
             )
         }
     }
@@ -497,7 +501,8 @@ final class EpisodeRepository: EpisodeRepositoryProtocol {
             locationAccuracy: row["location_accuracy"],
             locationTimestamp: row["location_timestamp"],
             createdAt: row["created_at"],
-            updatedAt: row["updated_at"]
+            updatedAt: row["updated_at"],
+            postdromeStartTime: row["postdrome_start_time"]
         )
     }
 

--- a/mobile-apps/ios/MigraLog/Services/Sync/SyncableTable.swift
+++ b/mobile-apps/ios/MigraLog/Services/Sync/SyncableTable.swift
@@ -73,7 +73,7 @@ enum SyncableTable: String, CaseIterable, Sendable {
         case .episodes:
             return ["id", "start_time", "end_time", "locations", "qualities", "symptoms",
                     "triggers", "notes", "latitude", "longitude", "location_accuracy",
-                    "location_timestamp", "created_at", "updated_at"]
+                    "location_timestamp", "created_at", "updated_at", "postdrome_start_time"]
         case .intensityReadings:
             return ["id", "episode_id", "timestamp", "intensity", "created_at", "updated_at"]
         case .symptomLogs:

--- a/mobile-apps/ios/MigraLog/Utils/FeatureFlags.swift
+++ b/mobile-apps/ios/MigraLog/Utils/FeatureFlags.swift
@@ -36,9 +36,16 @@ struct FeatureFlag: Identifiable {
     //     details: "Replaces the trends tab with the redesigned dashboard."
     // )
 
+    static let postdromeTracking = FeatureFlag(
+        key: "postdromeTracking",
+        title: "Post-drome Tracking",
+        details: "Transition an attack into a post-drome phase to track after "
+            + "effects (medications, symptoms, notes) without pain levels."
+    )
+
     /// Every flag surfaced in Beta Features, in display order.
     static let all: [FeatureFlag] = [
-        // .newInsightsDashboard,
+        .postdromeTracking,
     ]
 }
 

--- a/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
@@ -130,6 +130,51 @@ final class EpisodeDetailViewModel {
         }
     }
 
+    /// Beta post-drome tracking: mark the attack as subsided while keeping the
+    /// episode active so after effects can still be logged. The Live Activity is
+    /// left as-is — the episode is still ongoing.
+    @MainActor
+    func startPostdrome(at timestamp: Int64 = TimestampHelper.now) async {
+        guard var episode = details?.episode, episode.isActive, !episode.isInPostdrome else { return }
+        episode.postdromeStartTime = timestamp
+        episode.updatedAt = timestamp
+        do {
+            _ = try episodeRepository.updateEpisode(episode)
+            details = EpisodeWithDetails(
+                episode: episode,
+                intensityReadings: details?.intensityReadings ?? [],
+                symptomLogs: details?.symptomLogs ?? [],
+                painLocationLogs: details?.painLocationLogs ?? [],
+                episodeNotes: details?.episodeNotes ?? []
+            )
+        } catch {
+            ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "startPostdrome"])
+            self.error = error.localizedDescription
+        }
+    }
+
+    /// Beta post-drome tracking: undo the post-drome transition (the attack came
+    /// back, or it was tapped by mistake) — the episode returns to fully active.
+    @MainActor
+    func resumeAttack() async {
+        guard var episode = details?.episode, episode.isInPostdrome else { return }
+        episode.postdromeStartTime = nil
+        episode.updatedAt = TimestampHelper.now
+        do {
+            _ = try episodeRepository.updateEpisode(episode)
+            details = EpisodeWithDetails(
+                episode: episode,
+                intensityReadings: details?.intensityReadings ?? [],
+                symptomLogs: details?.symptomLogs ?? [],
+                painLocationLogs: details?.painLocationLogs ?? [],
+                episodeNotes: details?.episodeNotes ?? []
+            )
+        } catch {
+            ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "resumeAttack"])
+            self.error = error.localizedDescription
+        }
+    }
+
     @MainActor
     func editEndTime(_ timestamp: Int64) async {
         guard var episode = details?.episode, !episode.isActive else { return }

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeActionButtons.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeActionButtons.swift
@@ -10,6 +10,11 @@ struct EpisodeActionButtons: View {
     @Binding var showLogMedication: Bool
     @Binding var customEndTime: Date
     @Binding var showEndTimePicker: Bool
+    // Beta post-drome tracking. The flag gates only the entry point (the
+    // transition button); an episode already in post-drome keeps its controls
+    // even if the flag is later switched off, so no state gets stranded.
+    @AppStorage(FeatureFlag.postdromeTracking.storageKey)
+    private var postdromeTrackingEnabled = false
 
     var body: some View {
         VStack(spacing: DesignTokens.Spacing.sm) {
@@ -36,6 +41,32 @@ struct EpisodeActionButtons: View {
                     .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
             }
             .accessibilityIdentifier("log-medication-button")
+
+            if episode.isInPostdrome {
+                Button {
+                    Task { await viewModel.resumeAttack() }
+                } label: {
+                    Label("Resume Attack", systemImage: "arrow.uturn.backward.circle")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.indigo.opacity(0.1))
+                        .foregroundStyle(.indigo)
+                        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
+                }
+                .accessibilityIdentifier("resume-attack-button")
+            } else if postdromeTrackingEnabled {
+                Button {
+                    Task { await viewModel.startPostdrome() }
+                } label: {
+                    Label("Enter Post-drome", systemImage: "moon.haze")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.indigo.opacity(0.1))
+                        .foregroundStyle(.indigo)
+                        .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.lg))
+                }
+                .accessibilityIdentifier("enter-postdrome-button")
+            }
 
             HStack(spacing: DesignTokens.Spacing.sm) {
                 Button {

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -252,7 +252,15 @@ struct EpisodeDetailScreen: View {
 
                 Spacer()
 
-                if episode.isActive {
+                if episode.isInPostdrome {
+                    Text("Post-drome")
+                        .font(.caption.weight(.bold))
+                        .padding(.horizontal, DesignTokens.Spacing.md)
+                        .padding(.vertical, 6)
+                        .background(Color.indigo.opacity(0.2))
+                        .foregroundStyle(.indigo)
+                        .clipShape(Capsule())
+                } else if episode.isActive {
                     Text("Ongoing")
                         .font(.caption.weight(.bold))
                         .padding(.horizontal, DesignTokens.Spacing.md)
@@ -285,6 +293,19 @@ struct EpisodeDetailScreen: View {
                 }
             }
             .font(.subheadline)
+
+            // Beta post-drome tracking: when the attack transitioned into a
+            // post-drome phase, show when. Rendered for ended episodes too so
+            // the phase remains visible in history.
+            if let postdromeStart = episode.postdromeStartDate {
+                HStack {
+                    Text("Post-drome since")
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(DateFormatting.displayDateTime(postdromeStart))
+                }
+                .font(.subheadline)
+            }
 
             // Symptoms
             if !episode.symptoms.isEmpty {

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -237,47 +237,53 @@ struct EpisodeDetailScreen: View {
         }
     }
 
+    // Dates row: start time plus the episode's current status — the beta
+    // post-drome badge, the ongoing badge, or the end time.
+    @ViewBuilder
+    private func episodeDatesRow(_ episode: Episode) -> some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Started")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(DateFormatting.displayDateTime(episode.startDate))
+                    .font(.subheadline)
+            }
+
+            Spacer()
+
+            if episode.isInPostdrome {
+                Text("Post-drome")
+                    .font(.caption.weight(.bold))
+                    .padding(.horizontal, DesignTokens.Spacing.md)
+                    .padding(.vertical, 6)
+                    .background(Color.indigo.opacity(0.2))
+                    .foregroundStyle(.indigo)
+                    .clipShape(Capsule())
+            } else if episode.isActive {
+                Text("Ongoing")
+                    .font(.caption.weight(.bold))
+                    .padding(.horizontal, DesignTokens.Spacing.md)
+                    .padding(.vertical, 6)
+                    .background(Color.red.opacity(0.2))
+                    .foregroundStyle(.red)
+                    .clipShape(Capsule())
+            } else if let endDate = episode.endDate {
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("Ended")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(DateFormatting.displayDateTime(endDate))
+                        .font(.subheadline)
+                }
+            }
+        }
+    }
+
     @ViewBuilder
     private func episodeSummarySection(_ episode: Episode) -> some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
-            // Dates row
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Started")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Text(DateFormatting.displayDateTime(episode.startDate))
-                        .font(.subheadline)
-                }
-
-                Spacer()
-
-                if episode.isInPostdrome {
-                    Text("Post-drome")
-                        .font(.caption.weight(.bold))
-                        .padding(.horizontal, DesignTokens.Spacing.md)
-                        .padding(.vertical, 6)
-                        .background(Color.indigo.opacity(0.2))
-                        .foregroundStyle(.indigo)
-                        .clipShape(Capsule())
-                } else if episode.isActive {
-                    Text("Ongoing")
-                        .font(.caption.weight(.bold))
-                        .padding(.horizontal, DesignTokens.Spacing.md)
-                        .padding(.vertical, 6)
-                        .background(Color.red.opacity(0.2))
-                        .foregroundStyle(.red)
-                        .clipShape(Capsule())
-                } else if let endDate = episode.endDate {
-                    VStack(alignment: .trailing, spacing: 2) {
-                        Text("Ended")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text(DateFormatting.displayDateTime(endDate))
-                            .font(.subheadline)
-                    }
-                }
-            }
+            episodeDatesRow(episode)
 
             Divider()
 

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodesScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodesScreen.swift
@@ -96,7 +96,8 @@ struct EpisodeCardView: View {
                 IntensitySparklineView(
                     readings: readings,
                     episodeStart: episode.startTime,
-                    episodeEnd: episode.endTime
+                    episodeEnd: episode.endTime,
+                    postdromeStart: episode.postdromeStartTime
                 )
                 .frame(width: 160, height: 50)
                 .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.sm))
@@ -172,7 +173,8 @@ struct EpisodeListRowView: View {
                 IntensitySparklineView(
                     readings: readings,
                     episodeStart: episode.startTime,
-                    episodeEnd: episode.endTime
+                    episodeEnd: episode.endTime,
+                    postdromeStart: episode.postdromeStartTime
                 )
                 .frame(width: 140, height: 44)
                 .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.sm))

--- a/mobile-apps/ios/MigraLog/Views/Episodes/IntensitySparklineView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/IntensitySparklineView.swift
@@ -8,6 +8,10 @@ struct IntensitySparklineView: View {
     var episodeStart: Int64?
     /// Episode end time (nil for ongoing — uses current time)
     var episodeEnd: Int64?
+    /// Beta post-drome tracking: when set, the intensity line stops here and
+    /// the remainder of the chart is a flat grey span — pain levels aren't
+    /// tracked during the post-drome phase.
+    var postdromeStart: Int64?
 
     /// Pain scale gradient colors from 0 (green) to 10 (purple).
     /// Sourced from the shared palette in DesignTokens.Pain.
@@ -22,6 +26,8 @@ struct IntensitySparklineView: View {
             if !sorted.isEmpty {
                 let startT = episodeStart ?? sorted.first!.timestamp
                 let endT = episodeEnd ?? Int64(Date().timeIntervalSince1970 * 1000)
+                // The line/dots stop at the post-drome transition (if any).
+                let lineEndT = min(max(postdromeStart ?? endT, startT), endT)
                 let timeRange = max(Double(endT - startT), 1)
                 let padding: CGFloat = 4
                 let chartW = geo.size.width - padding * 2
@@ -29,7 +35,7 @@ struct IntensitySparklineView: View {
 
                 // Interpolate at 5-minute intervals with sample-and-hold, then smooth
                 let smoothed = Self.smoothedData(
-                    readings: sorted, start: startT, end: endT
+                    readings: sorted, start: startT, end: lineEndT
                 )
 
                 // Background gradient (green at bottom, purple at top)
@@ -41,6 +47,20 @@ struct IntensitySparklineView: View {
                             endPoint: .top
                         )
                     )
+
+                // Post-drome span: plain grey, no line — pain isn't tracked here.
+                if lineEndT < endT {
+                    let pdX = padding + chartW * CGFloat(Double(lineEndT - startT) / timeRange)
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 0,
+                        bottomLeadingRadius: 0,
+                        bottomTrailingRadius: DesignTokens.Radius.sm,
+                        topTrailingRadius: DesignTokens.Radius.sm
+                    )
+                    .fill(Color(.systemGray5))
+                    .frame(width: max(geo.size.width - pdX, 0), height: geo.size.height)
+                    .offset(x: pdX)
+                }
 
                 // Smoothed line with gradient stroke
                 if smoothed.count > 1 {
@@ -64,11 +84,12 @@ struct IntensitySparklineView: View {
                         style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round)
                     )
                 } else if sorted.count == 1 {
-                    // Single reading: flat line across full width
+                    // Single reading: flat line up to the post-drome cutoff (or full width)
                     let y = padding + chartH * (1 - CGFloat(sorted[0].intensity / 10.0))
+                    let lineEndX = padding + chartW * CGFloat(Double(lineEndT - startT) / timeRange)
                     Path { path in
                         path.move(to: CGPoint(x: padding, y: y))
-                        path.addLine(to: CGPoint(x: padding + chartW, y: y))
+                        path.addLine(to: CGPoint(x: lineEndX, y: y))
                     }
                     .stroke(
                         PainScale.color(for: sorted[0].intensity),
@@ -76,8 +97,8 @@ struct IntensitySparklineView: View {
                     )
                 }
 
-                // Reading dots at actual data points
-                ForEach(sorted) { reading in
+                // Reading dots at actual data points (none inside the post-drome span)
+                ForEach(sorted.filter { $0.timestamp <= lineEndT }) { reading in
                     let x = padding + chartW * CGFloat(Double(reading.timestamp - startT) / timeRange)
                     let y = padding + chartH * (1 - CGFloat(reading.intensity / 10.0))
                     Circle()

--- a/mobile-apps/ios/MigraLog/Views/Episodes/LogUpdateScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/LogUpdateScreen.swift
@@ -16,10 +16,17 @@ struct LogUpdateScreen: View {
     @State private var isSaving = false
     @State private var didLoadState = false
 
+    // Beta post-drome tracking: during the post-drome phase pain levels aren't
+    // meaningful, so the intensity slider is hidden and no reading is saved —
+    // updates capture only symptoms, locations, and notes.
+    private var isInPostdrome: Bool { viewModel.episode?.isInPostdrome == true }
+
     var body: some View {
         Form {
-            Section("Pain Intensity") {
-                PainIntensitySlider(intensity: $intensity)
+            if !isInPostdrome {
+                Section("Pain Intensity") {
+                    PainIntensitySlider(intensity: $intensity)
+                }
             }
 
             Section("Time") {
@@ -124,11 +131,13 @@ struct LogUpdateScreen: View {
         defer { isSaving = false }
         let updateTimestamp = TimestampHelper.fromDate(timestamp)
 
-        // Add intensity reading
-        await viewModel.addIntensityReading(
-            intensity: intensity,
-            timestamp: updateTimestamp
-        )
+        // Add intensity reading (not during post-drome — pain levels don't apply)
+        if !isInPostdrome {
+            await viewModel.addIntensityReading(
+                intensity: intensity,
+                timestamp: updateTimestamp
+            )
+        }
 
         // Add symptom logs only for newly added symptoms
         let newSymptoms = selectedSymptoms.subtracting(initialSymptoms)

--- a/mobile-apps/ios/MigraLog/Views/Episodes/TimelineView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/TimelineView.swift
@@ -18,6 +18,7 @@ struct TimelineEvent: Identifiable {
         case painLocation(PainLocationLog, PainLocationDelta)
         case note(EpisodeNote)
         case medication(DoseWithMedication)
+        case postdromeStarted
         case episodeEnded
 
         var isEpisodeEnded: Bool {
@@ -65,7 +66,8 @@ struct TimelineView: View {
                 IntensitySparklineView(
                     readings: details.intensityReadings,
                     episodeStart: details.episode.startTime,
-                    episodeEnd: details.episode.endTime
+                    episodeEnd: details.episode.endTime,
+                    postdromeStart: details.episode.postdromeStartTime
                 )
                 .frame(height: 80)
                 .clipShape(RoundedRectangle(cornerRadius: DesignTokens.Radius.sm))
@@ -214,6 +216,16 @@ struct TimelineView: View {
             ))
         }
 
+        // Post-drome transition (beta): the attack subsided here; later entries
+        // are after effects.
+        if let postdromeStart = details.episode.postdromeStartTime {
+            events.append(TimelineEvent(
+                id: "postdrome-started",
+                timestamp: postdromeStart,
+                kind: .postdromeStarted
+            ))
+        }
+
         // Episode ended event
         if let endTime = details.episode.endTime {
             events.append(TimelineEvent(
@@ -250,6 +262,7 @@ struct TimelineView: View {
         case .painLocation(_, _): .secondary
         case .note: .secondary
         case .medication: .secondary
+        case .postdromeStarted: .indigo
         case .episodeEnded: .secondary
         }
         Circle()
@@ -268,6 +281,7 @@ struct TimelineView: View {
         case .painLocation(_, let delta): delta.isInitial ? "Initial Pain Locations" : "Pain Location Changes"
         case .note: "Note"
         case .medication(let d): d.dose.status == .taken ? "Medication Taken" : "Medication Skipped"
+        case .postdromeStarted: "Entered Post-drome"
         case .episodeEnded: "Episode Ended"
         }
         Text(title)
@@ -353,6 +367,12 @@ struct TimelineView: View {
                 .foregroundStyle(.secondary)
                 .padding(.top, 2)
 
+        case .postdromeStarted:
+            Text("Attack subsided — tracking after effects")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .padding(.top, 2)
+
         case .episodeEnded:
             EmptyView()
         }
@@ -427,6 +447,15 @@ struct TimelineView: View {
                 showDeleteConfirmation = true
             } label: {
                 Label("Delete", systemImage: "trash")
+            }
+
+        case .postdromeStarted:
+            if viewModel.episode?.isInPostdrome == true {
+                Button {
+                    Task { await viewModel.resumeAttack() }
+                } label: {
+                    Label("Resume Attack", systemImage: "arrow.uturn.backward.circle")
+                }
             }
 
         case .episodeEnded:

--- a/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Database/DatabaseManagerTests.swift
@@ -190,7 +190,7 @@ final class DatabaseManagerTests: XCTestCase {
     // MARK: - Schema Version
 
     func testSchemaVersionIsTracked() throws {
-        XCTAssertEqual(DatabaseManager.schemaVersion, 39)
+        XCTAssertEqual(DatabaseManager.schemaVersion, 40)
     }
 
     func testMigrationIsRecordedInGRDB() throws {

--- a/mobile-apps/ios/MigraLogTests/MockRepositories.swift
+++ b/mobile-apps/ios/MigraLogTests/MockRepositories.swift
@@ -797,7 +797,8 @@ enum TestFixtures {
         locations: [PainLocation] = [],
         qualities: [PainQuality] = [],
         symptoms: [Symptom] = [],
-        triggers: [Trigger] = []
+        triggers: [Trigger] = [],
+        postdromeStartTime: Int64? = nil
     ) -> Episode {
         let ts = startTime ?? now
         return Episode(
@@ -814,7 +815,8 @@ enum TestFixtures {
             locationAccuracy: nil,
             locationTimestamp: nil,
             createdAt: ts,
-            updatedAt: ts
+            updatedAt: ts,
+            postdromeStartTime: postdromeStartTime
         )
     }
 

--- a/mobile-apps/ios/MigraLogTests/Repositories/EpisodeRepositoryTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Repositories/EpisodeRepositoryTests.swift
@@ -157,6 +157,40 @@ final class EpisodeRepositoryTests: XCTestCase {
         XCTAssertEqual(fetched?.longitude, -122.0)
     }
 
+    // Beta post-drome tracking: the nullable postdrome_start_time column
+    // round-trips through create, update (set and clear), and fetch.
+    func testPostdromeStartTimeRoundTrip() throws {
+        let episode = makeEpisode()
+        try repo.createEpisode(episode)
+        XCTAssertNil(try repo.getEpisodeById(episode.id)?.postdromeStartTime)
+
+        var inPostdrome = episode
+        inPostdrome.postdromeStartTime = 1_700_003_600_000
+        _ = try repo.updateEpisode(inPostdrome)
+        let fetched = try repo.getEpisodeById(episode.id)
+        XCTAssertEqual(fetched?.postdromeStartTime, 1_700_003_600_000)
+        XCTAssertTrue(fetched?.isInPostdrome == true)
+
+        var resumed = inPostdrome
+        resumed.postdromeStartTime = nil
+        _ = try repo.updateEpisode(resumed)
+        let cleared = try repo.getEpisodeById(episode.id)
+        XCTAssertNil(cleared?.postdromeStartTime)
+        XCTAssertTrue(cleared?.isInPostdrome == false)
+    }
+
+    // An ended episode is not "in post-drome" even if the phase was recorded.
+    func testIsInPostdromeFalseOnceEnded() throws {
+        var episode = makeEpisode()
+        episode.postdromeStartTime = 1_700_003_600_000
+        episode.endTime = 1_700_007_200_000
+        try repo.createEpisode(episode)
+
+        let fetched = try repo.getEpisodeById(episode.id)
+        XCTAssertEqual(fetched?.postdromeStartTime, 1_700_003_600_000)
+        XCTAssertTrue(fetched?.isInPostdrome == false)
+    }
+
     func testGetEpisodeByIdExists() throws {
         let episode = makeEpisode()
         try repo.createEpisode(episode)

--- a/mobile-apps/ios/MigraLogTests/ViewModels/EpisodeDetailViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/EpisodeDetailViewModelTests.swift
@@ -71,6 +71,76 @@ final class EpisodeDetailViewModelTests: XCTestCase {
         XCTAssertFalse(mockRepo.updateEpisodeCalled)
     }
 
+    // MARK: - Post-drome (beta)
+
+    func testStartPostdrome_setsPostdromeStartTime() async throws {
+        await sut.loadEpisode()
+        XCTAssertFalse(sut.episode!.isInPostdrome)
+
+        await sut.startPostdrome(at: 1_700_003_600_000)
+
+        XCTAssertEqual(sut.episode?.postdromeStartTime, 1_700_003_600_000)
+        XCTAssertTrue(sut.episode!.isInPostdrome)
+        XCTAssertTrue(sut.episode!.isActive, "Post-drome keeps the episode active")
+        XCTAssertTrue(mockRepo.updateEpisodeCalled)
+    }
+
+    func testStartPostdrome_endedEpisode_noOp() async throws {
+        mockRepo.episodes = [TestFixtures.makeEpisode(id: "ep-1", endTime: TimestampHelper.now)]
+        await sut.loadEpisode()
+
+        await sut.startPostdrome()
+
+        XCTAssertFalse(mockRepo.updateEpisodeCalled)
+        XCTAssertNil(sut.episode?.postdromeStartTime)
+    }
+
+    func testStartPostdrome_alreadyInPostdrome_noOp() async throws {
+        mockRepo.episodes = [TestFixtures.makeEpisode(id: "ep-1", postdromeStartTime: 1_700_003_600_000)]
+        await sut.loadEpisode()
+
+        await sut.startPostdrome()
+
+        XCTAssertFalse(mockRepo.updateEpisodeCalled)
+        XCTAssertEqual(sut.episode?.postdromeStartTime, 1_700_003_600_000)
+    }
+
+    func testResumeAttack_clearsPostdromeStartTime() async throws {
+        mockRepo.episodes = [TestFixtures.makeEpisode(id: "ep-1", postdromeStartTime: 1_700_003_600_000)]
+        await sut.loadEpisode()
+        XCTAssertTrue(sut.episode!.isInPostdrome)
+
+        await sut.resumeAttack()
+
+        XCTAssertNil(sut.episode?.postdromeStartTime)
+        XCTAssertFalse(sut.episode!.isInPostdrome)
+        XCTAssertTrue(sut.episode!.isActive)
+        XCTAssertTrue(mockRepo.updateEpisodeCalled)
+    }
+
+    func testResumeAttack_notInPostdrome_noOp() async throws {
+        await sut.loadEpisode()
+
+        await sut.resumeAttack()
+
+        XCTAssertFalse(mockRepo.updateEpisodeCalled)
+    }
+
+    func testEndEpisode_fromPostdrome_endsAndKeepsPhaseRecord() async throws {
+        mockRepo.episodes = [TestFixtures.makeEpisode(id: "ep-1", postdromeStartTime: 1_700_003_600_000)]
+        await sut.loadEpisode()
+        XCTAssertTrue(sut.episode!.isInPostdrome)
+
+        await sut.endEpisode()
+
+        XCTAssertNotNil(sut.episode?.endTime)
+        XCTAssertFalse(sut.episode!.isInPostdrome, "Ended episodes are no longer in post-drome")
+        XCTAssertEqual(
+            sut.episode?.postdromeStartTime, 1_700_003_600_000,
+            "The phase record is kept for history"
+        )
+    }
+
     // MARK: - Reopen Episode
 
     func testReopenEpisode_clearsEndTime() async throws {

--- a/mobile-apps/ios/MigraLogUITests/BetaFeaturesUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/BetaFeaturesUITests.swift
@@ -34,11 +34,16 @@ final class BetaFeaturesUITests: XCTestCase {
         let title = app.navigationBars.staticTexts["Beta Features"]
         UITestHelpers.waitForElement(title)
 
-        // Feature Flags section header + empty-state copy (no flags registered yet).
+        // Feature Flags section header + the registered post-drome flag, off by default.
         UITestHelpers.waitForElement(app.staticTexts["Feature Flags"])
+        let postdromeToggle = app.switches["feature-flag-postdromeTracking"]
         XCTAssertTrue(
-            app.staticTexts["No experimental features are available right now."].exists,
-            "Empty feature-flags state should be shown when no flags are registered"
+            postdromeToggle.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+            "Post-drome Tracking flag should render a toggle"
+        )
+        XCTAssertEqual(
+            postdromeToggle.value as? String, "0",
+            "Post-drome Tracking must be off by default"
         )
 
         // Sample data loader moved under Beta Features.

--- a/mobile-apps/ios/MigraLogUITests/PostdromeFlowUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/PostdromeFlowUITests.swift
@@ -69,14 +69,22 @@ final class PostdromeFlowUITests: XCTestCase {
         Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
 
         // === Phase 3: enter post-drome ===
+        // A scroll swipe can register as a tap on the transition button, so
+        // tolerate the transition having already happened: anchor scrolling on
+        // the always-present Log Update button, then tap only if still needed.
         let detailScroll = app.scrollViews["episode-detail-scroll"]
         let enterPostdrome = app.buttons["enter-postdrome-button"]
-        if !enterPostdrome.isHittable {
-            UITestHelpers.scrollToElement(enterPostdrome, in: detailScroll)
+        let resumeAttack = app.buttons["resume-attack-button"]
+        if !resumeAttack.exists {
+            let anchor = app.buttons["log-update-button"]
+            if !anchor.isHittable {
+                UITestHelpers.scrollToElement(anchor, in: detailScroll)
+            }
+            if enterPostdrome.waitForExistence(timeout: 2), enterPostdrome.isHittable {
+                attachScreenshot(named: "2-active-episode-with-enter-postdrome")
+                enterPostdrome.tap()
+            }
         }
-        UITestHelpers.waitForHittable(enterPostdrome)
-        attachScreenshot(named: "2-active-episode-with-enter-postdrome")
-        enterPostdrome.tap()
 
         let postdromeBadge = app.staticTexts
             .matching(NSPredicate(format: "label CONTAINS 'Post-drome'")).firstMatch
@@ -84,7 +92,6 @@ final class PostdromeFlowUITests: XCTestCase {
             postdromeBadge.waitForExistence(timeout: UITestHelpers.defaultTimeout),
             "Detail screen should show the Post-drome badge after transitioning"
         )
-        let resumeAttack = app.buttons["resume-attack-button"]
         UITestHelpers.waitForElement(resumeAttack)
         XCTAssertFalse(
             app.buttons["enter-postdrome-button"].exists,
@@ -124,6 +131,14 @@ final class PostdromeFlowUITests: XCTestCase {
 
         // === Phase 5: timeline reflects the update; still in post-drome ===
         UITestHelpers.waitForElement(resumeAttack)
+        let timelineEntry = app.staticTexts["Entered Post-drome"]
+        if !timelineEntry.exists {
+            UITestHelpers.scrollToElement(timelineEntry, in: detailScroll)
+        }
+        XCTAssertTrue(
+            timelineEntry.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+            "Timeline should show the Entered Post-drome event"
+        )
         attachScreenshot(named: "5-postdrome-with-timeline")
         // Intentionally leave the episode in post-drome so a manual relaunch
         // of the app lands on this state for exploration.

--- a/mobile-apps/ios/MigraLogUITests/PostdromeFlowUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/PostdromeFlowUITests.swift
@@ -1,0 +1,138 @@
+import XCTest
+
+/// End-to-end flow for the beta post-drome tracking feature
+/// (FeatureFlags.postdromeTracking): enable the flag in Settings → Beta
+/// Features, start an episode, transition it into post-drome, verify the pain
+/// slider is gone from Log Update, and log an update. Screenshots are attached
+/// at each stage for visual review.
+///
+/// Launches with the rich sample dataset (not the minimal fixtures) so the
+/// screens look realistic, and deliberately leaves the episode in post-drome —
+/// the seeded state persists in the app container, so relaunching the app after
+/// this test shows the feature live for manual exploration.
+final class PostdromeFlowUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["--uitesting", "--load-screenshot-data"]
+        app.launch()
+        UITestHelpers.waitForDashboard(in: app)
+    }
+
+    override func tearDownWithError() throws {
+        // Diagnose stalls: capture wherever the app ended up.
+        if let app {
+            attachScreenshot(named: "teardown-final-state")
+        }
+        app = nil
+    }
+
+    func testPostdromeFlow() throws {
+        // === Phase 1: enable the beta flag ===
+        let settingsButton = app.buttons["settings-button"]
+        UITestHelpers.waitForHittable(settingsButton)
+        settingsButton.tap()
+        UITestHelpers.waitForElement(app.navigationBars.staticTexts["Settings"])
+
+        let betaLink = app.buttons["beta-features"]
+        let list = app.collectionViews.firstMatch
+        if list.exists {
+            UITestHelpers.scrollToElement(betaLink, in: list)
+        }
+        UITestHelpers.waitForHittable(betaLink)
+        betaLink.tap()
+        UITestHelpers.waitForElement(app.navigationBars.staticTexts["Beta Features"])
+
+        // Idempotent: only toggle when off, so a rerun against a warm container
+        // still passes. Default-off is asserted by BetaFeaturesUITests.
+        let flagToggle = app.switches["feature-flag-postdromeTracking"]
+        UITestHelpers.waitForElement(flagToggle)
+        if flagToggle.value as? String == "0" {
+            flagToggle.switches.firstMatch.tap()
+        }
+        XCTAssertEqual(flagToggle.value as? String, "1", "Flag should be on after toggling")
+        attachScreenshot(named: "1-beta-flag-enabled")
+
+        // Back to the dashboard (pop Beta Features, then Settings).
+        app.navigationBars.buttons.element(boundBy: 0).tap()
+        app.navigationBars.buttons.element(boundBy: 0).tap()
+        UITestHelpers.waitForDashboard(in: app)
+
+        // === Phase 2: open the ongoing episode ===
+        // The screenshot dataset seeds an episode that is still ongoing, so
+        // open it directly rather than starting a new one.
+        let activeEpisodeCard = app.buttons["active-episode-card"]
+        UITestHelpers.waitForHittable(activeEpisodeCard)
+        activeEpisodeCard.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // === Phase 3: enter post-drome ===
+        let detailScroll = app.scrollViews["episode-detail-scroll"]
+        let enterPostdrome = app.buttons["enter-postdrome-button"]
+        if !enterPostdrome.isHittable {
+            UITestHelpers.scrollToElement(enterPostdrome, in: detailScroll)
+        }
+        UITestHelpers.waitForHittable(enterPostdrome)
+        attachScreenshot(named: "2-active-episode-with-enter-postdrome")
+        enterPostdrome.tap()
+
+        let postdromeBadge = app.staticTexts
+            .matching(NSPredicate(format: "label CONTAINS 'Post-drome'")).firstMatch
+        XCTAssertTrue(
+            postdromeBadge.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+            "Detail screen should show the Post-drome badge after transitioning"
+        )
+        let resumeAttack = app.buttons["resume-attack-button"]
+        UITestHelpers.waitForElement(resumeAttack)
+        XCTAssertFalse(
+            app.buttons["enter-postdrome-button"].exists,
+            "Enter Post-drome should be replaced by Resume Attack"
+        )
+        attachScreenshot(named: "3-postdrome-detail")
+
+        // === Phase 4: log an update — no pain slider in post-drome ===
+        let logUpdateButton = app.buttons["log-update-button"]
+        if !logUpdateButton.isHittable {
+            UITestHelpers.scrollToElement(logUpdateButton, in: detailScroll)
+        }
+        UITestHelpers.waitForHittable(logUpdateButton)
+        logUpdateButton.tap()
+        UITestHelpers.waitForElement(app.navigationBars.staticTexts["Log Update"])
+
+        XCTAssertFalse(
+            app.staticTexts["Pain Intensity"].exists,
+            "Pain intensity section must be hidden during post-drome"
+        )
+        XCTAssertEqual(app.sliders.count, 0, "No pain slider during post-drome")
+
+        // Log a lingering symptom and a note.
+        let fatigueChip = app.buttons["Fatigue"]
+        if fatigueChip.waitForExistence(timeout: 2) {
+            fatigueChip.tap()
+        }
+        let noteField = app.textViews.firstMatch
+        if noteField.waitForExistence(timeout: 2) {
+            noteField.tap()
+            noteField.typeText("Post-drome fog, tired but pain has subsided")
+        }
+        attachScreenshot(named: "4-log-update-no-pain-slider")
+
+        app.buttons["Save"].tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // === Phase 5: timeline reflects the update; still in post-drome ===
+        UITestHelpers.waitForElement(resumeAttack)
+        attachScreenshot(named: "5-postdrome-with-timeline")
+        // Intentionally leave the episode in post-drome so a manual relaunch
+        // of the app lands on this state for exploration.
+    }
+
+    private func attachScreenshot(named name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/spec/schemas/sqlite/schema-v40.sql
+++ b/spec/schemas/sqlite/schema-v40.sql
@@ -1,4 +1,4 @@
--- MigraLog SQLite Schema v38
+-- MigraLog SQLite Schema v40
 -- Canonical schema definition for the migraine tracking database.
 -- Source of truth: mobile-apps/ios/MigraLog/Database/DatabaseManager.swift
 --   (createSchema + registered migrations). This .sql is a formal mirror and
@@ -39,6 +39,16 @@
 --   enabled-schedule count, so adherence stats grade each day against the
 --   configuration true on that day. Backfilled from each active scheduled
 --   preventative's created_at. Synced.
+-- v39 (#592): added the nullable `schedule_id` column to medication_doses so a
+--   logged dose is tied to the specific scheduled occurrence it satisfies. Older
+--   doses keep NULL and fall back to time-of-day matching. Synced; doses capture
+--   triggers rebuilt to include it.
+-- v40: added the nullable `postdrome_start_time` column to episodes for the beta
+--   post-drome tracking feature (FeatureFlags.postdromeTracking). When set on an
+--   active episode the attack has subsided but the episode stays open to capture
+--   after effects (meds, symptoms, notes — no pain levels). NULL = feature unused;
+--   fully backward compatible and removable. Synced; episodes capture triggers
+--   rebuilt to include it.
 --
 -- Conventions:
 --   - All IDs are TEXT (UUIDs)
@@ -62,7 +72,8 @@ CREATE TABLE IF NOT EXISTS episodes (
   location_accuracy REAL CHECK(location_accuracy IS NULL OR location_accuracy >= 0),
   location_timestamp INTEGER CHECK(location_timestamp IS NULL OR location_timestamp > 0),
   created_at INTEGER NOT NULL CHECK(created_at > 0),
-  updated_at INTEGER NOT NULL CHECK(updated_at > 0)
+  updated_at INTEGER NOT NULL CHECK(updated_at > 0),
+  postdrome_start_time INTEGER CHECK(postdrome_start_time IS NULL OR postdrome_start_time > 0)  -- v40, beta post-drome tracking
 );
 
 -- Intensity readings table
@@ -164,6 +175,7 @@ CREATE TABLE IF NOT EXISTS medication_expectation_periods (
 CREATE TABLE IF NOT EXISTS medication_doses (
   id TEXT PRIMARY KEY,
   medication_id TEXT NOT NULL,
+  schedule_id TEXT,              -- v39 (#592): the scheduled occurrence this dose satisfies
   timestamp INTEGER NOT NULL CHECK(timestamp > 0),
   quantity REAL NOT NULL CHECK(quantity >= 0),
   dosage_amount REAL,


### PR DESCRIPTION
## Summary
Candidate feature: transition an active migraine attack into a **post-drome** phase to track after effects. Off by default behind the **Post-drome Tracking** flag in Settings → Beta Features (pre-release builds only).

- **Enter Post-drome** button on an active episode (only when the flag is on); **Resume Attack** undoes it; ending the episode works exactly as before and closes the post-drome with it
- During post-drome the episode stays active, so meds / symptoms / locations / notes keep logging against it unchanged — but the pain-intensity slider is hidden in Log Update and no readings are recorded
- Detail screen shows an indigo **Post-drome** badge and a "Post-drome since" row (kept in history after the episode ends)

## Deliberately minimal / easy to remove
- One nullable synced column: `episodes.postdrome_start_time` (v40 migration, guarded ALTER + episodes capture-trigger rebuild per v37/v39 precedent; `SyncableTable.syncedColumns` updated — no CloudKit schema change needed)
- "In post-drome" is derived state (`end_time IS NULL AND postdrome_start_time IS NOT NULL`); no new tables, no changes to dose/note/symptom association
- The flag gates only the entry point; existing post-drome data renders regardless, so toggling the flag off can't strand weird states
- Removal = delete the flag + two VM methods + small UI branches; the column sits inert (or drop it in a later migration)
- Live Activity intentionally untouched (episode is still active); spec schema mirror caught up to v40 (also backfills the missed v39 `medication_doses.schedule_id` note)

## Testing
- Full `MigraLogTests` unit target passes locally (repo round-trip, VM transition tests, synced-columns drift guard, capture-trigger tests)
- `PostdromeFlowUITests` drives the whole flow on the simulator (enable flag → enter post-drome → no pain slider → log update) with screenshot evidence
- `BetaFeaturesUITests` updated: asserts the flag renders and is off by default (was asserting the empty flags state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)