### PR TITLE
fix(ios): retap settings gear when a system banner steals the tap

### DIFF
--- a/mobile-apps/ios/MigraLogUITests/AccessibilityUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/AccessibilityUITests.swift
@@ -155,8 +155,7 @@ final class AccessibilityUITests: XCTestCase {
         XCTAssertTrue(startButton.isHittable, "Start episode button should be visible")
 
         // Step 2: Navigate to Settings, verify theme options
-        settingsButton.tap()
-        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        UITestHelpers.openSettings(in: app)
 
         let lightTheme = app.buttons["theme-light"]
         let darkTheme = app.buttons["theme-dark"]

--- a/mobile-apps/ios/MigraLogUITests/BetaFeaturesUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/BetaFeaturesUITests.swift
@@ -60,11 +60,6 @@ final class BetaFeaturesUITests: XCTestCase {
     // MARK: - Helpers
 
     private func openSettings() {
-        let settingsButton = app.buttons["settings-button"]
-        UITestHelpers.waitForHittable(settingsButton)
-        settingsButton.tap()
-
-        let settingsTitle = app.navigationBars.staticTexts["Settings"]
-        UITestHelpers.waitForElement(settingsTitle)
+        UITestHelpers.openSettings(in: app)
     }
 }

--- a/mobile-apps/ios/MigraLogUITests/CategorySafetyRulesUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/CategorySafetyRulesUITests.swift
@@ -156,10 +156,7 @@ final class CategorySafetyRulesUITests: XCTestCase {
     private func openSafetyLimits() {
         UITestHelpers.navigateTo(tab: .dashboard, in: app)
         // Pop any pushed screens left from a previous visit.
-        let settingsButton = app.buttons["settings-button"]
-        UITestHelpers.waitForHittable(settingsButton)
-        settingsButton.tap()
-        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+        UITestHelpers.openSettings(in: app)
         let limitsRow = app.buttons["medication-safety-limits"]
         let listView = app.tables.firstMatch.exists ? app.tables.firstMatch : app.collectionViews.firstMatch
         if !limitsRow.isHittable && listView.exists {

--- a/mobile-apps/ios/MigraLogUITests/DeveloperModeUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/DeveloperModeUITests.swift
@@ -67,12 +67,7 @@ final class DeveloperModeUITests: XCTestCase {
     // MARK: - Helpers
 
     private func openSettings() {
-        let settingsButton = app.buttons["settings-button"]
-        UITestHelpers.waitForHittable(settingsButton)
-        settingsButton.tap()
-
-        let settingsTitle = app.navigationBars.staticTexts["Settings"]
-        UITestHelpers.waitForElement(settingsTitle)
+        UITestHelpers.openSettings(in: app)
     }
 
     @discardableResult

--- a/mobile-apps/ios/MigraLogUITests/NotificationSettingsUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/NotificationSettingsUITests.swift
@@ -19,15 +19,8 @@ final class NotificationSettingsUITests: XCTestCase {
     // MARK: - 8.1 Global notification settings
 
     func testGlobalNotificationSettings() throws {
-        // Step 1: Tap settings gear on dashboard
-        let settingsButton = app.buttons["settings-button"]
-        UITestHelpers.waitForHittable(settingsButton)
-        settingsButton.tap()
-        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
-
-        // Verify we're on Settings screen
-        let settingsTitle = app.navigationBars.staticTexts["Settings"]
-        UITestHelpers.waitForElement(settingsTitle)
+        // Step 1: Tap settings gear on dashboard, verify we're on Settings screen
+        UITestHelpers.openSettings(in: app)
 
         // Step 2: Tap "Notifications" (NavigationLink in a List, renders as button)
         let notificationSettings = app.buttons["notification-settings"]

--- a/mobile-apps/ios/MigraLogUITests/PostdromeFlowUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/PostdromeFlowUITests.swift
@@ -31,10 +31,7 @@ final class PostdromeFlowUITests: XCTestCase {
 
     func testPostdromeFlow() throws {
         // === Phase 1: enable the beta flag ===
-        let settingsButton = app.buttons["settings-button"]
-        UITestHelpers.waitForHittable(settingsButton)
-        settingsButton.tap()
-        UITestHelpers.waitForElement(app.navigationBars.staticTexts["Settings"])
+        UITestHelpers.openSettings(in: app)
 
         let betaLink = app.buttons["beta-features"]
         let list = app.collectionViews.firstMatch

--- a/mobile-apps/ios/MigraLogUITests/ThemeSwitchingUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/ThemeSwitchingUITests.swift
@@ -57,12 +57,7 @@ final class ThemeSwitchingUITests: XCTestCase {
     // MARK: - Helpers
 
     private func openSettings() {
-        let settingsButton = app.buttons["settings-button"]
-        UITestHelpers.waitForHittable(settingsButton)
-        settingsButton.tap()
-
-        let settingsTitle = app.navigationBars.staticTexts["Settings"]
-        UITestHelpers.waitForElement(settingsTitle)
+        UITestHelpers.openSettings(in: app)
     }
 
     private func tapTheme(_ identifier: String) {

--- a/mobile-apps/ios/MigraLogUITests/TrackingOptionsUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/TrackingOptionsUITests.swift
@@ -140,14 +140,7 @@ final class TrackingOptionsUITests: XCTestCase {
     // MARK: - Helpers
 
     private func openSettings() {
-        let settingsButton = app.buttons["settings-button"]
-        UITestHelpers.waitForHittable(settingsButton)
-        settingsButton.tap()
-
-        // Wait for the Settings list to settle before scrolling/querying — the
-        // collection view isn't queryable mid-transition.
-        let settingsTitle = app.navigationBars.staticTexts["Settings"]
-        UITestHelpers.waitForElement(settingsTitle)
+        UITestHelpers.openSettings(in: app)
     }
 
     /// Open a single tracking category screen (Symptoms / Triggers / Pain

--- a/mobile-apps/ios/MigraLogUITests/UITestHelpers.swift
+++ b/mobile-apps/ios/MigraLogUITests/UITestHelpers.swift
@@ -171,6 +171,43 @@ enum UITestHelpers {
         return false
     }
 
+    /// Open the app's Settings screen from the dashboard gear button, verifying
+    /// the screen actually appeared and retapping if it didn't.
+    ///
+    /// A bare gear tap can be stolen by a system notification banner dropping
+    /// over the top-right corner: the 2026-07-31 dispatched nightly's fresh
+    /// simulator posted its one-shot "Apple Intelligence & Siri" banner just as
+    /// testHighContrastElements tapped the gear, the tap deep-linked into the
+    /// system Settings app, and the test scrolled the dashboard looking for the
+    /// theme options. That steal backgrounds the app, so unlike tapToPresent
+    /// this loop re-activates it before retapping; the banner is one-shot, so
+    /// the retry recovers.
+    static func openSettings(
+        in app: XCUIApplication,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let gear = app.buttons["settings-button"]
+        let settingsTitle = app.navigationBars.staticTexts["Settings"]
+        waitForHittable(gear, timeout: 15, file: file, line: line)
+        let maxAttempts = 3
+        for _ in 0..<maxAttempts {
+            if app.state != .runningForeground {
+                app.activate()
+                Thread.sleep(forTimeInterval: animationWait)
+            }
+            if gear.isHittable {
+                gear.tap()
+                Thread.sleep(forTimeInterval: animationWait)
+            }
+            if settingsTitle.waitForExistence(timeout: defaultTimeout) {
+                return
+            }
+        }
+        XCTFail("Settings screen did not appear after \(maxAttempts) attempts",
+                file: file, line: line)
+    }
+
     /// Tap a button that presents a sheet/screen and wait for an element on that
     /// destination to appear, retapping if it doesn't.
     ///


### PR DESCRIPTION
## Summary
Third and final fix in today's nightly-flake series (#612 permission dialog, #613 backdate wheel clamp). The re-dispatched nightly (run 30642782915) failed only `testHighContrastElements`: the fresh simulator posted its one-shot **"Apple Intelligence & Siri" banner** just as the test tapped the dashboard settings gear — top-right, exactly where banners drop. The tap hit the banner, deep-linked into the system Settings app (screen recording shows Settings → Siri with the "◀ MigraLog" breadcrumb), and the test then swiped the dashboard looking for `theme-light`.

## Fix
New `UITestHelpers.openSettings(in:)`: tap the gear, verify the Settings screen actually appeared, retap if not — re-activating the app first, since a banner steal backgrounds it (which is why the existing `tapToPresent` retap guard can't recover on its own). The banner is one-shot per boot, so the retry recovers. All eight suites that previously tapped the gear bare (Accessibility, BetaFeatures, CategorySafetyRules, DeveloperMode, NotificationSettings, PostdromeFlow, ThemeSwitching, TrackingOptions) now share the helper.

## Testing
- All eight touched suites pass locally (iPhone 17 Pro, iOS 26.0).
- SwiftLint: no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)