### PR TITLE
fix(ios): dismiss permission dialog spawned by notification settings UI test

### DIFF
--- a/mobile-apps/ios/MigraLogUITests/NotificationSettingsUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/NotificationSettingsUITests.swift
@@ -44,6 +44,18 @@ final class NotificationSettingsUITests: XCTestCase {
         let notifTitle = app.navigationBars.staticTexts["Notification Settings"]
         XCTAssertTrue(notifTitle.waitForExistence(timeout: UITestHelpers.defaultTimeout),
                        "Notification settings screen should be visible")
+
+        // Step 4: Dismiss the permission dialog this screen spawns. Its `.task`
+        // auto-requests notification permission (syncDailyCheckinNotification →
+        // requestPermission), and on a simulator where permission is still
+        // not-determined the system dialog can pop after this test's assertions
+        // have already passed. Left up, it outlives the app relaunch and blocks
+        // the following tests' taps (2026-07-31 nightly: sank both
+        // testPerMedicationNotificationOverrides and
+        // testCachedPermissionsNoDialogs). Second call covers the possible
+        // Critical Alerts dialog, as in completeOnboarding.
+        UITestHelpers.handleSystemAlert(in: app, buttonLabel: "Allow", timeout: 5)
+        UITestHelpers.handleSystemAlert(in: app, buttonLabel: "Allow")
     }
 
     // MARK: - 8.2 Per-medication notification overrides

--- a/mobile-apps/ios/MigraLogUITests/UITestHelpers.swift
+++ b/mobile-apps/ios/MigraLogUITests/UITestHelpers.swift
@@ -327,10 +327,14 @@ enum UITestHelpers {
     }
 
     /// Attempt to handle a system alert by tapping the specified button.
-    static func handleSystemAlert(in app: XCUIApplication, buttonLabel: String) {
+    ///
+    /// System alerts live in springboard, not the app under test, so they persist
+    /// across app relaunches until answered — a dialog one test leaves up silently
+    /// blocks every later test's taps while all element queries still pass.
+    static func handleSystemAlert(in app: XCUIApplication, buttonLabel: String, timeout: TimeInterval = 2) {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let alertButton = springboard.buttons[buttonLabel]
-        if alertButton.waitForExistence(timeout: 2) {
+        if alertButton.waitForExistence(timeout: timeout) {
             alertButton.tap()
             Thread.sleep(forTimeInterval: animationWait)
         }


### PR DESCRIPTION
## Summary
The 2026-07-31 nightly failed two UI tests, both blocked by the same leftover system dialog:

- `testPerMedicationNotificationOverrides` — "Tab Medications did not stay selected after 3 taps"
- `testCachedPermissionsNoDialogs` — dashboard never appeared within 15s

**Root cause:** `testGlobalNotificationSettings` opens the Notification Settings screen, whose `.task` auto-requests notification permission (`syncDailyCheckinNotification` → `requestPermission`). On the fresh CI simulator that pops the system permission dialog — sometimes only after the test's final assertion has already passed. Springboard alerts survive app relaunches, so the undismissed dialog silently swallowed the following tests' taps until `testCompleteOnboardingFlow`'s Allow handler cleared it. The nightly's failure screen recordings show the dialog covering the screen for the full duration of both failed tests. The failing and previous passing nightly ran the same commit — this is a timing race, not a regression.

**Fix:** dismiss the dialog where it's spawned — after verifying the settings screen opened, tap Allow (5s window for the async request under CI load), plus a second pass for the possible Critical Alerts dialog, mirroring `completeOnboarding`. `handleSystemAlert` gains a `timeout` parameter.

## Testing
- Ran `NotificationSettingsUITests` + `OnboardingUITests` locally on a **freshly created** iPhone 17 Pro (iOS 26.0) simulator (permission not-determined, matching the nightly runner): dialog appeared, new step dismissed it (confirmed in xcresult activity log), all 4 tests passed.
- SwiftLint: no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)