### PR TITLE
feat(ios): beta 2-hour post-dose check-in notification

### DIFF
--- a/mobile-apps/ios/MigraLog/App/ContentView.swift
+++ b/mobile-apps/ios/MigraLog/App/ContentView.swift
@@ -71,6 +71,12 @@ struct ContentView: View {
             // navigation state. AppState ignores anything it doesn't recognize.
             appState.handle(url: url)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .doseCheckinTapped)) { notification in
+            // A 2h dose check-in was tapped: open the episode's Log Update
+            // screen, the same surface the Live Activity intensity link uses.
+            guard let episodeId = notification.userInfo?["episodeId"] as? String else { return }
+            appState.route(to: .logIntensity(episodeId: episodeId))
+        }
         .onChange(of: scenePhase) { _, phase in
             switch phase {
             case .active:

--- a/mobile-apps/ios/MigraLog/Services/DoseCheckinNotificationService.swift
+++ b/mobile-apps/ios/MigraLog/Services/DoseCheckinNotificationService.swift
@@ -1,0 +1,100 @@
+import Foundation
+import UserNotifications
+
+// MARK: - Protocol
+
+protocol DoseCheckinNotificationServiceProtocol: Sendable {
+    /// Schedule a "how are you feeling?" check-in for a just-logged dose, when
+    /// eligible. Best-effort: never throws, so dose logging can't fail because
+    /// a notification couldn't be scheduled.
+    func scheduleCheckin(for dose: MedicationDose) async
+    /// Cancel any pending or delivered check-ins tied to the episode (e.g. when
+    /// it ends — the outcome is known, so the prompt is stale).
+    func cancelCheckins(forEpisodeId episodeId: String) async
+}
+
+// MARK: - Implementation
+
+/// Beta (`FeatureFlags.doseCheckin`): 2 hours after a rescue dose is taken
+/// during an episode, prompt the user to log an update. Two hours is the
+/// standard clinical marker for acute treatment response, and the prompted
+/// intensity reading feeds the derived time-to-relief in
+/// `AnalyticsInsights.medicationEffectiveness` — no new data model needed.
+///
+/// At most one check-in is pending per episode: a newer dose resets the
+/// 2-hour clock, since response is measured from the most recent treatment.
+/// State lives entirely in the notification center (deterministic IDs +
+/// `userInfo`), so unlike the reminder pipeline there is no DB bookkeeping.
+final class DoseCheckinNotificationService: DoseCheckinNotificationServiceProtocol {
+    static let idPrefix = "dose_checkin_"
+    static let checkinDelay: TimeInterval = 2 * 60 * 60
+
+    private let notificationService: NotificationServiceProtocol
+    private let medicationRepo: MedicationRepositoryProtocol
+    private let logger = AppLogger.shared
+
+    init(
+        notificationService: NotificationServiceProtocol,
+        medicationRepo: MedicationRepositoryProtocol
+    ) {
+        self.notificationService = notificationService
+        self.medicationRepo = medicationRepo
+    }
+
+    func scheduleCheckin(for dose: MedicationDose) async {
+        guard FeatureFlags.isEnabled(.doseCheckin), notificationsEnabled() else { return }
+        guard dose.status == .taken, let episodeId = dose.episodeId else { return }
+        guard let medication = try? medicationRepo.getMedicationById(dose.medicationId),
+              medication.type == .rescue else { return }
+
+        // A newer dose supersedes any earlier pending check-in for the episode.
+        await cancelPendingCheckins(forEpisodeId: episodeId)
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: Self.checkinDelay, repeats: false)
+        do {
+            try await notificationService.scheduleNotification(
+                id: Self.idPrefix + dose.id,
+                title: "How are you feeling?",
+                body: "It's been 2 hours since your medication. Tap to log an update.",
+                trigger: trigger,
+                categoryIdentifier: NotificationCategory.doseCheckin,
+                userInfo: [
+                    "type": "dose_checkin",
+                    "doseId": dose.id,
+                    "episodeId": episodeId,
+                    "medicationId": dose.medicationId
+                ]
+            )
+            logger.info("Scheduled 2h dose check-in for dose \(dose.id)")
+        } catch {
+            logger.error("Failed to schedule dose check-in", error: error)
+        }
+    }
+
+    func cancelCheckins(forEpisodeId episodeId: String) async {
+        await cancelPendingCheckins(forEpisodeId: episodeId)
+
+        let delivered = await notificationService.getDeliveredNotifications()
+        for notification in delivered where matches(notification.request, episodeId: episodeId) {
+            notificationService.removeDeliveredNotification(id: notification.request.identifier)
+        }
+    }
+
+    // MARK: - Private
+
+    private func cancelPendingCheckins(forEpisodeId episodeId: String) async {
+        let pending = await notificationService.getPendingNotifications()
+        for request in pending where matches(request, episodeId: episodeId) {
+            notificationService.cancelNotification(id: request.identifier)
+        }
+    }
+
+    private func matches(_ request: UNNotificationRequest, episodeId: String) -> Bool {
+        request.identifier.hasPrefix(Self.idPrefix)
+            && request.content.userInfo["episodeId"] as? String == episodeId
+    }
+
+    private func notificationsEnabled() -> Bool {
+        UserDefaults.standard.object(forKey: "notifications_enabled") as? Bool ?? true
+    }
+}

--- a/mobile-apps/ios/MigraLog/Services/MedicationDoseLogger.swift
+++ b/mobile-apps/ios/MigraLog/Services/MedicationDoseLogger.swift
@@ -15,6 +15,7 @@ protocol MedicationDoseLoggerProtocol: Sendable {
 final class MedicationDoseLogger: MedicationDoseLoggerProtocol {
     private let medicationRepo: MedicationRepositoryProtocol
     private let notificationService: MedicationNotificationServiceProtocol
+    private let doseCheckinService: DoseCheckinNotificationServiceProtocol
 
     init(
         medicationRepo: MedicationRepositoryProtocol = MedicationRepository(dbManager: DatabaseManager.shared),
@@ -22,16 +23,22 @@ final class MedicationDoseLogger: MedicationDoseLoggerProtocol {
             notificationService: NotificationService.shared,
             scheduledNotificationRepo: ScheduledNotificationRepository(dbManager: DatabaseManager.shared),
             medicationRepo: MedicationRepository(dbManager: DatabaseManager.shared)
+        ),
+        doseCheckinService: DoseCheckinNotificationServiceProtocol = DoseCheckinNotificationService(
+            notificationService: NotificationService.shared,
+            medicationRepo: MedicationRepository(dbManager: DatabaseManager.shared)
         )
     ) {
         self.medicationRepo = medicationRepo
         self.notificationService = notificationService
+        self.doseCheckinService = doseCheckinService
     }
 
     @discardableResult
     func record(_ dose: MedicationDose) async throws -> MedicationDose {
         let saved = try medicationRepo.createDose(dose)
         await notificationService.cancelTodaysReminders(medicationId: saved.medicationId)
+        await doseCheckinService.scheduleCheckin(for: saved)
         return saved
     }
 }

--- a/mobile-apps/ios/MigraLog/Services/NotificationResponseHandler.swift
+++ b/mobile-apps/ios/MigraLog/Services/NotificationResponseHandler.swift
@@ -67,6 +67,9 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
                 let checkinUserInfo = response.notification.request.content.userInfo
                 await handleDailyCheckinResponse(actionIdentifier: actionIdentifier, userInfo: checkinUserInfo)
 
+            case NotificationCategory.doseCheckin:
+                await handleDoseCheckinResponse(actionIdentifier: actionIdentifier, userInfo: userInfo)
+
             default:
                 logger.debug("Unhandled notification category: \(categoryIdentifier)")
             }
@@ -251,6 +254,30 @@ final class NotificationResponseHandler: NSObject, UNUserNotificationCenterDeleg
 
         default:
             logger.debug("Unhandled daily check-in action: \(actionIdentifier)")
+        }
+    }
+
+    // MARK: - Dose Check-in Response Handling
+
+    /// Both the default tap and the "Log Update" action open the app; post the
+    /// episode id so `ContentView` can route to the Log Update screen.
+    func handleDoseCheckinResponse(actionIdentifier: String, userInfo: [AnyHashable: Any]) async {
+        switch actionIdentifier {
+        case NotificationAction.logUpdate, UNNotificationDefaultActionIdentifier:
+            guard let episodeId = userInfo["episodeId"] as? String else {
+                logger.warn("No episodeId in dose check-in notification userInfo")
+                return
+            }
+            await MainActor.run {
+                NotificationCenter.default.post(
+                    name: .doseCheckinTapped,
+                    object: nil,
+                    userInfo: ["episodeId": episodeId]
+                )
+            }
+
+        default:
+            logger.debug("Unhandled dose check-in action: \(actionIdentifier)")
         }
     }
 

--- a/mobile-apps/ios/MigraLog/Services/NotificationService.swift
+++ b/mobile-apps/ios/MigraLog/Services/NotificationService.swift
@@ -7,6 +7,7 @@ enum NotificationCategory {
     static let medication = "MEDICATION_REMINDER"
     static let multipleMedication = "MULTIPLE_MEDICATION_REMINDER"
     static let dailyCheckin = "DAILY_CHECKIN"
+    static let doseCheckin = "DOSE_CHECKIN"
 }
 
 enum NotificationAction {
@@ -18,6 +19,7 @@ enum NotificationAction {
     static let remindLater = "REMIND_LATER"
     static let clearDay = "CLEAR_DAY"
     static let notClear = "NOT_CLEAR"
+    static let logUpdate = "LOG_UPDATE"
 }
 
 // MARK: - Notification Service Protocol
@@ -159,7 +161,21 @@ final class NotificationService: NotificationServiceProtocol {
             options: []
         )
 
-        center.setNotificationCategories([medicationCategory, multipleMedicationCategory, dailyCheckinCategory])
+        let logUpdateAction = UNNotificationAction(
+            identifier: NotificationAction.logUpdate,
+            title: "Log Update",
+            options: [.foreground]
+        )
+        let doseCheckinCategory = UNNotificationCategory(
+            identifier: NotificationCategory.doseCheckin,
+            actions: [logUpdateAction],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        center.setNotificationCategories([
+            medicationCategory, multipleMedicationCategory, dailyCheckinCategory, doseCheckinCategory
+        ])
     }
 
     // MARK: - Permission

--- a/mobile-apps/ios/MigraLog/Utils/FeatureFlags.swift
+++ b/mobile-apps/ios/MigraLog/Utils/FeatureFlags.swift
@@ -43,9 +43,17 @@ struct FeatureFlag: Identifiable {
             + "effects (medications, symptoms, notes) without pain levels."
     )
 
+    static let doseCheckin = FeatureFlag(
+        key: "doseCheckin",
+        title: "2-Hour Medication Check-in",
+        details: "Two hours after you take a rescue medication during an attack, "
+            + "get a reminder to log how you're feeling."
+    )
+
     /// Every flag surfaced in Beta Features, in display order.
     static let all: [FeatureFlag] = [
         .postdromeTracking,
+        .doseCheckin,
     ]
 }
 

--- a/mobile-apps/ios/MigraLog/Utils/Notifications.swift
+++ b/mobile-apps/ios/MigraLog/Utils/Notifications.swift
@@ -4,4 +4,8 @@ extension Notification.Name {
     static let medicationDataChanged = Notification.Name("medicationDataChanged")
     static let episodeDataChanged = Notification.Name("episodeDataChanged")
     static let dailyStatusDataChanged = Notification.Name("dailyStatusDataChanged")
+    /// A 2h dose check-in notification was tapped; userInfo carries "episodeId".
+    /// Posted by `NotificationResponseHandler`, observed by `ContentView` to
+    /// route to the episode's Log Update screen.
+    static let doseCheckinTapped = Notification.Name("doseCheckinTapped")
 }

--- a/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
@@ -15,6 +15,7 @@ final class EpisodeDetailViewModel {
     private let episodeRepository: EpisodeRepositoryProtocol
     private let medicationRepository: MedicationRepositoryProtocol
     private let dailyCheckinService: DailyCheckinNotificationServiceProtocol
+    private let doseCheckinService: DoseCheckinNotificationServiceProtocol
     private let liveActivityManager: LiveActivityManaging
     private var episodeId: String
 
@@ -30,12 +31,17 @@ final class EpisodeDetailViewModel {
             episodeRepo: EpisodeRepository(dbManager: DatabaseManager.shared),
             dailyStatusRepo: DailyStatusRepository(dbManager: DatabaseManager.shared)
         ),
+        doseCheckinService: DoseCheckinNotificationServiceProtocol = DoseCheckinNotificationService(
+            notificationService: NotificationService.shared,
+            medicationRepo: MedicationRepository(dbManager: DatabaseManager.shared)
+        ),
         liveActivityManager: LiveActivityManaging = LiveActivityManager.shared
     ) {
         self.episodeId = episodeId
         self.episodeRepository = episodeRepository
         self.medicationRepository = medicationRepository
         self.dailyCheckinService = dailyCheckinService
+        self.doseCheckinService = doseCheckinService
         self.liveActivityManager = liveActivityManager
     }
 
@@ -97,6 +103,8 @@ final class EpisodeDetailViewModel {
             )
             // Reinstate daily check-in notifications now that episode is complete
             try? await dailyCheckinService.scheduleNotifications()
+            // The episode's outcome is known — drop any pending 2h dose check-in.
+            await doseCheckinService.cancelCheckins(forEpisodeId: episode.id)
             // Transition the Live Activity to its warm post-episode close.
             liveActivityManager.end(episodeId: episode.id, at: timestamp)
         } catch {
@@ -122,6 +130,8 @@ final class EpisodeDetailViewModel {
             )
             // Reinstate daily check-in notifications now that episode is complete
             try? await dailyCheckinService.scheduleNotifications()
+            // The episode's outcome is known — drop any pending 2h dose check-in.
+            await doseCheckinService.cancelCheckins(forEpisodeId: episode.id)
             // Transition the Live Activity to its warm post-episode close.
             liveActivityManager.end(episodeId: episode.id, at: now)
         } catch {

--- a/mobile-apps/ios/MigraLogTests/Services/DoseCheckinNotificationServiceTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/DoseCheckinNotificationServiceTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+import UserNotifications
+@testable import MigraLog
+
+// MARK: - Mock Dose Checkin Notification Service
+
+final class MockDoseCheckinNotificationService: DoseCheckinNotificationServiceProtocol, @unchecked Sendable {
+    var scheduledDoseIds: [String] = []
+    var cancelledEpisodeIds: [String] = []
+
+    func scheduleCheckin(for dose: MedicationDose) async {
+        scheduledDoseIds.append(dose.id)
+    }
+
+    func cancelCheckins(forEpisodeId episodeId: String) async {
+        cancelledEpisodeIds.append(episodeId)
+    }
+}
+
+// MARK: - Tests
+
+final class DoseCheckinNotificationServiceTests: XCTestCase {
+    private var sut: DoseCheckinNotificationService!
+    private var mockNotificationService: MockNotificationService!
+    private var mockMedicationRepo: MockMedicationRepository!
+
+    private let rescueMed = TestFixtures.makeMedication(id: "med-rescue", type: .rescue)
+    private let preventativeMed = TestFixtures.makeMedication(id: "med-prev", type: .preventative)
+
+    override func setUp() {
+        super.setUp()
+        mockNotificationService = MockNotificationService()
+        mockMedicationRepo = MockMedicationRepository()
+        mockMedicationRepo.medications = [rescueMed, preventativeMed]
+
+        UserDefaults.standard.set(true, forKey: FeatureFlag.doseCheckin.storageKey)
+        UserDefaults.standard.set(true, forKey: "notifications_enabled")
+
+        sut = DoseCheckinNotificationService(
+            notificationService: mockNotificationService,
+            medicationRepo: mockMedicationRepo
+        )
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockNotificationService = nil
+        mockMedicationRepo = nil
+        UserDefaults.standard.removeObject(forKey: FeatureFlag.doseCheckin.storageKey)
+        UserDefaults.standard.removeObject(forKey: "notifications_enabled")
+        super.tearDown()
+    }
+
+    // MARK: - Scheduling
+
+    func testScheduleCheckin_schedulesForTakenRescueDoseInEpisode() async throws {
+        let dose = makeDose(id: "dose-1", medicationId: "med-rescue", episodeId: "ep-1")
+
+        await sut.scheduleCheckin(for: dose)
+
+        XCTAssertEqual(mockNotificationService.scheduledNotifications.count, 1)
+        let scheduled = try XCTUnwrap(mockNotificationService.scheduledNotifications.first)
+        XCTAssertEqual(scheduled.id, "dose_checkin_dose-1")
+        XCTAssertEqual(scheduled.categoryIdentifier, NotificationCategory.doseCheckin)
+        XCTAssertEqual(scheduled.userInfo?["episodeId"] as? String, "ep-1")
+        XCTAssertEqual(scheduled.userInfo?["doseId"] as? String, "dose-1")
+        XCTAssertEqual(scheduled.userInfo?["type"] as? String, "dose_checkin")
+
+        let trigger = try XCTUnwrap(scheduled.trigger as? UNTimeIntervalNotificationTrigger)
+        XCTAssertEqual(trigger.timeInterval, DoseCheckinNotificationService.checkinDelay)
+        XCTAssertFalse(trigger.repeats)
+    }
+
+    func testScheduleCheckin_skipsWhenFlagOff() async {
+        UserDefaults.standard.removeObject(forKey: FeatureFlag.doseCheckin.storageKey)
+        let dose = makeDose(id: "dose-1", medicationId: "med-rescue", episodeId: "ep-1")
+
+        await sut.scheduleCheckin(for: dose)
+
+        XCTAssertTrue(mockNotificationService.scheduledNotifications.isEmpty)
+    }
+
+    func testScheduleCheckin_skipsWhenNotificationsDisabled() async {
+        UserDefaults.standard.set(false, forKey: "notifications_enabled")
+        let dose = makeDose(id: "dose-1", medicationId: "med-rescue", episodeId: "ep-1")
+
+        await sut.scheduleCheckin(for: dose)
+
+        XCTAssertTrue(mockNotificationService.scheduledNotifications.isEmpty)
+    }
+
+    func testScheduleCheckin_skipsSkippedDose() async {
+        let dose = makeDose(id: "dose-1", medicationId: "med-rescue", episodeId: "ep-1", status: .skipped)
+
+        await sut.scheduleCheckin(for: dose)
+
+        XCTAssertTrue(mockNotificationService.scheduledNotifications.isEmpty)
+    }
+
+    func testScheduleCheckin_skipsDoseOutsideEpisode() async {
+        let dose = makeDose(id: "dose-1", medicationId: "med-rescue", episodeId: nil)
+
+        await sut.scheduleCheckin(for: dose)
+
+        XCTAssertTrue(mockNotificationService.scheduledNotifications.isEmpty)
+    }
+
+    func testScheduleCheckin_skipsPreventativeMedication() async {
+        let dose = makeDose(id: "dose-1", medicationId: "med-prev", episodeId: "ep-1")
+
+        await sut.scheduleCheckin(for: dose)
+
+        XCTAssertTrue(mockNotificationService.scheduledNotifications.isEmpty)
+    }
+
+    func testScheduleCheckin_skipsWhenMedicationNotFound() async {
+        let dose = makeDose(id: "dose-1", medicationId: "med-unknown", episodeId: "ep-1")
+
+        await sut.scheduleCheckin(for: dose)
+
+        XCTAssertTrue(mockNotificationService.scheduledNotifications.isEmpty)
+    }
+
+    // MARK: - Superseding
+
+    func testScheduleCheckin_newDoseReplacesPendingCheckinForSameEpisode() async {
+        mockNotificationService.pendingRequests = [
+            makeCheckinRequest(doseId: "dose-old", episodeId: "ep-1")
+        ]
+        let dose = makeDose(id: "dose-new", medicationId: "med-rescue", episodeId: "ep-1")
+
+        await sut.scheduleCheckin(for: dose)
+
+        XCTAssertEqual(mockNotificationService.cancelledIds, ["dose_checkin_dose-old"])
+        XCTAssertEqual(mockNotificationService.scheduledNotifications.map(\.id), ["dose_checkin_dose-new"])
+    }
+
+    func testScheduleCheckin_keepsPendingCheckinForOtherEpisode() async {
+        mockNotificationService.pendingRequests = [
+            makeCheckinRequest(doseId: "dose-old", episodeId: "ep-other")
+        ]
+        let dose = makeDose(id: "dose-new", medicationId: "med-rescue", episodeId: "ep-1")
+
+        await sut.scheduleCheckin(for: dose)
+
+        XCTAssertTrue(mockNotificationService.cancelledIds.isEmpty)
+    }
+
+    // MARK: - Cancellation
+
+    func testCancelCheckins_cancelsOnlyMatchingEpisode() async {
+        mockNotificationService.pendingRequests = [
+            makeCheckinRequest(doseId: "dose-1", episodeId: "ep-1"),
+            makeCheckinRequest(doseId: "dose-2", episodeId: "ep-2")
+        ]
+
+        await sut.cancelCheckins(forEpisodeId: "ep-1")
+
+        XCTAssertEqual(mockNotificationService.cancelledIds, ["dose_checkin_dose-1"])
+    }
+
+    func testCancelCheckins_ignoresNonCheckinNotifications() async {
+        let content = UNMutableNotificationContent()
+        content.userInfo = ["episodeId": "ep-1"]
+        mockNotificationService.pendingRequests = [
+            UNNotificationRequest(identifier: "daily_checkin_2026-07-19", content: content, trigger: nil)
+        ]
+
+        await sut.cancelCheckins(forEpisodeId: "ep-1")
+
+        XCTAssertTrue(mockNotificationService.cancelledIds.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeDose(
+        id: String,
+        medicationId: String,
+        episodeId: String?,
+        status: DoseStatus = .taken
+    ) -> MedicationDose {
+        let now = TimestampHelper.now
+        return MedicationDose(
+            id: id,
+            medicationId: medicationId,
+            timestamp: now,
+            quantity: 1,
+            dosageAmount: 400,
+            dosageUnit: "mg",
+            status: status,
+            episodeId: episodeId,
+            effectivenessRating: nil,
+            timeToRelief: nil,
+            sideEffects: [],
+            notes: nil,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    private func makeCheckinRequest(doseId: String, episodeId: String) -> UNNotificationRequest {
+        let content = UNMutableNotificationContent()
+        content.userInfo = ["type": "dose_checkin", "doseId": doseId, "episodeId": episodeId]
+        return UNNotificationRequest(
+            identifier: DoseCheckinNotificationService.idPrefix + doseId,
+            content: content,
+            trigger: nil
+        )
+    }
+}

--- a/mobile-apps/ios/MigraLogTests/Services/MedicationDoseLoggerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/MedicationDoseLoggerTests.swift
@@ -4,15 +4,18 @@ import XCTest
 final class MedicationDoseLoggerTests: XCTestCase {
     private var mockMedicationRepo: MockMedicationRepository!
     private var mockNotificationService: MockMedicationNotificationService!
+    private var mockDoseCheckinService: MockDoseCheckinNotificationService!
     private var sut: MedicationDoseLogger!
 
     override func setUp() {
         super.setUp()
         mockMedicationRepo = MockMedicationRepository()
         mockNotificationService = MockMedicationNotificationService()
+        mockDoseCheckinService = MockDoseCheckinNotificationService()
         sut = MedicationDoseLogger(
             medicationRepo: mockMedicationRepo,
-            notificationService: mockNotificationService
+            notificationService: mockNotificationService,
+            doseCheckinService: mockDoseCheckinService
         )
     }
 
@@ -20,6 +23,7 @@ final class MedicationDoseLoggerTests: XCTestCase {
         sut = nil
         mockMedicationRepo = nil
         mockNotificationService = nil
+        mockDoseCheckinService = nil
         super.tearDown()
     }
 
@@ -50,6 +54,29 @@ final class MedicationDoseLoggerTests: XCTestCase {
                 "Reminders must not be cancelled if the dose was never written"
             )
         }
+    }
+
+    func testRecord_schedulesDoseCheckin() async throws {
+        let dose = makeDose(medicationId: "med-1")
+
+        _ = try await sut.record(dose)
+
+        XCTAssertEqual(
+            mockDoseCheckinService.scheduledDoseIds, [dose.id],
+            "The saved dose should be offered to the check-in scheduler (it applies its own gating)"
+        )
+    }
+
+    func testRecord_doesNotScheduleCheckin_whenPersistFails() async {
+        mockMedicationRepo.errorToThrow = NSError(domain: "test", code: 1)
+        let dose = makeDose(medicationId: "med-1")
+
+        _ = try? await sut.record(dose)
+
+        XCTAssertTrue(
+            mockDoseCheckinService.scheduledDoseIds.isEmpty,
+            "No check-in should be scheduled for a dose that was never written"
+        )
     }
 
     // MARK: - Helpers

--- a/mobile-apps/ios/MigraLogTests/Services/NotificationResponseHandlerTests.swift
+++ b/mobile-apps/ios/MigraLogTests/Services/NotificationResponseHandlerTests.swift
@@ -116,6 +116,46 @@ final class NotificationResponseHandlerTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - Dose Check-in
+
+    func testDoseCheckinResponse_defaultTap_postsRoutingNotification() async {
+        let expectation = expectation(forNotification: .doseCheckinTapped, object: nil) { notification in
+            notification.userInfo?["episodeId"] as? String == "ep-1"
+        }
+
+        await sut.handleDoseCheckinResponse(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            userInfo: ["type": "dose_checkin", "episodeId": "ep-1"]
+        )
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    func testDoseCheckinResponse_logUpdateAction_postsRoutingNotification() async {
+        let expectation = expectation(forNotification: .doseCheckinTapped, object: nil) { notification in
+            notification.userInfo?["episodeId"] as? String == "ep-1"
+        }
+
+        await sut.handleDoseCheckinResponse(
+            actionIdentifier: NotificationAction.logUpdate,
+            userInfo: ["episodeId": "ep-1"]
+        )
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    func testDoseCheckinResponse_missingEpisodeId_doesNotPost() async {
+        let expectation = expectation(forNotification: .doseCheckinTapped, object: nil)
+        expectation.isInverted = true
+
+        await sut.handleDoseCheckinResponse(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            userInfo: ["type": "dose_checkin"]
+        )
+
+        await fulfillment(of: [expectation], timeout: 0.2)
+    }
+
     // MARK: - Initialization
 
     func testInit_setsUpAllDependencies() {

--- a/mobile-apps/ios/MigraLogTests/ViewModels/DashboardViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/DashboardViewModelTests.swift
@@ -22,7 +22,8 @@ final class DashboardViewModelTests: XCTestCase {
             categoryLimitRepository: mockCategoryLimitRepo,
             doseLogger: MedicationDoseLogger(
                 medicationRepo: mockMedRepo,
-                notificationService: MockMedicationNotificationService()
+                notificationService: MockMedicationNotificationService(),
+                doseCheckinService: MockDoseCheckinNotificationService()
             )
         )
     }

--- a/mobile-apps/ios/MigraLogTests/ViewModels/EpisodeDetailViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/EpisodeDetailViewModelTests.swift
@@ -4,18 +4,24 @@ import XCTest
 @MainActor
 final class EpisodeDetailViewModelTests: XCTestCase {
     private var mockRepo: MockEpisodeRepository!
+    private var mockDoseCheckinService: MockDoseCheckinNotificationService!
     private var sut: EpisodeDetailViewModel!
     private var testEpisode: Episode!
 
     override func setUp() {
         super.setUp()
         mockRepo = MockEpisodeRepository()
+        mockDoseCheckinService = MockDoseCheckinNotificationService()
         testEpisode = TestFixtures.makeEpisode(id: "ep-1")
         mockRepo.episodes = [testEpisode]
         mockRepo.intensityReadings = [
             TestFixtures.makeReading(id: "r-1", episodeId: "ep-1", intensity: 6.0)
         ]
-        sut = EpisodeDetailViewModel(episodeId: "ep-1", episodeRepository: mockRepo)
+        sut = EpisodeDetailViewModel(
+            episodeId: "ep-1",
+            episodeRepository: mockRepo,
+            doseCheckinService: mockDoseCheckinService
+        )
     }
 
     // MARK: - Load
@@ -59,6 +65,14 @@ final class EpisodeDetailViewModelTests: XCTestCase {
         XCTAssertNotNil(sut.episode?.endTime)
         XCTAssertFalse(sut.episode!.isActive)
         XCTAssertTrue(mockRepo.updateEpisodeCalled)
+    }
+
+    func testEndEpisode_cancelsPendingDoseCheckins() async throws {
+        await sut.loadEpisode()
+
+        await sut.endEpisode()
+
+        XCTAssertEqual(mockDoseCheckinService.cancelledEpisodeIds, ["ep-1"])
     }
 
     func testEndEpisode_alreadyEnded_noOp() async throws {

--- a/mobile-apps/ios/MigraLogTests/ViewModels/LogMedicationViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/LogMedicationViewModelTests.swift
@@ -19,7 +19,8 @@ final class LogMedicationViewModelTests: XCTestCase {
             categoryLimitRepository: mockCategoryLimitRepo,
             doseLogger: MedicationDoseLogger(
                 medicationRepo: mockMedRepo,
-                notificationService: MockMedicationNotificationService()
+                notificationService: MockMedicationNotificationService(),
+                doseCheckinService: MockDoseCheckinNotificationService()
             )
         )
     }


### PR DESCRIPTION
## Summary

Adds a beta-gated feature (new `doseCheckin` feature flag under **Settings → Beta Features**, visible in pre-release builds only, off by default): **two hours after a rescue medication is logged as taken during an active episode, a local notification asks how the user is doing and prompts them to log an update.** Two hours is the standard clinical marker for acute treatment response.

## Design: prompt an update, keep the data model clean

The tap (or the notification's **Log Update** action) routes to the episode's existing **Log Update** screen via the same `DeepLinkTarget.logIntensity` path the Live Activity uses. The response is recorded as a normal `IntensityReading` — **no new tables, columns, or sync changes**.

This was chosen deliberately with the trends/analytics reports in mind: `AnalyticsInsights.medicationEffectiveness` already derives time-to-relief from the first post-dose intensity reading that drops below the dose-time baseline. Today that derivation depends on users spontaneously logging updates; this prompt makes those readings denser and consistently sampled at the 2h mark, directly improving the **Med Response** chart with zero analytics-side changes. A better/worse/same response type was considered and deferred — nothing consumes it today and it would need new schema + new reports.

## Mechanics

- **Scheduling** — new `DoseCheckinNotificationService`, called from `MedicationDoseLogger.record()` (the single choke point all dose-logging paths funnel through). Gated on: flag enabled, notifications enabled, dose `.taken`, dose linked to an episode, medication type `.rescue`.
- **One pending check-in per episode** — a newer dose cancels the prior pending check-in and restarts the 2h clock (response is measured from the most recent treatment).
- **Episode end cancels check-ins** (pending and delivered) — the outcome is known, so the prompt would be stale.
- **No DB bookkeeping** — state lives entirely in the notification center via deterministic IDs (`dose_checkin_<doseId>`) + `userInfo`; avoids the `scheduled_notifications` CHECK-constraint migration.
- **Privacy** — notification copy contains no medication name or health details.
- New `DOSE_CHECKIN` category with a foreground **Log Update** action; tap handling posts `.doseCheckinTapped`, observed in `ContentView` → `AppState.route(to: .logIntensity)`. This is the first notification tap that deep-links to a screen.

## Testing

- New `DoseCheckinNotificationServiceTests` (11 cases): gating (flag/notifications/status/episode/med type), trigger interval + payload, supersede-per-episode, targeted cancellation.
- Extended `MedicationDoseLoggerTests`, `NotificationResponseHandlerTests` (tap → routing notification), `EpisodeDetailViewModelTests` (end episode cancels check-ins).
- Full local suite passes on iPhone 17 Pro / iOS 26.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)