### PR TITLE
feat(ios): surface post-drome phase on Live Activity + refresh graph band

### DIFF
--- a/mobile-apps/ios/MigraLog/DesignSystem/DesignTokens.swift
+++ b/mobile-apps/ios/MigraLog/DesignSystem/DesignTokens.swift
@@ -100,6 +100,9 @@ enum DesignTokens {
         static let active = Color(red: 0.84, green: 0.23, blue: 0.30)
         /// Softer tint for the post-episode close state.
         static let calm = Color(red: 0.30, green: 0.55, blue: 0.50)
+        /// Calm indigo for the beta post-drome (recovery) phase — matches the
+        /// indigo Post-drome badge on the episode detail screen.
+        static let postdrome = Color.indigo
     }
 
     // MARK: - Spacing

--- a/mobile-apps/ios/MigraLog/LiveActivity/LiveActivityManager.swift
+++ b/mobile-apps/ios/MigraLog/LiveActivity/LiveActivityManager.swift
@@ -174,11 +174,15 @@ final class LiveActivityManager: LiveActivityManaging {
         let readings = (try? episodeRepository.getReadingsByEpisodeId(episodeId)) ?? []
         let intensity = readings.max { $0.timestamp < $1.timestamp }?.intensity
         let lastRescue = latestRescueDose(episodeId: episodeId)
+        // Beta post-drome tracking: surface the recovery phase so the activity
+        // reads "post-drome" instead of an active attack.
+        let postdromeStartAt = (try? episodeRepository.getEpisodeById(episodeId))?.postdromeStartDate
         return Self.makeContentState(
             intensity: intensity,
             rescue: lastRescue,
             showMedicationNames: showMedicationNames,
-            endedAt: endedAt
+            endedAt: endedAt,
+            postdromeStartAt: postdromeStartAt
         )
     }
 
@@ -189,13 +193,15 @@ final class LiveActivityManager: LiveActivityManaging {
         intensity: Double?,
         rescue: (name: String, takenAt: Date)?,
         showMedicationNames: Bool,
-        endedAt: Date?
+        endedAt: Date?,
+        postdromeStartAt: Date? = nil
     ) -> EpisodeActivityAttributes.ContentState {
         EpisodeActivityAttributes.ContentState(
             currentIntensity: intensity,
             lastRescueMedName: rescue.map { showMedicationNames ? $0.name : genericRescueName },
             lastRescueMedAt: rescue?.takenAt,
-            endedAt: endedAt
+            endedAt: endedAt,
+            postdromeStartAt: postdromeStartAt
         )
     }
 

--- a/mobile-apps/ios/MigraLog/LiveActivity/Shared/EpisodeActivityAttributes.swift
+++ b/mobile-apps/ios/MigraLog/LiveActivity/Shared/EpisodeActivityAttributes.swift
@@ -27,7 +27,18 @@ struct EpisodeActivityAttributes: ActivityAttributes {
         /// that lingers briefly before the activity is dismissed.
         var endedAt: Date?
 
+        /// Beta post-drome tracking: set once the attack has subsided but the
+        /// episode is still open to capture after effects. Drives the calmer
+        /// "recovery" presentation — pain intensity is no longer surfaced
+        /// because it stops being tracked in this phase. Nil during the active
+        /// attack; ignored once `endedAt` is set.
+        var postdromeStartAt: Date?
+
         var isEnded: Bool { endedAt != nil }
+
+        /// In the post-drome recovery phase: still ongoing, but the attack
+        /// itself has passed. Mutually exclusive with `isEnded`.
+        var isInPostdrome: Bool { endedAt == nil && postdromeStartAt != nil }
 
         var hasRescueMed: Bool { lastRescueMedName != nil && lastRescueMedAt != nil }
     }

--- a/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
@@ -157,6 +157,8 @@ final class EpisodeDetailViewModel {
                 painLocationLogs: details?.painLocationLogs ?? [],
                 episodeNotes: details?.episodeNotes ?? []
             )
+            // Reflect the recovery phase on the Live Activity (pain no longer surfaced).
+            liveActivityManager.refresh(episodeId: episode.id)
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "startPostdrome"])
             self.error = error.localizedDescription
@@ -179,6 +181,8 @@ final class EpisodeDetailViewModel {
                 painLocationLogs: details?.painLocationLogs ?? [],
                 episodeNotes: details?.episodeNotes ?? []
             )
+            // Back to an active attack — restore the active Live Activity presentation.
+            liveActivityManager.refresh(episodeId: episode.id)
         } catch {
             ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "resumeAttack"])
             self.error = error.localizedDescription

--- a/mobile-apps/ios/MigraLog/Views/Episodes/IntensitySparklineView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/IntensitySparklineView.swift
@@ -48,18 +48,57 @@ struct IntensitySparklineView: View {
                         )
                     )
 
-                // Post-drome span: plain grey, no line — pain isn't tracked here.
+                // Post-drome span (beta): the attack has subsided and pain is no
+                // longer tracked here, so instead of a line we render a soft
+                // indigo "recovery" band — a dashed boundary at the transition
+                // plus a label — matching the indigo Post-drome badge elsewhere.
+                // Reads as a distinct phase rather than a grey rendering gap.
                 if lineEndT < endT {
                     let pdX = padding + chartW * CGFloat(Double(lineEndT - startT) / timeRange)
+                    let pdWidth = max(geo.size.width - pdX, 0)
+
                     UnevenRoundedRectangle(
                         topLeadingRadius: 0,
                         bottomLeadingRadius: 0,
                         bottomTrailingRadius: DesignTokens.Radius.sm,
                         topTrailingRadius: DesignTokens.Radius.sm
                     )
-                    .fill(Color(.systemGray5))
-                    .frame(width: max(geo.size.width - pdX, 0), height: geo.size.height)
+                    .fill(
+                        LinearGradient(
+                            colors: [Color.indigo.opacity(0.18), Color.indigo.opacity(0.07)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .frame(width: pdWidth, height: geo.size.height)
                     .offset(x: pdX)
+
+                    // Dashed boundary marking the moment the attack subsided.
+                    Path { path in
+                        path.move(to: CGPoint(x: pdX, y: 0))
+                        path.addLine(to: CGPoint(x: pdX, y: geo.size.height))
+                    }
+                    .stroke(
+                        Color.indigo.opacity(0.55),
+                        style: StrokeStyle(lineWidth: 1, dash: [3, 3])
+                    )
+
+                    // Phase label, centered in the band when there's room;
+                    // falls back to just the glyph in a narrow band.
+                    if pdWidth > 72 {
+                        Label("Post-drome", systemImage: "moon.zzz.fill")
+                            .labelStyle(.titleAndIcon)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.indigo)
+                            .frame(width: pdWidth, height: geo.size.height)
+                            .offset(x: pdX)
+                    } else if pdWidth > 20 {
+                        Image(systemName: "moon.zzz.fill")
+                            .font(.caption2)
+                            .foregroundStyle(.indigo)
+                            .frame(width: pdWidth, height: geo.size.height)
+                            .offset(x: pdX)
+                    }
                 }
 
                 // Smoothed line with gradient stroke

--- a/mobile-apps/ios/MigraLogTests/LiveActivity/LiveActivityContentStateTests.swift
+++ b/mobile-apps/ios/MigraLogTests/LiveActivity/LiveActivityContentStateTests.swift
@@ -57,4 +57,45 @@ final class LiveActivityContentStateTests: XCTestCase {
         XCTAssertEqual(state.endedAt, endedAt)
         XCTAssertTrue(state.isEnded)
     }
+
+    // MARK: - Post-drome (beta)
+
+    func testPostdromeStartSurfacesRecoveryPhase() {
+        let postdromeStartAt = Date(timeIntervalSince1970: 3_000)
+        let state = LiveActivityManager.makeContentState(
+            intensity: 6,
+            rescue: nil,
+            showMedicationNames: true,
+            endedAt: nil,
+            postdromeStartAt: postdromeStartAt
+        )
+        XCTAssertEqual(state.postdromeStartAt, postdromeStartAt)
+        XCTAssertTrue(state.isInPostdrome)
+        XCTAssertFalse(state.isEnded)
+    }
+
+    func testActiveAttackIsNotInPostdrome() {
+        let state = LiveActivityManager.makeContentState(
+            intensity: 6,
+            rescue: nil,
+            showMedicationNames: true,
+            endedAt: nil
+        )
+        XCTAssertNil(state.postdromeStartAt)
+        XCTAssertFalse(state.isInPostdrome)
+    }
+
+    /// Ending an episode that was in post-drome must read as ended, not as an
+    /// ongoing recovery — `isEnded` wins.
+    func testEndedTakesPrecedenceOverPostdrome() {
+        let state = LiveActivityManager.makeContentState(
+            intensity: nil,
+            rescue: nil,
+            showMedicationNames: true,
+            endedAt: Date(timeIntervalSince1970: 9_000),
+            postdromeStartAt: Date(timeIntervalSince1970: 3_000)
+        )
+        XCTAssertTrue(state.isEnded)
+        XCTAssertFalse(state.isInPostdrome)
+    }
 }

--- a/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivity.swift
+++ b/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivity.swift
@@ -34,7 +34,7 @@ struct EpisodeLiveActivity: Widget {
                 }
             }
         } compactLeading: {
-            Image(systemName: "bolt.heart.fill")
+            Image(systemName: LiveActivityStyle.symbol(for: context.state))
                 .foregroundStyle(tint(for: context.state))
                 .accessibilityHidden(true)
         } compactTrailing: {
@@ -47,13 +47,18 @@ struct EpisodeLiveActivity: Widget {
                 .minimumScaleFactor(0.7)
                 .frame(maxWidth: 78)
         } minimal: {
-            PulsingDot(color: tint(for: context.state))
+            PulsingDot(
+                color: tint(for: context.state),
+                accessibilityLabel: context.state.isInPostdrome
+                    ? "Migraine episode, post-drome recovery"
+                    : "Active migraine episode"
+            )
         }
         .keylineTint(tint(for: context.state))
     }
 
     private func tint(for state: EpisodeActivityAttributes.ContentState) -> Color {
-        state.isEnded ? LiveActivityStyle.calmColor : LiveActivityStyle.activeColor
+        LiveActivityStyle.tint(for: state)
     }
 }
 
@@ -73,28 +78,36 @@ struct EpisodeLockScreenView: View {
     }
 
     private var activeBody: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        let state = context.state
+        let tint = LiveActivityStyle.tint(for: state)
+        return VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .firstTextBaseline) {
                 Label {
-                    Text("In migraine")
+                    Text(LiveActivityStyle.phaseLabel(for: state))
                         .font(.subheadline.weight(.semibold))
                 } icon: {
-                    Image(systemName: "bolt.heart.fill")
-                        .foregroundStyle(LiveActivityStyle.activeColor)
+                    Image(systemName: LiveActivityStyle.symbol(for: state))
+                        .foregroundStyle(tint)
                 }
                 Spacer()
-                DurationText(attributes: context.attributes, state: context.state)
+                DurationText(attributes: context.attributes, state: state)
                     .font(.title3.monospacedDigit().weight(.semibold))
-                    .foregroundStyle(LiveActivityStyle.activeColor)
+                    .foregroundStyle(tint)
             }
-            // Read "In migraine, <elapsed>" as one element.
+            // Read "In migraine, <elapsed>" (or "Post-drome, …") as one element.
             .accessibilityElement(children: .combine)
             HStack(spacing: DesignTokens.Spacing.md) {
-                if let intensity = LiveActivityStyle.intensityLabel(context.state.currentIntensity) {
+                if state.isInPostdrome {
+                    // Pain intensity isn't tracked in recovery — surface the
+                    // phase instead of a stale reading.
+                    StatChip(systemImage: "sparkles", text: "Recovering")
+                        .foregroundStyle(LiveActivityStyle.postdromeColor)
+                        .accessibilityLabel("In post-drome recovery")
+                } else if let intensity = LiveActivityStyle.intensityLabel(state.currentIntensity) {
                     StatChip(systemImage: "gauge.with.dots.needle.50percent", text: intensity)
                         .accessibilityLabel("Pain intensity \(intensity)")
                 }
-                LastMedLabel(state: context.state, alignment: .leading)
+                LastMedLabel(state: state, alignment: .leading)
                 Spacer()
             }
             ActionRow(episodeId: context.attributes.episodeId)

--- a/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivityComponents.swift
+++ b/mobile-apps/ios/MigraLogWidgets/EpisodeLiveActivityComponents.swift
@@ -114,9 +114,13 @@ struct ExpandedLeadingView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
-            Image(systemName: "bolt.heart.fill")
-                .foregroundStyle(state.isEnded ? LiveActivityStyle.calmColor : LiveActivityStyle.activeColor)
-            if let intensity = LiveActivityStyle.intensityLabel(state.currentIntensity) {
+            Image(systemName: LiveActivityStyle.symbol(for: state))
+                .foregroundStyle(LiveActivityStyle.tint(for: state))
+            if state.isInPostdrome {
+                Text("Recovery")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(LiveActivityStyle.postdromeColor)
+            } else if let intensity = LiveActivityStyle.intensityLabel(state.currentIntensity) {
                 Text(intensity)
                     .font(.caption.weight(.semibold))
             }
@@ -132,11 +136,17 @@ struct ExpandedTrailingView: View {
         VStack(alignment: .trailing, spacing: 2) {
             DurationText(attributes: attributes, state: state)
                 .font(.title3.monospacedDigit().weight(.semibold))
-                .foregroundStyle(state.isEnded ? LiveActivityStyle.calmColor : LiveActivityStyle.activeColor)
-            Text(state.isEnded ? "ended" : "elapsed")
+                .foregroundStyle(LiveActivityStyle.tint(for: state))
+            Text(durationCaption)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
         }
+    }
+
+    private var durationCaption: String {
+        if state.isEnded { return "ended" }
+        if state.isInPostdrome { return "recovering" }
+        return "elapsed"
     }
 }
 
@@ -144,11 +154,12 @@ struct ExpandedTrailingView: View {
 
 struct PulsingDot: View {
     let color: Color
+    var accessibilityLabel: String = "Active migraine episode"
 
     var body: some View {
         Circle()
             .fill(color)
             .frame(width: 8, height: 8)
-            .accessibilityLabel("Active migraine episode")
+            .accessibilityLabel(accessibilityLabel)
     }
 }

--- a/mobile-apps/ios/MigraLogWidgets/LiveActivityStyle.swift
+++ b/mobile-apps/ios/MigraLogWidgets/LiveActivityStyle.swift
@@ -10,6 +10,27 @@ enum LiveActivityStyle {
     /// A softer tint used for the post-episode close state.
     static let calmColor = DesignTokens.LiveActivity.calm
 
+    /// Indigo accent for the beta post-drome (recovery) phase.
+    static let postdromeColor = DesignTokens.LiveActivity.postdrome
+
+    /// Accent for the current phase: red while the attack is active, indigo in
+    /// the post-drome recovery phase, calm green once ended.
+    static func tint(for state: EpisodeActivityAttributes.ContentState) -> Color {
+        if state.isEnded { return calmColor }
+        if state.isInPostdrome { return postdromeColor }
+        return activeColor
+    }
+
+    /// Phase glyph: a calming moon during recovery, the bolt-heart otherwise.
+    static func symbol(for state: EpisodeActivityAttributes.ContentState) -> String {
+        state.isInPostdrome ? "moon.zzz.fill" : "bolt.heart.fill"
+    }
+
+    /// Lock Screen / VoiceOver headline for the ongoing phase.
+    static func phaseLabel(for state: EpisodeActivityAttributes.ContentState) -> String {
+        state.isInPostdrome ? "Post-drome" : "In migraine"
+    }
+
     static func intensityLabel(_ intensity: Double?) -> String? {
         guard let intensity else { return nil }
         return "\(Int(intensity.rounded()))/10"


### PR DESCRIPTION
## Summary
Expands the beta **post-drome tracking** feature (#598). That PR deliberately left the Live Activity untouched, so an episode in post-drome still read as **"In migraine"** with a live pain reading — this fixes that, and makes the post-drome span on the intensity graph read as a real phase rather than a grey gap.

### Live Activity — now phase-aware (active → post-drome → ended)
- `ContentState` gains `postdromeStartAt` + derived `isInPostdrome` (mutually exclusive with `isEnded`; **ended wins**). `LiveActivityManager` populates it from the episode, and both `startPostdrome` / `resumeAttack` now `refresh()` the running activity so it flips live.
- Lock Screen & Dynamic Island switch to an **indigo "Post-drome"** presentation with a calming `moon.zzz.fill` glyph, **hide the pain intensity** (it's no longer tracked in recovery) in favour of a "Recovering" chip, and relabel the duration caption to "recovering".
- Phase tint / symbol / headline centralised in `LiveActivityStyle` so all presentations stay in sync. Indigo matches the existing Post-drome badge on the detail screen.

### Intensity graph — recovery band instead of a grey gap
- The post-drome span was a flat `systemGray5` rectangle that looked like a rendering error. Replaced with a soft **indigo vertical-gradient band**, a **dashed boundary** marking the moment the attack subsided, and a centered **"🌙 Post-drome"** label (glyph-only in narrow bands).

## Testing
- Added post-drome content-state tests: surfaces recovery phase, active-attack-is-not-postdrome, ended-takes-precedence-over-postdrome.
- Full `MigraLogTests` unit target + `PostdromeFlowUITests` pass locally on iPhone 17 Pro / iOS 26. SwiftLint clean.
- `BackupServiceTests.testRestoreFromReactNativeBackup` fails locally only because it reads a hardcoded stale file in `~/Downloads` (unsupported schema v0); it `XCTSkip`s in CI and is unrelated to this change.

## No schema / CloudKit impact
Uses the existing `episodes.postdrome_start_time` column added in #598. No migration, no sync change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)