### PR TITLE
fix(ios): make backdate UI test robust to noon-crossing wheel clamping

### DIFF
--- a/mobile-apps/ios/MigraLogUITests/LogUpdateTimePickerUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/LogUpdateTimePickerUITests.swift
@@ -112,13 +112,19 @@ final class LogUpdateTimePickerUITests: XCTestCase {
         let hourWheel = app.pickerWheels.element(boundBy: 0)
         XCTAssertTrue(hourWheel.waitForExistence(timeout: UITestHelpers.defaultTimeout),
                       "Tapping the time button should show picker wheels")
-        hourWheel.adjust(toPickerWheelValue: component(of: date, format: "h"))
-        app.pickerWheels.element(boundBy: 1)
-            .adjust(toPickerWheelValue: component(of: date, format: "mm"))
+        // The pickers are bounded to `...Date()`, and UIKit snaps the wheels
+        // back whenever an intermediate state is a future time. When backdating
+        // across noon (e.g. now 12:17 PM -> target 11:47 AM), adjusting the
+        // hour before the period would transiently select 11:17 PM and get
+        // clamped. Setting AM/PM first keeps every intermediate state in the
+        // past, so no adjustment is ever undone.
         if app.pickerWheels.count > 2 {
             app.pickerWheels.element(boundBy: 2)
                 .adjust(toPickerWheelValue: component(of: date, format: "a"))
         }
+        hourWheel.adjust(toPickerWheelValue: component(of: date, format: "h"))
+        app.pickerWheels.element(boundBy: 1)
+            .adjust(toPickerWheelValue: component(of: date, format: "mm"))
         Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
 
         // Dismiss the popover by tapping outside it


### PR DESCRIPTION
## Summary
The 2026-07-20 nightly UI suite failed on `LogUpdateTimePickerUITests.testLogUpdateCanBeBackdated` ("Time picker should show the backdated time 11:47 AM"). Root cause, not flakiness in the vague sense:

- The Log Update picker is bounded `episodeStart...Date()` and the New Episode picker `...Date()` — UIKit snaps the wheels back whenever an intermediate selection is a future time.
- The test helper adjusted wheels hour → minute → AM/PM. Backdating across noon (run at 12:17 PM UTC targeting 11:47 AM) transiently selected 11:47 **PM**, a future time, which got clamped — undoing the hour/minute adjustments.
- Every previously green nightly ran before noon UTC; today's started at 11:58, putting the test past noon.

## Fix
Adjust the AM/PM wheel **first**, then hour, then minute. When backdating, every intermediate state then remains in the past, so no adjustment is ever clamped away.

## Testing
- Ran `MigraLogUITests/LogUpdateTimePickerUITests` locally on iPhone 17 Pro (26.5): passed.
- Noon-crossing path verified by reasoning through the clamp behavior (can't fake the simulator clock); next nightly after a 12:00 UTC start will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)