### PR TITLE
fix(ios): make nightly UI suite robust to midnight window and slow runners

### DIFF
--- a/mobile-apps/ios/MigraLogUITests/LogUpdateTimePickerUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/LogUpdateTimePickerUITests.swift
@@ -23,8 +23,20 @@ final class LogUpdateTimePickerUITests: XCTestCase {
 
     func testLogUpdateCanBeBackdated() throws {
         let now = Date()
-        let episodeStart = now.addingTimeInterval(-2 * 60 * 60)
-        let updateTime = now.addingTimeInterval(-30 * 60)
+        // The compact picker's popover only exposes time-of-day wheels, so both
+        // times must land on today's date: shortly after midnight "2 hours ago"
+        // is yesterday, the wheels can't reach it (every intermediate state is a
+        // future time that gets clamped), and the update time then falls outside
+        // the episodeStart...now bounds (#603, 2026-07-21 00:27 UTC run). Clamp
+        // both times to stay after midnight, and skip the first minutes of the
+        // day where there's no room for two distinct backdated minutes.
+        let midnight = Calendar.current.startOfDay(for: now)
+        try XCTSkipIf(now.timeIntervalSince(midnight) < 3 * 60,
+                      "Backdating needs distinct past times on today's date")
+        let episodeStart = max(now.addingTimeInterval(-2 * 60 * 60),
+                               midnight.addingTimeInterval(60))
+        let updateTime = max(now.addingTimeInterval(-30 * 60),
+                             midnight.addingTimeInterval(2 * 60))
 
         // === Create an episode started 2 hours ago ===
         let startButton = app.buttons["start-episode-button"]

--- a/mobile-apps/ios/MigraLogUITests/UITestHelpers.swift
+++ b/mobile-apps/ios/MigraLogUITests/UITestHelpers.swift
@@ -45,8 +45,14 @@ enum UITestHelpers {
     }
 
     /// Wait for the dashboard screen to be visible.
+    ///
+    /// Reaching the dashboard is a launch/onboarding-scale settle, not an
+    /// in-screen wait: on a loaded CI runner it can exceed the default 5s
+    /// (#603, the 2026-07-21 nightly where the whole suite ran ~1.5x slower),
+    /// so allow the same 15s window navigation settles use. Costs nothing
+    /// when the app is fast — the wait returns as soon as the title appears.
     @discardableResult
-    static func waitForDashboard(in app: XCUIApplication, timeout: TimeInterval = defaultTimeout) -> XCUIElement {
+    static func waitForDashboard(in app: XCUIApplication, timeout: TimeInterval = 15) -> XCUIElement {
         let title = dashboardTitle(in: app)
         waitForElement(title, timeout: timeout)
         return title
@@ -139,7 +145,10 @@ enum UITestHelpers {
             waitForHittable(tabButton, timeout: 15, file: file, line: line)
             tabButton.tap()
             Thread.sleep(forTimeInterval: animationWait)
-            if waitForSelected(tabButton, timeout: 3) {
+            // 8s not 3s: under heavy runner load `isSelected` can lag the tap by
+            // several seconds without the selection having reverted (#603); a
+            // premature retap burns an attempt on a switch that already landed.
+            if waitForSelected(tabButton, timeout: 8) {
                 return
             }
         }


### PR DESCRIPTION
## Summary
The verification rerun of the nightly Full UI suite ([run 29790351976](https://github.com/vfilby/migralog/actions/runs/29790351976), started 00:27 UTC) failed with 3 test failures. Each has a concrete cause; none are app bugs.

### 1. `testLogUpdateCanBeBackdated` — midnight window (the #604 fix was necessary but not sufficient)
The compact date picker's popover only exposes hour/minute/AM-PM wheels — it can never change the date. Shortly after midnight, "episode started 2 hours ago" lands on **yesterday**: every intermediate wheel state is a future time on today's date, so the `...Date()` bound clamps it and the episode start stays ~now. The 30-min-backdated update time is then before the episode start and the `episodeStart...now` bound clamps that too (observed: target 12:21 AM at 00:52 UTC).

**Fix:** clamp both backdated times to stay after local midnight (`max(now - offset, midnight + margin)`), and `XCTSkipIf` within the first 3 minutes of the day where two distinct backdated minutes don't exist. Daytime behaviour is unchanged.

### 2. `testCachedPermissionsNoDialogs` — 5s launch settle on a slow runner
The failing run's runner was ~1.5x slower across the board (suite 1987s vs 1307s the night before). `waitForDashboard` used the 5s `defaultTimeout` for what is a launch/onboarding-scale settle. **Fix:** default it to the 15s window navigation settles already use; costs nothing when fast.

### 3. `testPerMedicationNotificationOverrides` — tab selection poll too tight
`navigateTo` gave `isSelected` only 3s to reflect a landed tab switch before burning one of its 3 retap attempts. Under load the selection lags without having reverted (#488 retap logic). **Fix:** allow 8s per attempt.

## Testing
- `LogUpdateTimePickerUITests`, `NotificationSettingsUITests`, `OnboardingUITests` all pass locally (iPhone 17 Pro, OS 26.5).
- Will trigger a manual nightly run post-merge to confirm, then close #603.

Fixes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)