### PR TITLE
fix(ci): keep website commits out of TestFlight "What to Test"

### DIFF
--- a/.github/scripts/changelog.mjs
+++ b/.github/scripts/changelog.mjs
@@ -4,11 +4,17 @@
 // extra secret. `feat:` commits become a "New" list, `fix:` commits a "Fixed"
 // list; trailing PR refs like "(#486)" are stripped for tester-facing prose.
 //
-// Only commits that touch the iOS app (INCLUDE_PATHS, default "mobile-apps/ios")
-// are eligible — website, tooling, and repo-script changes never reach testers,
-// whatever their scope says. On top of that, two classes of commit are dropped as
-// non-tester-facing: those whose scope is in EXCLUDE_SCOPES (default "ci"), and
-// those whose subject matches EXCLUDE_PATTERN (default: test-infrastructure churn).
+// Only commits that touch the iOS app (INCLUDE_PATHS, default "mobile-apps/ios",
+// minus EXCLUDE_PATHS) are eligible — website, tooling, and repo-script changes
+// never reach testers, whatever their scope says. Because the marketing-screenshot
+// generator lives *inside* the iOS test target (MigraLogUITests/ScreenshotsUITests.swift),
+// a website commit that only regenerates screenshots would otherwise sneak past the
+// path filter; EXCLUDE_PATHS carves that file back out so such commits don't count
+// as iOS-app changes. On top of the path filter, two classes of commit are dropped
+// as non-tester-facing: those whose scope is in EXCLUDE_SCOPES (default: "ci" plus
+// the website family — website/web/site/docs/marketing, including hyphen/slash
+// suffixes like "website-infra"), and those whose subject matches EXCLUDE_PATTERN
+// (default: test-infrastructure churn).
 //
 // Used by:
 //   set-beta-notes.mjs      — upload-time notes for a single build (range: prev release..HEAD)
@@ -17,7 +23,13 @@
 // Env (read once at import):
 //   INCLUDE_PATHS     — optional; comma-separated pathspecs a commit must touch to be
 //                       listed (default "mobile-apps/ios"). Empty string disables the filter.
-//   EXCLUDE_SCOPES    — optional; comma-separated scopes to drop (default "ci")
+//   EXCLUDE_PATHS     — optional; comma-separated pathspecs to carve back out of
+//                       INCLUDE_PATHS (default: the website-screenshot generator that
+//                       lives under the iOS test target). Empty string disables it.
+//   EXCLUDE_SCOPES    — optional; comma-separated scopes to drop (default:
+//                       "ci,website,web,site,docs,marketing"). A commit is dropped when
+//                       its scope equals an entry or starts with "<entry>-"/"<entry>/"
+//                       (so "website-infra" is caught by "website").
 //   EXCLUDE_PATTERN   — optional; JS regex (case-insensitive) dropping matching subjects
 
 import { execSync } from 'node:child_process';
@@ -29,15 +41,42 @@ export const CHAR_LIMIT = 4000; // App Store Connect whatsNew max length
 const DEFAULT_EXCLUDE_PATTERN =
   '\\b(ui|unit|snapshot)\\s+tests?\\b|\\bnightly\\b|\\bflaky\\b|waitfor\\w+|\\btest\\s+(suite|harness|plan)\\b';
 
+// Website work is tester-invisible even when its scope is present. "ci" stays for
+// pipeline plumbing; the rest cover the marketing-site family. See isExcludedScope
+// for the suffix rule that also catches "website-infra", "web/deploy", etc.
+const DEFAULT_EXCLUDE_SCOPES = 'ci,website,web,site,docs,marketing';
+
+// The App Store screenshot generator is an iOS test file but exists solely to feed
+// the marketing website; edits to it are website work, not app changes. Carving it
+// out of the include filter stops screenshot-only website commits from qualifying.
+const DEFAULT_EXCLUDE_PATHS = 'mobile-apps/ios/MigraLogUITests/ScreenshotsUITests.swift';
+
 const excludeScopes = new Set(
-  (process.env.EXCLUDE_SCOPES ?? 'ci')
+  (process.env.EXCLUDE_SCOPES ?? DEFAULT_EXCLUDE_SCOPES)
     .split(',')
     .map((s) => s.trim().toLowerCase())
     .filter(Boolean),
 );
+
+// A scope is excluded if it matches an entry exactly, or is a hyphen/slash-suffixed
+// sub-scope of one ("website" also drops "website-infra" and "web/deploy").
+function isExcludedScope(scope) {
+  if (!scope) return false;
+  if (excludeScopes.has(scope)) return true;
+  for (const ex of excludeScopes) {
+    if (scope.startsWith(`${ex}-`) || scope.startsWith(`${ex}/`)) return true;
+  }
+  return false;
+}
+
 const excludePattern = new RegExp(process.env.EXCLUDE_PATTERN || DEFAULT_EXCLUDE_PATTERN, 'i');
 
 const includePaths = (process.env.INCLUDE_PATHS ?? 'mobile-apps/ios')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const excludePaths = (process.env.EXCLUDE_PATHS ?? DEFAULT_EXCLUDE_PATHS)
   .split(',')
   .map((s) => s.trim())
   .filter(Boolean);
@@ -70,9 +109,14 @@ export function resolveVersionRef(version) {
 // commits.
 export function generateNotes(lowerRef, upperRef = 'HEAD') {
   const range = lowerRef ? `${lowerRef}..${upperRef}` : upperRef;
-  const pathspec = includePaths.length
-    ? ` -- ${includePaths.map((p) => `"${p}"`).join(' ')}`
-    : '';
+  // Include the iOS app paths, then carve out excluded sub-paths (e.g. the
+  // website-screenshot generator) with git's :(exclude) pathspec magic. Exclude
+  // pathspecs are ignored by git unless a positive pathspec is also present.
+  const pathParts = [
+    ...includePaths.map((p) => `"${p}"`),
+    ...(includePaths.length ? excludePaths.map((p) => `":(exclude)${p}"`) : []),
+  ];
+  const pathspec = pathParts.length ? ` -- ${pathParts.join(' ')}` : '';
   const raw = execSync(`git log --no-merges --format=%s ${range}${pathspec}`, { encoding: 'utf8' });
   const subjects = raw.split('\n').map((s) => s.trim()).filter(Boolean);
 
@@ -86,8 +130,8 @@ export function generateNotes(lowerRef, upperRef = 'HEAD') {
     // Strip trailing PR refs like " (#486)" or " (#486) (#500)".
     const text = m[3].replace(/\s*\(#\d+\)/g, '').trim();
     if (!text) continue;
-    // Drop non-tester-facing noise: excluded scopes (e.g. ci) and test churn.
-    if (excludeScopes.has(scope)) continue;
+    // Drop non-tester-facing noise: excluded scopes (ci, website family) and test churn.
+    if (isExcludedScope(scope)) continue;
     if (excludePattern.test(text)) continue;
     (type === 'feat' ? features : fixes).push(capitalize(text));
   }


### PR DESCRIPTION
## Problem
Some TestFlight **What to Test** notes described website work — e.g. *"landing page redesign — clinical layout, brand palette, carousel, TestFlight beta"* — instead of actual iOS app changes.

Two gaps let website commits through the `changelog.mjs` filter:
1. **Path filter is too coarse.** The App Store screenshot generator (`MigraLogUITests/ScreenshotsUITests.swift`) lives *inside* the iOS test target. A `feat(website)` commit that only regenerates marketing screenshots still touches a `mobile-apps/ios` path, so it passed `INCLUDE_PATHS`.
2. **Only `ci` was excluded by scope.** `website` / `web` / `website-infra` scopes were never dropped.

## Fix
- `EXCLUDE_SCOPES` now defaults to `ci,website,web,site,docs,marketing`, with hyphen/slash-suffix matching so `website-infra` is caught by `website`.
- New `EXCLUDE_PATHS` (default `MigraLogUITests/ScreenshotsUITests.swift`) carves that file back out of the iOS path filter via git `:(exclude)`, so screenshot-only commits no longer qualify.
- Both are env-overridable; all workflow wiring already inherits the shared defaults, so no workflow changes were needed.

## Verification
Ran `generateNotes` over the last ~40 commits:
- **Before:** notes included *"Landing page redesign — clinical layout, brand palette, carousel, TestFlight beta"*.
- **After:** all website commits (#595, #596, #597, #579, #577) drop out; every genuine iOS feat/fix still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)