### PR TITLE
feat(ios): edit post-drome transition time from the timeline

### DIFF
--- a/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
+++ b/mobile-apps/ios/MigraLog/ViewModels/EpisodeDetailViewModel.swift
@@ -189,6 +189,39 @@ final class EpisodeDetailViewModel {
         }
     }
 
+    /// Beta post-drome tracking: correct the recorded transition time. Works for
+    /// active episodes and for ended ones that kept their phase record.
+    @MainActor
+    func editPostdromeStartTime(_ timestamp: Int64) async {
+        guard var episode = details?.episode, episode.postdromeStartTime != nil else { return }
+        guard timestamp > episode.startTime else {
+            self.error = "Post-drome start must be after the episode start time."
+            return
+        }
+        if let endTime = episode.endTime, timestamp >= endTime {
+            self.error = "Post-drome start must be before the episode end time."
+            return
+        }
+        episode.postdromeStartTime = timestamp
+        episode.updatedAt = TimestampHelper.now
+        do {
+            _ = try episodeRepository.updateEpisode(episode)
+            details = EpisodeWithDetails(
+                episode: episode,
+                intensityReadings: details?.intensityReadings ?? [],
+                symptomLogs: details?.symptomLogs ?? [],
+                painLocationLogs: details?.painLocationLogs ?? [],
+                episodeNotes: details?.episodeNotes ?? []
+            )
+            if episode.isActive {
+                liveActivityManager.refresh(episodeId: episode.id)
+            }
+        } catch {
+            ErrorLogger.shared.logError(error, context: ["viewModel": "EpisodeDetailViewModel", "action": "editPostdromeStartTime"])
+            self.error = error.localizedDescription
+        }
+    }
+
     @MainActor
     func editEndTime(_ timestamp: Int64) async {
         guard var episode = details?.episode, !episode.isActive else { return }

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeActionButtons.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeActionButtons.swift
@@ -105,15 +105,19 @@ struct EpisodeActionButtons: View {
 struct CustomEndTimeSheet: View {
     @Binding var customEndTime: Date
     var minimumDate: Date? = nil
+    /// Upper bound for the picker; defaults to now (times can't be in the future).
+    var maximumDate: Date? = nil
+    var title: String = "Custom End Time"
+    var pickerLabel: String = "End Time"
     let onConfirm: () -> Void
     let onCancel: () -> Void
 
     var body: some View {
         VStack {
             DatePicker(
-                "End Time",
+                pickerLabel,
                 selection: $customEndTime,
-                in: (minimumDate ?? .distantPast)...Date()
+                in: (minimumDate ?? .distantPast)...(maximumDate ?? Date())
             )
             .datePickerStyle(.wheel)
 
@@ -126,7 +130,7 @@ struct CustomEndTimeSheet: View {
             }
             .padding()
         }
-        .navigationTitle("Custom End Time")
+        .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/EpisodeDetailScreen.swift
@@ -15,6 +15,8 @@ struct EpisodeDetailScreen: View {
     @State private var showLogMedication = false
     @State private var showEndConfirm = false
     @State private var customEndTime = Date()
+    @State private var customPostdromeTime = Date()
+    @State private var showPostdromeTimePicker = false
 
     // Timeline editing state
     @State private var editingReading: IntensityReading?
@@ -49,6 +51,8 @@ struct EpisodeDetailScreen: View {
                             pendingDeleteLabel: $pendingDeleteLabel,
                             customEndTime: $customEndTime,
                             showEndTimePicker: $showEndTimePicker,
+                            customPostdromeTime: $customPostdromeTime,
+                            showPostdromeTimePicker: $showPostdromeTimePicker,
                             editingDose: $editingDose,
                             showEditEpisodeSheet: $showEditSheet
                         )
@@ -152,6 +156,26 @@ struct EpisodeDetailScreen: View {
                         showEndTimePicker = false
                     },
                     onCancel: { showEndTimePicker = false }
+                )
+            }
+        }
+        .sheet(isPresented: $showPostdromeTimePicker) {
+            NavigationStack {
+                CustomEndTimeSheet(
+                    customEndTime: $customPostdromeTime,
+                    minimumDate: viewModel.episode?.startDate,
+                    maximumDate: viewModel.episode?.endDate,
+                    title: "Post-drome Start Time",
+                    pickerLabel: "Post-drome Start",
+                    onConfirm: {
+                        Task {
+                            await viewModel.editPostdromeStartTime(
+                                TimestampHelper.fromDate(customPostdromeTime)
+                            )
+                        }
+                        showPostdromeTimePicker = false
+                    },
+                    onCancel: { showPostdromeTimePicker = false }
                 )
             }
         }

--- a/mobile-apps/ios/MigraLog/Views/Episodes/TimelineView.swift
+++ b/mobile-apps/ios/MigraLog/Views/Episodes/TimelineView.swift
@@ -53,6 +53,8 @@ struct TimelineView: View {
     @Binding var pendingDeleteLabel: String
     @Binding var customEndTime: Date
     @Binding var showEndTimePicker: Bool
+    @Binding var customPostdromeTime: Date
+    @Binding var showPostdromeTimePicker: Bool
     @Binding var editingDose: DoseWithMedication?
     @Binding var showEditEpisodeSheet: Bool
 
@@ -450,6 +452,14 @@ struct TimelineView: View {
             }
 
         case .postdromeStarted:
+            Button {
+                if let postdromeStart = viewModel.episode?.postdromeStartTime {
+                    customPostdromeTime = Date(timeIntervalSince1970: Double(postdromeStart) / 1000.0)
+                }
+                showPostdromeTimePicker = true
+            } label: {
+                Label("Edit Time", systemImage: "clock")
+            }
             if viewModel.episode?.isInPostdrome == true {
                 Button {
                     Task { await viewModel.resumeAttack() }

--- a/mobile-apps/ios/MigraLogTests/ViewModels/EpisodeDetailViewModelTests.swift
+++ b/mobile-apps/ios/MigraLogTests/ViewModels/EpisodeDetailViewModelTests.swift
@@ -155,6 +155,72 @@ final class EpisodeDetailViewModelTests: XCTestCase {
         )
     }
 
+    // MARK: - Edit Post-drome Start Time (beta)
+
+    func testEditPostdromeStartTime_updatesTime() async throws {
+        mockRepo.episodes = [TestFixtures.makeEpisode(
+            id: "ep-1", startTime: 1_700_000_000_000, postdromeStartTime: 1_700_003_600_000
+        )]
+        await sut.loadEpisode()
+
+        await sut.editPostdromeStartTime(1_700_007_200_000)
+
+        XCTAssertEqual(sut.episode?.postdromeStartTime, 1_700_007_200_000)
+        XCTAssertNil(sut.error)
+        XCTAssertTrue(mockRepo.updateEpisodeCalled)
+    }
+
+    func testEditPostdromeStartTime_beforeEpisodeStart_setsError() async throws {
+        mockRepo.episodes = [TestFixtures.makeEpisode(
+            id: "ep-1", startTime: 1_700_000_000_000, postdromeStartTime: 1_700_003_600_000
+        )]
+        await sut.loadEpisode()
+
+        await sut.editPostdromeStartTime(1_699_999_000_000)
+
+        XCTAssertNotNil(sut.error)
+        XCTAssertEqual(sut.episode?.postdromeStartTime, 1_700_003_600_000, "Invalid edit is not applied")
+        XCTAssertFalse(mockRepo.updateEpisodeCalled)
+    }
+
+    func testEditPostdromeStartTime_afterEpisodeEnd_setsError() async throws {
+        mockRepo.episodes = [TestFixtures.makeEpisode(
+            id: "ep-1", startTime: 1_700_000_000_000, endTime: 1_700_010_800_000,
+            postdromeStartTime: 1_700_003_600_000
+        )]
+        await sut.loadEpisode()
+
+        await sut.editPostdromeStartTime(1_700_010_800_000)
+
+        XCTAssertNotNil(sut.error)
+        XCTAssertEqual(sut.episode?.postdromeStartTime, 1_700_003_600_000, "Invalid edit is not applied")
+        XCTAssertFalse(mockRepo.updateEpisodeCalled)
+    }
+
+    func testEditPostdromeStartTime_endedEpisode_validTime_updates() async throws {
+        mockRepo.episodes = [TestFixtures.makeEpisode(
+            id: "ep-1", startTime: 1_700_000_000_000, endTime: 1_700_010_800_000,
+            postdromeStartTime: 1_700_003_600_000
+        )]
+        await sut.loadEpisode()
+
+        await sut.editPostdromeStartTime(1_700_005_000_000)
+
+        XCTAssertEqual(sut.episode?.postdromeStartTime, 1_700_005_000_000)
+        XCTAssertNil(sut.error)
+        XCTAssertTrue(mockRepo.updateEpisodeCalled)
+    }
+
+    func testEditPostdromeStartTime_noPostdrome_noOp() async throws {
+        await sut.loadEpisode()
+        XCTAssertNil(sut.episode?.postdromeStartTime)
+
+        await sut.editPostdromeStartTime(1_700_003_600_000)
+
+        XCTAssertFalse(mockRepo.updateEpisodeCalled)
+        XCTAssertNil(sut.episode?.postdromeStartTime)
+    }
+
     // MARK: - Reopen Episode
 
     func testReopenEpisode_clearsEndTime() async throws {

--- a/mobile-apps/ios/MigraLogUITests/PostdromeFlowUITests.swift
+++ b/mobile-apps/ios/MigraLogUITests/PostdromeFlowUITests.swift
@@ -137,6 +137,29 @@ final class PostdromeFlowUITests: XCTestCase {
             "Timeline should show the Entered Post-drome event"
         )
         attachScreenshot(named: "5-postdrome-with-timeline")
+
+        // === Phase 6: long-press the timeline row to edit the transition time ===
+        // Confirm without moving the wheels: the seeded value round-trips, which
+        // exercises the menu → sheet → save path without wheel-clamping flakes.
+        timelineEntry.press(forDuration: 1.0)
+        let editTimeItem = app.buttons["Edit Time"]
+        XCTAssertTrue(
+            editTimeItem.waitForExistence(timeout: UITestHelpers.defaultTimeout),
+            "Long-pressing the post-drome row should offer Edit Time"
+        )
+        attachScreenshot(named: "6-postdrome-context-menu")
+        editTimeItem.tap()
+
+        UITestHelpers.waitForElement(app.navigationBars.staticTexts["Post-drome Start Time"])
+        attachScreenshot(named: "7-postdrome-edit-time-sheet")
+        app.buttons["Confirm"].tap()
+        Thread.sleep(forTimeInterval: UITestHelpers.animationWait)
+
+        UITestHelpers.waitForElement(resumeAttack)
+        XCTAssertTrue(
+            timelineEntry.exists,
+            "Timeline keeps the Entered Post-drome event after the edit"
+        )
         // Intentionally leave the episode in post-drome so a manual relaunch
         // of the app lands on this state for exploration.
     }


### PR DESCRIPTION
## Summary
Enhances the beta post-drome tracker (`FeatureFlag.postdromeTracking`): long-pressing the **Entered Post-drome** timeline row now offers **Edit Time**, opening the existing wheel-picker sheet seeded with the current transition time.

- New `EpisodeDetailViewModel.editPostdromeStartTime(_:)` — validates start < time < end (or now), mirrors `editEndTime`, refreshes the Live Activity for active episodes
- `CustomEndTimeSheet` generalized with `title`/`pickerLabel`/`maximumDate` params (defaults unchanged for existing call sites)
- Edit works on ended episodes that kept their phase record too (matches the Edit End Time affordance); **Resume Attack** stays gated on `isInPostdrome`
- Follows the flag rule from #600-era work: the edit affordance isn't flag-gated, so an episode already in post-drome keeps its controls if the flag is later switched off

## Testing
- 5 new unit tests in `EpisodeDetailViewModelTests` (valid edit, before-start rejection, after-end rejection, ended-episode edit, no-postdrome no-op) — full `MigraLogTests` target run locally, 1114 tests
- `PostdromeFlowUITests` extended with a long-press → Edit Time → confirm phase; run locally, green
- SwiftLint: no error-level violations

Note: `BackupServiceTests.testRestoreFromReactNativeBackup` fails locally on main too ("Unsupported backup schema version 0") — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)