### PR TITLE
fix(ios): stop Log Update from inserting phantom intensity readings

### DIFF
--- a/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Dashboard/DashboardScreen.swift
@@ -15,6 +15,9 @@ struct DashboardScreen: View {
     /// Drives the add-medication sheet launched from a setup-checklist task, with
     /// the type preselected to match the task.
     @State private var showAddMedication = false
+    /// True once the Log Update sheet's `.task` reload has completed for the
+    /// current presentation; reset on dismiss so each presentation re-gates.
+    @State private var logUpdateDataFresh = false
     @State private var addMedicationType: MedicationType = .rescue
     @State private var refreshId = UUID()
     @State private var refreshTask: Task<Void, Never>?
@@ -54,13 +57,18 @@ struct DashboardScreen: View {
             }
         }
         .sheet(isPresented: $viewModel.showLogUpdate, onDismiss: {
+            logUpdateDataFresh = false
             Task { await viewModel.loadData() }
         }) {
             NavigationStack {
-                // Gate on the detail view model having loaded the *current*
-                // episode so LogUpdateScreen prefills from real data rather
-                // than a stale or empty state.
-                if let episode = detailViewModel.episode,
+                // Gate on this presentation's reload having finished, not just on
+                // the detail view model holding the current episode id: a stale
+                // same-id load from an earlier presentation would otherwise let
+                // LogUpdateScreen prefill (one-shot, in onAppear) from readings
+                // that miss anything logged since — e.g. via EpisodeDetailScreen,
+                // which uses its own view model instance.
+                if logUpdateDataFresh,
+                   let episode = detailViewModel.episode,
                    episode.id == viewModel.currentEpisode?.id {
                     LogUpdateScreen(episodeId: episode.id, viewModel: detailViewModel)
                 } else {
@@ -72,6 +80,7 @@ struct DashboardScreen: View {
                 if let id = viewModel.currentEpisode?.id {
                     await detailViewModel.loadEpisode(id)
                 }
+                logUpdateDataFresh = true
             }
         }
         .sheet(isPresented: $viewModel.showLogMedication, onDismiss: {

--- a/mobile-apps/ios/MigraLog/Views/Episodes/LogUpdateScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/LogUpdateScreen.swift
@@ -7,6 +7,7 @@ struct LogUpdateScreen: View {
 
     @State private var trackingOptions = TrackingOptionsViewModel()
     @State private var intensity: Double = 5.0
+    @State private var initialIntensity: Double = 5.0
     @State private var selectedLocations: Set<PainLocation> = []
     @State private var initialLocations: Set<PainLocation> = []
     @State private var selectedSymptoms: Set<Symptom> = []
@@ -61,6 +62,7 @@ struct LogUpdateScreen: View {
             Section("Note") {
                 TextEditor(text: $noteText)
                     .frame(minHeight: 60)
+                    .accessibilityIdentifier("update-note-field")
             }
         }
         .navigationTitle("Log Update")
@@ -99,6 +101,7 @@ struct LogUpdateScreen: View {
         if let latestReading = viewModel.intensityReadings.last {
             intensity = latestReading.intensity
         }
+        initialIntensity = intensity
 
         // Pre-fill pain locations from most recent log, or episode's initial locations
         if let latestLocationLog = viewModel.painLocationLogs.last {
@@ -131,8 +134,11 @@ struct LogUpdateScreen: View {
         defer { isSaving = false }
         let updateTimestamp = TimestampHelper.fromDate(timestamp)
 
-        // Add intensity reading (not during post-drome — pain levels don't apply)
-        if !isInPostdrome {
+        // Add intensity reading only if the user moved the slider (and not during
+        // post-drome — pain levels don't apply). An untouched slider must not
+        // write a reading: a note-only update would otherwise insert a phantom
+        // intensity change at the update time.
+        if !isInPostdrome && intensity != initialIntensity {
             await viewModel.addIntensityReading(
                 intensity: intensity,
                 timestamp: updateTimestamp

--- a/mobile-apps/ios/MigraLogUITests/LogUpdateNoteOnlyUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/LogUpdateNoteOnlyUITests.swift
@@ -1,0 +1,88 @@
+import XCTest
+
+/// Regression test: saving a Log Update with only a note must not insert an
+/// intensity reading. The update flow used to write the (pre-filled) slider
+/// value on every save, so a note-only update showed a phantom "Intensity
+/// Update" on the timeline with a value the user never entered.
+final class LogUpdateNoteOnlyUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = UITestHelpers.launchCleanDashboard()
+        UITestHelpers.waitForDashboard(in: app)
+    }
+
+    override func tearDownWithError() throws {
+        if let app {
+            let screenshot = XCTAttachment(screenshot: app.screenshot())
+            screenshot.name = "final-state"
+            screenshot.lifetime = .keepAlways
+            add(screenshot)
+        }
+        app = nil
+    }
+
+    func testNoteOnlyUpdateDoesNotAddIntensityReading() throws {
+        // === Start an episode with defaults (writes the initial intensity) ===
+        let startButton = app.buttons["start-episode-button"]
+        let saveButton = app.buttons["save-episode-button"]
+        UITestHelpers.tapToPresent(startButton, expecting: saveButton)
+        UITestHelpers.waitForHittable(saveButton)
+        saveButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // === Open episode detail ===
+        let activeEpisodeCard = app.buttons["active-episode-card"]
+        UITestHelpers.waitForHittable(activeEpisodeCard)
+        activeEpisodeCard.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // === Log an update containing only a note ===
+        let logUpdateButton = app.buttons["log-update-button"]
+        let detailScroll = app.scrollViews.firstMatch
+        if !logUpdateButton.isHittable {
+            UITestHelpers.scrollToElement(logUpdateButton, in: detailScroll)
+        }
+        UITestHelpers.waitForHittable(logUpdateButton)
+        logUpdateButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // The Note section sits at the bottom of the Form; its row is
+        // virtualized and doesn't exist until scrolled into view.
+        let updateForm = app.collectionViews.firstMatch
+        let noteField = app.textViews["update-note-field"]
+        UITestHelpers.scrollToElement(noteField, in: updateForm)
+        noteField.tap()
+        noteField.typeText("Note-only update, slider untouched")
+
+        let saveUpdateButton = app.buttons["Save"]
+        UITestHelpers.waitForHittable(saveUpdateButton)
+        saveUpdateButton.tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        // === Timeline shows the note but no second intensity entry ===
+        // Bring the whole (short) timeline on screen; the fresh episode has only
+        // a handful of entries, so scrolling to the end-episode control below the
+        // timeline renders them all.
+        let endNowButton = app.buttons["end-now-button"]
+        if !endNowButton.isHittable {
+            UITestHelpers.scrollToElement(endNowButton, in: detailScroll)
+        }
+
+        let noteEntry = app.staticTexts["Note-only update, slider untouched"]
+        XCTAssertTrue(noteEntry.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+                      "Timeline should show the note from the update")
+
+        let intensityEntries = app.staticTexts.matching(
+            NSPredicate(format: "label == %@", "Intensity Update")
+        )
+        XCTAssertEqual(intensityEntries.count, 1,
+                       "A note-only update must not add an intensity reading; only the episode's initial reading should be on the timeline")
+
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "timeline-note-only-update"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+    }
+}

--- a/mobile-apps/ios/MigraLogUITests/LogUpdateTimePickerUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/LogUpdateTimePickerUITests.swift
@@ -73,6 +73,14 @@ final class LogUpdateTimePickerUITests: XCTestCase {
                       "Log Update screen should have a Time picker")
         attach(name: "log-update-time-picker")
 
+        // An update only writes an intensity reading when the slider actually
+        // moved (an untouched slider is not a change), so move it to make this
+        // a real backdated intensity update.
+        let slider = app.sliders.firstMatch
+        XCTAssertTrue(slider.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+                      "Log Update screen should have the intensity slider")
+        slider.adjust(toNormalizedSliderPosition: 0.7)
+
         // === Backdate the update by 30 minutes ===
         setTime(of: updatePicker, to: updateTime)
         XCTAssertTrue(


### PR DESCRIPTION
## Summary
Logging an update that only contained a note inserted an "Intensity Update" timeline entry the user never made, sometimes with a value that matched no current reading (reported glitch).

Two defects combined:
- **`LogUpdateScreen.save()` wrote an intensity reading on every save** (outside post-drome), with no change detection — unlike symptoms and pain locations, which diff against their initial state. A note-only update therefore inserted a reading at the update time.
- **The inserted value could be stale or fabricated.** The slider prefill is one-shot (`onAppear`), and the dashboard's Log Update sheet gated only on the detail view model holding the current episode id. On any presentation after the first, a stale load from an earlier presentation passed the gate while the `.task` reload raced behind it — so readings logged via `EpisodeDetailScreen` (its own view model instance) were missing from the prefill, which then fell back to an older reading or the bare `5.0` default.

## Changes
- Track `initialIntensity` at prefill; only write a reading when the slider actually moved.
- Gate the dashboard's Log Update sheet on the current presentation's reload having completed (`logUpdateDataFresh`), reset on dismiss.
- `LogUpdateTimePickerUITests` now moves the slider so the backdated update still writes the reading it asserts on.
- New `LogUpdateNoteOnlyUITests` regression test: a note-only update shows the note and exactly one (initial) intensity entry on the timeline.
- Added `update-note-field` accessibility identifier to the note editor.

## Testing
- Unit suite: 1109 tests, sole failure is the pre-existing, environment-dependent `BackupServiceTests/testRestoreFromReactNativeBackup` (restores a legacy RN backup from `~/Downloads` with `user_version = 0`, rejected since the #529/#535 hardening; skipped on CI).
- UI tests run locally on iPhone 17 Pro (iOS 26.0): `LogUpdateNoteOnlyUITests`, `LogUpdateTimePickerUITests`, `EpisodeLifecycleUITests` — all passing.
- SwiftLint: no error-level violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)