### PR TITLE
fix(ios): dismiss number pad in rule editor via keyboard Done button (#599)

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/Settings/CategorySafetyRuleEditorSheet.swift
+++ b/mobile-apps/ios/MigraLog/Views/Settings/CategorySafetyRuleEditorSheet.swift
@@ -29,6 +29,9 @@ struct CategorySafetyRuleEditorSheet: View {
     @State private var windowDaysText: String = ""
     @State private var cooldownHoursText: String = ""
     @State private var excludedMedicationIds: Set<String> = []
+    /// The numeric keyboards (number/decimal pad) have no return key, so a
+    /// keyboard-toolbar Done button is the only way to dismiss them.
+    @FocusState private var numericFieldFocused: Bool
 
     var body: some View {
         NavigationStack {
@@ -50,6 +53,11 @@ struct CategorySafetyRuleEditorSheet: View {
                     Button("Save") { save() }
                         .disabled(!isValid)
                         .accessibilityIdentifier("rule-editor-save")
+                }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") { numericFieldFocused = false }
+                        .accessibilityIdentifier("rule-editor-keyboard-done")
                 }
             }
             .onAppear(perform: configureInitialState)
@@ -116,6 +124,7 @@ struct CategorySafetyRuleEditorSheet: View {
             LabeledContent("Max days taken") {
                 TextField("", text: $maxDaysText, prompt: Text("e.g. 15"))
                     .keyboardType(.numberPad)
+                    .focused($numericFieldFocused)
                     .multilineTextAlignment(.trailing)
                     .accessibilityIdentifier("rule-editor-max-days")
             }
@@ -123,6 +132,7 @@ struct CategorySafetyRuleEditorSheet: View {
                 HStack(spacing: DesignTokens.Spacing.xs) {
                     TextField("", text: $windowDaysText, prompt: Text("e.g. 30"))
                         .keyboardType(.numberPad)
+                        .focused($numericFieldFocused)
                         .multilineTextAlignment(.trailing)
                         .accessibilityIdentifier("rule-editor-window-days")
                     Text("days")
@@ -150,6 +160,7 @@ struct CategorySafetyRuleEditorSheet: View {
                 HStack(spacing: DesignTokens.Spacing.xs) {
                     TextField("", text: $cooldownHoursText, prompt: Text("e.g. 8"))
                         .keyboardType(.decimalPad)
+                        .focused($numericFieldFocused)
                         .multilineTextAlignment(.trailing)
                         .accessibilityIdentifier("rule-editor-cooldown-hours")
                     Text("hours")

--- a/mobile-apps/ios/MigraLogUITests/CategorySafetyRulesUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/CategorySafetyRulesUITests.swift
@@ -121,9 +121,12 @@ final class CategorySafetyRulesUITests: XCTestCase {
     // MARK: - Helpers
 
     /// The rule editor opens at the medium detent and its Form is lazy, so the
-    /// medications checklist may not exist in the hierarchy yet. Swipe up to
-    /// expand the sheet, then scroll until the row is hittable.
+    /// medications checklist may not exist in the hierarchy yet. Dismiss the
+    /// software keyboard if it's up (the number pad covers the lower half of
+    /// the medium-detent sheet — #599), swipe up to expand the sheet, then
+    /// scroll until the row is hittable.
     private func revealChecklistRow() -> XCUIElement {
+        dismissKeyboardIfPresent()
         let row = app.buttons["rule-editor-medication-fixture-med-ibuprofen"]
         if !row.isHittable {
             app.swipeUp()
@@ -134,6 +137,19 @@ final class CategorySafetyRulesUITests: XCTestCase {
         }
         UITestHelpers.waitForHittable(row)
         return row
+    }
+
+    /// With the simulator's hardware keyboard disconnected, typing into the
+    /// numeric fields leaves the software number pad covering the lower half
+    /// of the medium-detent sheet. The number pad has no return key, so tap
+    /// the keyboard toolbar's Done button. No-op when the hardware keyboard
+    /// is connected (CI) and no software keyboard appears.
+    private func dismissKeyboardIfPresent() {
+        guard app.keyboards.firstMatch.exists else { return }
+        let done = app.buttons["rule-editor-keyboard-done"]
+        UITestHelpers.waitForHittable(done)
+        done.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
     }
 
     /// Dashboard → settings gear → Medication Safety Limits.


### PR DESCRIPTION
## Summary
Fixes #599 — `CategorySafetyRulesUITests/testExcludingMedicationSilencesCategoryWarning` fails whenever the simulator shows the software keyboard: after typing into `rule-editor-window-days`, the number pad stays up and covers the lower half of the medium-detent Add Rule sheet, so `revealChecklistRow()` can never surface the medication checklist row.

Root cause is actually a small UX gap, not just test robustness: the rule editor's numeric fields use number/decimal pads, which have **no return key**, and the sheet offered no way to dismiss them — for real users too.

## Changes
- **`CategorySafetyRuleEditorSheet`**: add a keyboard-toolbar **Done** button (`ToolbarItemGroup(placement: .keyboard)`, backed by a shared `@FocusState` on the three numeric fields), accessibility id `rule-editor-keyboard-done`.
- **`CategorySafetyRulesUITests`**: `revealChecklistRow()` now dismisses the software keyboard via that button whenever one is present, before expanding/scrolling the sheet. No-op when the hardware keyboard is connected (nightly CI), so CI behavior is unchanged.

## Testing
- Ran `testExcludingMedicationSilencesCategoryWarning` locally on iPhone 17 Pro (26.0) with `ConnectHardwareKeyboard = 0` — the exact previously-failing condition from #599 — **passed** (66s).
- Full-project SwiftLint: 0 errors; no new warnings introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)